### PR TITLE
sdcard: use dev_ids to check for presence

### DIFF
--- a/src/core/thread.h
+++ b/src/core/thread.h
@@ -2,6 +2,7 @@
 #define _THREAD_H
 
 #include <stdint.h>
+#include <pthread.h>
 
 #define THREAD_COUNT_MAX (10)
 #define THREAD_COUNT (4)


### PR DESCRIPTION
this new approach should be faster and more reliable, works by comparing the dev (as in filesystem device) ids of the mountpoint and the parent of the mountpoint.