### PR TITLE
Change autoscan to on/last/off

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -160,20 +160,20 @@ return NULL;
 void start_running(void)
 {
 	int source;
-	if(g_setting.autoscan.source == 0) 
+	if(g_setting.autoscan.source == SETTING_SOURCE_LAST)
 		source = g_setting.autoscan.last_source;
 	else
 		source = g_setting.autoscan.source;
-		
-	if(source == 1) {//HDZero
+
+	if(source == SETTING_SOURCE_HDZERO) {//HDZero
 		g_source_info.source = 0;
 		HDZero_open();
-		if(g_setting.autoscan.status == 0) {
+		if(g_setting.autoscan.status == SETTING_AUTOSCAN_SCAN) {
 			pthread_t pid;
 			g_autoscan_exit = false;
 			pthread_create(&pid,NULL,thread_autoscan,NULL);
 		}
-		else if(g_setting.autoscan.status == 1) {
+		else if(g_setting.autoscan.status == SETTING_AUTOSCAN_LAST) {
 			g_menu_op = OPLEVEL_VIDEO;
 			switch_to_video(true);
 		}
@@ -183,11 +183,11 @@ void start_running(void)
 	}
 	else {
 		g_menu_op = OPLEVEL_VIDEO;
-		if(source == 2) {//module Bay
+		if(source == SETTING_SOURCE_EXPANSION) {//module Bay
 			switch_to_analog(1);
 			g_source_info.source = 3;
 		}
-		else if(source == 3) {//AV in
+		else if(source == SETTING_SOURCE_AV_IN) {//AV in
 			switch_to_analog(0);
 			g_source_info.source = 2;
 		}

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -56,15 +56,17 @@ static void load_ini_setting(void)
 	g_setting.fans.right_speed = atoi(str);
 
   	ini_gets("autoscan", "status", "enable", str, sizeof(str), SETTING_INI);
-	if(strcmp(str, "enable") == 0)	
+	if(strcmp(str, "enable") == 0 || strcmp(str, "scan") == 0)
 	{
-		g_setting.autoscan.status = true;
+		g_setting.autoscan.status = 0;
+	}else if(strcmp(str, "disable") == 0 || strcmp(str, "last") == 0){
+		g_setting.autoscan.status = 1;
 	}else{
-		g_setting.autoscan.status = false;
+		g_setting.autoscan.status = 2;
 	}
 	g_setting.autoscan.source = ini_getl("autoscan", "source", 0, SETTING_INI);
 	g_setting.autoscan.last_source = ini_getl("autoscan", "last_source", 1, SETTING_INI);
-	
+
 	//power
   	ini_gets("power", "voltage", "35", str, sizeof(str), SETTING_INI);
 	g_setting.power.voltage = atoi(str);
@@ -166,18 +168,17 @@ void start_running(void)
 	if(source == 1) {//HDZero
 		g_source_info.source = 0;
 		HDZero_open();
-		if(g_setting.autoscan.status) {//autoscan =1
-			/* //Auto scan Disabled per request 
+		if(g_setting.autoscan.status == 0) {
 			pthread_t pid;
 			g_autoscan_exit = false;
 			pthread_create(&pid,NULL,thread_autoscan,NULL);
-			*/
-			g_source_info.source = 0;
-			g_menu_op = OPLEVEL_MAINMENU;
 		}
-		else{ //auto scan disabled, go directly to last saved channel
+		else if(g_setting.autoscan.status == 1) {
 			g_menu_op = OPLEVEL_VIDEO;
 			switch_to_video(true);
+		}
+		else{ //auto scan disabled, go to go directly to last saved channel
+			g_menu_op = OPLEVEL_MAINMENU;
 		}
 	}
 	else {

--- a/src/page/page_autoscan.c
+++ b/src/page/page_autoscan.c
@@ -38,12 +38,12 @@ lv_obj_t *page_autoscan_create(lv_obj_t *parent, struct panel_arr *arr)
 	create_select_item(arr, cont);
 
 	btn_group_t btn_group;
-	create_btn_group_item(&btn_group0, cont, 2, "Auto Scan", "On", "Off", "","",  0);
+	create_btn_group_item(&btn_group0, cont, 3, "Auto Scan", "On", "Last", "Off","",  0);
 	create_btn_group_item2(&btn_group1, cont, 5, "Default", "Last","HDZero", "Expansion", "AV In", "HDMI In", " ",  1); //2 rows
 	create_label_item(cont, "<Back", 1, 3, 1);
 
 	lv_obj_t *label2 = lv_label_create(cont);
-   	lv_label_set_text(label2, "*if Auto Scan is off, goggles will default to show last tuned channel");
+   	lv_label_set_text(label2, "*if Auto Scan is 'Last', goggles will default to show last tuned channel");
 	lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
 	lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
 	lv_obj_set_style_text_color(label2, lv_color_make(255,255,255), 0);
@@ -52,8 +52,8 @@ lv_obj_t *page_autoscan_create(lv_obj_t *parent, struct panel_arr *arr)
 	lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 3,
 						 LV_GRID_ALIGN_START, 4, 2);
 
-	btn_group_set_sel(&btn_group0, !g_setting.autoscan.status);		
-	btn_group_set_sel(&btn_group1, g_setting.autoscan.source);		
+	btn_group_set_sel(&btn_group0, g_setting.autoscan.status);
+	btn_group_set_sel(&btn_group1, g_setting.autoscan.source);
 	return page;
 }
 
@@ -65,11 +65,13 @@ void autoscan_toggle(int sel)
 	if(sel == 0) {
 		btn_group_toggle_sel(&btn_group0);		
 
-		value = btn_group_get_sel(&btn_group0) == 0 ? 1 : 0;
-		if(value){
-			ini_puts("autoscan", "status", "enable", SETTING_INI);
+		value = btn_group_get_sel(&btn_group0);
+		if(value == 0){
+			ini_puts("autoscan", "status", "scan", SETTING_INI);
+		}else if (value == 1){
+			ini_puts("autoscan", "status", "last", SETTING_INI);
 		}else{
-			ini_puts("autoscan", "status", "disable", SETTING_INI);
+			ini_puts("autoscan", "status", "menu", SETTING_INI);
 		}
 		g_setting.autoscan.status = value;
 	}

--- a/src/page/page_common.h
+++ b/src/page/page_common.h
@@ -65,10 +65,24 @@ typedef struct {
 	int channel;
 } setting_scan_t;
 
+typedef enum {
+    SETTING_AUTOSCAN_SCAN = 0,
+    SETTING_AUTOSCAN_LAST = 1,
+    SETTING_AUTOSCAN_MENU = 2
+} setting_status_t;
+
+typedef enum {
+    SETTING_SOURCE_LAST = 0,
+    SETTING_SOURCE_HDZERO = 1,
+    SETTING_SOURCE_EXPANSION = 2,
+    SETTING_SOURCE_AV_IN = 3,
+    SETTING_SOURCE_HDMI_IN = 4
+} setting_source_t;
+
 typedef struct {
-	int status;	// 0=enable, 1=last, 2=disable
-	int last_source;
-	int source; //0=Last mem, 1=HDZero,2= Expansion, 3=AV in,4=HDMI in
+	setting_status_t status;
+	setting_source_t last_source;
+	setting_source_t source;
 } setting_autoscan_t;
 
 typedef struct {

--- a/src/page/page_common.h
+++ b/src/page/page_common.h
@@ -66,9 +66,9 @@ typedef struct {
 } setting_scan_t;
 
 typedef struct {
-	bool status;
-	int  last_source;
-	int  source; //0=Last mem, 1=HDZero,2= Expansion, 3=AV in,4=HDMI in
+	int status;	// 0=enable, 1=last, 2=disable
+	int last_source;
+	int source; //0=Last mem, 1=HDZero,2= Expansion, 3=AV in,4=HDMI in
 } setting_autoscan_t;
 
 typedef struct {


### PR DESCRIPTION
Changes the "Auto Scan" option to `On`/`Last`/`Off`

- `On` does the auto scan
- `Last` tunes to last channel
- `Off` just displays the main menu on the scan page

Fixes #23 