### PR TITLE
cmake: media library dependency fixed to avoid possible linking error 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE src/window)
 
 target_link_libraries(${PROJECT_NAME}
 	liblvgl.a
-	libmedia.a
+	media
 	m
 	pthread
     sample_confparser 


### PR DESCRIPTION
```
hdzero-goggle/toolchain/bin/../lib/gcc/arm-openwrt-linux-muslgnueabi/6.4.1/../../../../arm-openwrt-linux-muslgnueabi/bin/ld: cannot find -lmedia
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/HDZGOGGLE.dir/build.make:1404: HDZGOGGLE] Error 1
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/HDZGOGGLE.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

~~+ whitespace cleanups~~