### PR TITLE
Backpack cleanup

### DIFF
--- a/src/core/main_menu.c
+++ b/src/core/main_menu.c
@@ -212,6 +212,9 @@ void submenu_nav(uint8_t key)
 		if(pp == &pp_record)
 			formatsd_negtive();
 
+		if(pp == &pp_connections)
+			page_connections_reset();
+
 		if(key == DIAL_KEY_UP) {
 			if(pp->p_arr.cur < pp->p_arr.max - 1)
 				pp->p_arr.cur++;

--- a/src/core/main_menu.c
+++ b/src/core/main_menu.c
@@ -70,7 +70,7 @@ page_pack_t pp_autoscan = {
 page_pack_t pp_connections = {
 	.p_arr = {
 		.cur = 0,
-		.max = 9,
+		.max = 8,
 	}
 };
 page_pack_t pp_headtracker = {
@@ -84,7 +84,7 @@ page_pack_t pp_playback;
 page_pack_t pp_version = {
 	.p_arr = {
 		.cur = 0,
-		.max = 4,
+		.max = 5,
 	}
 };
 

--- a/src/page/page_connections.h
+++ b/src/page/page_connections.h
@@ -6,5 +6,6 @@
 #include "page_common.h"
 lv_obj_t *page_connections_create(lv_obj_t *parent, struct panel_arr *arr);
 void connect_function(int sel);
+void page_connections_reset();
 
 #endif


### PR DESCRIPTION
Moves the backpack flashing to the "Firmware" menu, as previously suggested.
Also adds colors to "Success", "FAILED" and "Timeout" status values.
Button text returns back to _default_ value when cursor is moved.