### PR TITLE
page pack refactor

### DIFF
--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -233,15 +233,15 @@ static void btn_click(void)  //short press enter key
 	}
 	else if((g_menu_op == OPLEVEL_SUBMENU) ||(g_menu_op == OPLEVEL_PLAYBACK))
 	{ 
-		submenu_fun();	
+		submenu_click();	
 	}
 	else if(g_menu_op == PAGE_FAN_SLIDE)
 	{ 
-		submenu_fun();	
+		submenu_click();	
 	}
 	else if(g_menu_op == PAGE_POWER_SLIDE)
 	{ 
-		submenu_fun();	
+		submenu_click();	
 	}
 	pthread_mutex_unlock(&lvgl_mutex);
 }
@@ -260,7 +260,7 @@ static void roller_up(void)
 	}
 	else if((g_menu_op == OPLEVEL_SUBMENU) ||(g_menu_op == OPLEVEL_PLAYBACK))
 	{
-		submenu_nav(DIAL_KEY_UP);
+		submenu_roller(DIAL_KEY_UP);
 	}
 	else if(g_menu_op == OPLEVEL_VIDEO)
 	{
@@ -296,7 +296,7 @@ static void roller_down(void)
 	}
 	else if((g_menu_op == OPLEVEL_SUBMENU) ||(g_menu_op == OPLEVEL_PLAYBACK))
 	{
-		submenu_nav(DIAL_KEY_DOWN);
+		submenu_roller(DIAL_KEY_DOWN);
 	}
 	else if(g_menu_op == OPLEVEL_VIDEO)
 	{

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -1,27 +1,25 @@
 #include "page_autoscan.h"
 
+#include "minIni.h"
 #include "page_common.h"
 #include "ui/ui_style.h"
-#include "minIni.h"
 
-
-static lv_coord_t col_dsc[] = {100,150,180,220,180,160, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {100, 150, 180, 220, 180, 160, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 static btn_group_t btn_group0;
 static btn_group_t btn_group1;
 
-lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
     create_text(NULL, section, false, "Auto Scan:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
@@ -29,56 +27,53 @@ lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr)
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
+    create_select_item(arr, cont);
 
-	btn_group_t btn_group;
-	create_btn_group_item(&btn_group0, cont, 3, "Auto Scan", "On", "Last", "Off","",  0);
-	create_btn_group_item2(&btn_group1, cont, 5, "Default", "Last","HDZero", "Expansion", "AV In", "HDMI In", " ",  1); //2 rows
-	create_label_item(cont, "< Back", 1, 3, 1);
+    btn_group_t btn_group;
+    create_btn_group_item(&btn_group0, cont, 3, "Auto Scan", "On", "Last", "Off", "", 0);
+    create_btn_group_item2(&btn_group1, cont, 5, "Default", "Last", "HDZero", "Expansion", "AV In", "HDMI In", " ", 1); // 2 rows
+    create_label_item(cont, "< Back", 1, 3, 1);
 
-	lv_obj_t *label2 = lv_label_create(cont);
-   	lv_label_set_text(label2, "*if Auto Scan is 'Last', goggles will default to show last tuned channel");
-	lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
-	lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_color(label2, lv_color_make(255,255,255), 0);
-	lv_obj_set_style_pad_top(label2, 12, 0);
-	lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
-	lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 3,
-						 LV_GRID_ALIGN_START, 4, 2);
+    lv_obj_t *label2 = lv_label_create(cont);
+    lv_label_set_text(label2, "*if Auto Scan is 'Last', goggles will default to show last tuned channel");
+    lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_color(label2, lv_color_make(255, 255, 255), 0);
+    lv_obj_set_style_pad_top(label2, 12, 0);
+    lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
+    lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 3,
+                         LV_GRID_ALIGN_START, 4, 2);
 
-	btn_group_set_sel(&btn_group0, g_setting.autoscan.status);
-	btn_group_set_sel(&btn_group1, g_setting.autoscan.source);
-	return page;
+    btn_group_set_sel(&btn_group0, g_setting.autoscan.status);
+    btn_group_set_sel(&btn_group1, g_setting.autoscan.source);
+    return page;
 }
 
+void autoscan_toggle(int sel) {
+    int value = 0;
 
-void autoscan_toggle(int sel)
-{
-	int value = 0;
-	
-	if(sel == 0) {
-		btn_group_toggle_sel(&btn_group0);		
+    if (sel == 0) {
+        btn_group_toggle_sel(&btn_group0);
 
-		value = btn_group_get_sel(&btn_group0);
-		if(value == 0){
-			ini_puts("autoscan", "status", "scan", SETTING_INI);
-		}else if (value == 1){
-			ini_puts("autoscan", "status", "last", SETTING_INI);
-		}else{
-			ini_puts("autoscan", "status", "menu", SETTING_INI);
-		}
-		g_setting.autoscan.status = value;
-	}
-	else if(sel < 3) {
-		btn_group_toggle_sel(&btn_group1);	
-		value = btn_group_get_sel(&btn_group1);
-		ini_putl("autoscan", "source", value, SETTING_INI);
-		g_setting.autoscan.source = value;
-	}
+        value = btn_group_get_sel(&btn_group0);
+        if (value == 0) {
+            ini_puts("autoscan", "status", "scan", SETTING_INI);
+        } else if (value == 1) {
+            ini_puts("autoscan", "status", "last", SETTING_INI);
+        } else {
+            ini_puts("autoscan", "status", "menu", SETTING_INI);
+        }
+        g_setting.autoscan.status = value;
+    } else if (sel < 3) {
+        btn_group_toggle_sel(&btn_group1);
+        value = btn_group_get_sel(&btn_group1);
+        ini_putl("autoscan", "source", value, SETTING_INI);
+        g_setting.autoscan.source = value;
+    }
 }

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -11,7 +11,7 @@ static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_L
 static btn_group_t btn_group0;
 static btn_group_t btn_group1;
 
-lv_obj_t *page_autoscan_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -1,7 +1,7 @@
 #include "page_autoscan.h"
 
-#include "minIni.h"
-#include "page_common.h"
+#include <minIni.h>
+
 #include "ui/ui_style.h"
 
 static lv_coord_t col_dsc[] = {100, 150, 180, 220, 180, 160, LV_GRID_TEMPLATE_LAST};
@@ -55,7 +55,7 @@ lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     return page;
 }
 
-void autoscan_toggle(int sel) {
+static void page_autoscan_on_click(uint8_t key, int sel) {
     int value = 0;
 
     if (sel == 0) {
@@ -77,3 +77,15 @@ void autoscan_toggle(int sel) {
         g_setting.autoscan.source = value;
     }
 }
+
+page_pack_t pp_autoscan = {
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    },
+
+    .enter = NULL,
+    .exit = NULL,
+    .on_roller = NULL,
+    .on_click = &page_autoscan_on_click,
+};

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -10,7 +10,7 @@ static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_T
 static btn_group_t btn_group0;
 static btn_group_t btn_group1;
 
-lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -84,6 +84,7 @@ page_pack_t pp_autoscan = {
         .max = 4,
     },
 
+    .create = &page_autoscan_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -84,9 +84,9 @@ page_pack_t pp_autoscan = {
         .max = 4,
     },
 
-    .create = &page_autoscan_create,
+    .create = page_autoscan_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,
-    .on_click = &page_autoscan_on_click,
+    .on_click = page_autoscan_on_click,
 };

--- a/src/ui/page_autoscan.h
+++ b/src/ui/page_autoscan.h
@@ -3,9 +3,10 @@
 
 #include <lvgl/lvgl.h>
 
-#include "page_common.h"
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_autoscan;
 
 lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr);
-void autoscan_toggle(int sel);
 
 #endif

--- a/src/ui/page_autoscan.h
+++ b/src/ui/page_autoscan.h
@@ -5,7 +5,7 @@
 #include "lvgl/lvgl.h"
 #include "page_common.h"
 
-lv_obj_t *page_autoscan_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr);
 void autoscan_toggle(int sel);
 
 #endif

--- a/src/ui/page_autoscan.h
+++ b/src/ui/page_autoscan.h
@@ -7,6 +7,4 @@
 
 extern page_pack_t pp_autoscan;
 
-lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr);
-
 #endif

--- a/src/ui/page_autoscan.h
+++ b/src/ui/page_autoscan.h
@@ -1,8 +1,8 @@
 #ifndef _PAGE_AUTOSCAN_H
 #define _PAGE_AUTOSCAN_H
 
+#include <lvgl/lvgl.h>
 
-#include "lvgl/lvgl.h"
 #include "page_common.h"
 
 lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr);

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -6,13 +6,13 @@
 #include "ui/ui_attribute.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-// global 
+// global
 setting_t g_setting;
 
 op_level_t g_menu_op = OPLEVEL_MAINMENU;
 bool g_sdcard_enable = false;
 bool g_sdcard_det_req = false;
-int  g_sdcard_size = 0;
+int g_sdcard_size = 0;
 bool g_autoscan_exit = true;
 bool g_scanning = false;
 bool g_showRXOSD = true;
@@ -21,45 +21,41 @@ bool g_test_en = false;
 source_info_t g_source_info;
 /////////////////////////////////////////////////////////////////////////////
 
-
 LV_IMG_DECLARE(img_arrow);
 LV_IMG_DECLARE(img_arrow0);
 LV_IMG_DECLARE(img_arrow1);
-int create_text(struct menu_obj_s *s, lv_obj_t * parent, bool is_icon, const char * txt,
-                              lv_menu_builder_variant_t builder_variant)
-{
-    lv_obj_t * obj = lv_menu_cont_create(parent);
+int create_text(struct menu_obj_s *s, lv_obj_t *parent, bool is_icon, const char *txt,
+                lv_menu_builder_variant_t builder_variant) {
+    lv_obj_t *obj = lv_menu_cont_create(parent);
 
-    lv_obj_t * img = NULL;
-    lv_obj_t * label = NULL;
+    lv_obj_t *img = NULL;
+    lv_obj_t *label = NULL;
 
-    if(txt) {
+    if (txt) {
         label = lv_label_create(obj);
         lv_label_set_text(label, txt);
-		lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
+        lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
         lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
-    //    lv_obj_set_flex_grow(label, 1);
+        //    lv_obj_set_flex_grow(label, 1);
     }
-    if(is_icon) {
+    if (is_icon) {
         img = lv_img_create(obj);
         lv_img_set_src(img, &img_arrow);
     }
 
-    if(builder_variant == LV_MENU_ITEM_BUILDER_VARIANT_2 && is_icon && txt) {
+    if (builder_variant == LV_MENU_ITEM_BUILDER_VARIANT_2 && is_icon && txt) {
         lv_obj_add_flag(img, LV_OBJ_FLAG_FLEX_IN_NEW_TRACK);
         lv_obj_swap(img, label);
     }
 
-	if(s)
-	{
-		s->cont = obj;
-		s->icon = img;
-	}
+    if (s) {
+        s->cont = obj;
+        s->icon = img;
+    }
     return 0;
 }
 
-void create_select_item(panel_arr_t *arr, lv_obj_t *parent)
-{
+void create_select_item(panel_arr_t *arr, lv_obj_t *parent) {
     arr->panel0 = lv_obj_create(parent);
     arr->panel1 = lv_obj_create(parent);
     arr->panel2 = lv_obj_create(parent);
@@ -79,15 +75,15 @@ void create_select_item(panel_arr_t *arr, lv_obj_t *parent)
     lv_obj_clear_flag(arr->panel6, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_clear_flag(arr->panel7, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_clear_flag(arr->panel8, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_flag(arr->panel0, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel1, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel2, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel3, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel4, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel5, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel6, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel7, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel8, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel0, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel1, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel2, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel3, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel4, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel5, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel6, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel7, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel8, LV_OBJ_FLAG_HIDDEN);
 
     lv_obj_add_style(arr->panel0, &style_select, LV_PART_MAIN);
     lv_obj_add_style(arr->panel1, &style_select, LV_PART_MAIN);
@@ -99,106 +95,99 @@ void create_select_item(panel_arr_t *arr, lv_obj_t *parent)
     lv_obj_add_style(arr->panel7, &style_select, LV_PART_MAIN);
     lv_obj_add_style(arr->panel8, &style_select, LV_PART_MAIN);
 
-	lv_obj_set_grid_cell(arr->panel0, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 0, 1);
-	lv_obj_set_grid_cell(arr->panel1, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 1, 1);
-	lv_obj_set_grid_cell(arr->panel2, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 2, 1);
-	lv_obj_set_grid_cell(arr->panel3, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 3, 1);
-	lv_obj_set_grid_cell(arr->panel4, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 4, 1);
-	lv_obj_set_grid_cell(arr->panel5, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 5, 1);
-	lv_obj_set_grid_cell(arr->panel6, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 6, 1);
-	lv_obj_set_grid_cell(arr->panel7, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 7, 1);
-	lv_obj_set_grid_cell(arr->panel8, LV_GRID_ALIGN_STRETCH, 0, 6,
-						 LV_GRID_ALIGN_STRETCH, 8, 1);
+    lv_obj_set_grid_cell(arr->panel0, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_grid_cell(arr->panel1, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 1, 1);
+    lv_obj_set_grid_cell(arr->panel2, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 2, 1);
+    lv_obj_set_grid_cell(arr->panel3, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 3, 1);
+    lv_obj_set_grid_cell(arr->panel4, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 4, 1);
+    lv_obj_set_grid_cell(arr->panel5, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 5, 1);
+    lv_obj_set_grid_cell(arr->panel6, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 6, 1);
+    lv_obj_set_grid_cell(arr->panel7, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 7, 1);
+    lv_obj_set_grid_cell(arr->panel8, LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 8, 1);
 }
-void set_select_item(const panel_arr_t *arr, int row)
-{
-	lv_obj_add_flag(arr->panel0, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel1, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel2, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel3, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel4, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel5, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel6, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel7, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_add_flag(arr->panel8, LV_OBJ_FLAG_HIDDEN);
+void set_select_item(const panel_arr_t *arr, int row) {
+    lv_obj_add_flag(arr->panel0, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel1, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel2, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel3, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel4, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel5, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel6, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel7, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arr->panel8, LV_OBJ_FLAG_HIDDEN);
 
-	switch(row)
-	{
-		case 0:
-			lv_obj_clear_flag(arr->panel0, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 1:
-			lv_obj_clear_flag(arr->panel1, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 2:
-			lv_obj_clear_flag(arr->panel2, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 3:
-			lv_obj_clear_flag(arr->panel3, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 4:
-			lv_obj_clear_flag(arr->panel4, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 5:
-			lv_obj_clear_flag(arr->panel5, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 6:
-			lv_obj_clear_flag(arr->panel6, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 7:
-			lv_obj_clear_flag(arr->panel7, LV_OBJ_FLAG_HIDDEN);
-			break;
-		case 8:
-			lv_obj_clear_flag(arr->panel8, LV_OBJ_FLAG_HIDDEN);
-			break;
-		default:
-			break;
-	}
+    switch (row) {
+    case 0:
+        lv_obj_clear_flag(arr->panel0, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 1:
+        lv_obj_clear_flag(arr->panel1, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 2:
+        lv_obj_clear_flag(arr->panel2, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 3:
+        lv_obj_clear_flag(arr->panel3, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 4:
+        lv_obj_clear_flag(arr->panel4, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 5:
+        lv_obj_clear_flag(arr->panel5, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 6:
+        lv_obj_clear_flag(arr->panel6, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 7:
+        lv_obj_clear_flag(arr->panel7, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case 8:
+        lv_obj_clear_flag(arr->panel8, LV_OBJ_FLAG_HIDDEN);
+        break;
+    default:
+        break;
+    }
 }
 
-lv_obj_t* create_label_item(lv_obj_t *parent, const char *name, int col, int row, int cols)
-{
-	lv_obj_t *label = lv_label_create(parent);
-   	lv_label_set_text(label, name);
-	lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_pad_top(label, 12, 0);
-	lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
-	lv_obj_set_size(label, 320*cols, 60);
- 	
-	lv_label_set_recolor(label, true);    
-	
-	lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, col, cols,
-						 LV_GRID_ALIGN_CENTER, row, 1);
-	return label;						 
+lv_obj_t *create_label_item(lv_obj_t *parent, const char *name, int col, int row, int cols) {
+    lv_obj_t *label = lv_label_create(parent);
+    lv_label_set_text(label, name);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_pad_top(label, 12, 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_set_size(label, 320 * cols, 60);
+
+    lv_label_set_recolor(label, true);
+
+    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, col, cols,
+                         LV_GRID_ALIGN_CENTER, row, 1);
+    return label;
 }
 
-
-void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const char *name, int range, int default_value, int row)
-{
-	lv_obj_t *label = lv_label_create(parent);
-   	lv_label_set_text(label, name);
-	lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_pad_top(label, 12, 0);
-	lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const char *name, int range, int default_value, int row) {
+    lv_obj_t *label = lv_label_create(parent);
+    lv_label_set_text(label, name);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_pad_top(label, 12, 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_size(label, 320, 60);
-	lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2,
-						 LV_GRID_ALIGN_CENTER, row, 1);
-
+    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 
     slider_group->slider = lv_slider_create(parent);
 
-
-    lv_obj_remove_style_all(slider_group->slider);       
+    lv_obj_remove_style_all(slider_group->slider);
     lv_obj_add_style(slider_group->slider, &style_silder_main, LV_PART_MAIN);
     lv_obj_add_style(slider_group->slider, &style_silder_indicator, LV_PART_INDICATOR);
     lv_obj_add_style(slider_group->slider, &style_silder_pressed_color, LV_PART_INDICATOR | LV_STATE_PRESSED);
@@ -208,201 +197,173 @@ void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const ch
     lv_obj_set_size(slider_group->slider, 320, 3);
     lv_slider_set_range(slider_group->slider, 0, range);
     lv_slider_set_value(slider_group->slider, default_value, LV_ANIM_OFF);
-	lv_obj_set_grid_cell(slider_group->slider, LV_GRID_ALIGN_STRETCH, 3, 2,
-						 LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_grid_cell(slider_group->slider, LV_GRID_ALIGN_STRETCH, 3, 2,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 
-	slider_group->label = lv_label_create(parent);
-	char buf[25];
-	memset(buf, 0, sizeof(buf));
-	sprintf(buf, "%d", default_value);
-   	lv_label_set_text(slider_group->label, buf);
-	lv_obj_set_style_text_font(slider_group->label, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(slider_group->label, LV_TEXT_ALIGN_CENTER, 0);
-	lv_obj_set_style_pad_top(slider_group->label, 12, 0);
-	lv_label_set_long_mode(slider_group->label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    slider_group->label = lv_label_create(parent);
+    char buf[25];
+    memset(buf, 0, sizeof(buf));
+    sprintf(buf, "%d", default_value);
+    lv_label_set_text(slider_group->label, buf);
+    lv_obj_set_style_text_font(slider_group->label, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(slider_group->label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_style_pad_top(slider_group->label, 12, 0);
+    lv_label_set_long_mode(slider_group->label, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_size(slider_group->label, 160, 60);
-	lv_obj_set_grid_cell(slider_group->label, LV_GRID_ALIGN_START, 5, 1,
-						 LV_GRID_ALIGN_CENTER, row, 1);
-
+    lv_obj_set_grid_cell(slider_group->label, LV_GRID_ALIGN_START, 5, 1,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 }
 
-void create_btn_item(lv_obj_t *parent, const char *name,int col, int row)
-{
+void create_btn_item(lv_obj_t *parent, const char *name, int col, int row) {
 
-	lv_obj_t *btn = lv_btn_create(parent);
+    lv_obj_t *btn = lv_btn_create(parent);
 
     lv_obj_t *label = lv_label_create(btn);
     lv_label_set_text(label, name);
-	lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
 
-	lv_obj_set_style_text_font(btn, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(btn, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_bg_color(btn, lv_color_make(19, 19, 19), 0);
-	lv_obj_set_style_bg_opa(btn, 0x0, 0);
-	lv_obj_set_style_shadow_width(btn, 0, 0);
-	lv_obj_set_style_pad_top(btn, 0, 0);
+    lv_obj_set_style_text_font(btn, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(btn, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_bg_color(btn, lv_color_make(19, 19, 19), 0);
+    lv_obj_set_style_bg_opa(btn, 0x0, 0);
+    lv_obj_set_style_shadow_width(btn, 0, 0);
+    lv_obj_set_style_pad_top(btn, 0, 0);
     lv_obj_set_size(btn, 160, 60);
-	lv_obj_set_grid_cell(btn, LV_GRID_ALIGN_START, col, 1,
-						 LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_grid_cell(btn, LV_GRID_ALIGN_START, col, 1,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 }
 
-static lv_coord_t col_dsc[] = {40,150, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {40, 150, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, LV_GRID_TEMPLATE_LAST};
 
-
-
-
-static void create_btn_with_arrow(lv_obj_t *parent, btn_with_arr_t *btn_a, const char *name, int row, int col)
-{
+static void create_btn_with_arrow(lv_obj_t *parent, btn_with_arr_t *btn_a, const char *name, int row, int col) {
     btn_a->container = lv_obj_create(parent);
     lv_obj_set_size(btn_a->container, 200, 60);
     lv_obj_set_pos(btn_a->container, 0, 0);
     lv_obj_set_layout(btn_a->container, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(btn_a->container, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(btn_a->container, &style_context, LV_PART_MAIN);
-	lv_obj_set_style_bg_opa(btn_a->container, 0x0, 0);
+    lv_obj_clear_flag(btn_a->container, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(btn_a->container, &style_context, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(btn_a->container, 0x0, 0);
     lv_obj_set_style_grid_column_dsc_array(btn_a->container, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(btn_a->container, row_dsc, 0);
-	lv_obj_set_grid_cell(btn_a->container, LV_GRID_ALIGN_START, col, 1,
-						 LV_GRID_ALIGN_CENTER, row, 1);
-	
+    lv_obj_set_grid_cell(btn_a->container, LV_GRID_ALIGN_START, col, 1,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 
-	btn_a->arrow = lv_img_create(btn_a->container);
-   	lv_img_set_src(btn_a->arrow, &img_arrow1);
-	lv_obj_add_flag(btn_a->arrow, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_set_grid_cell(btn_a->arrow, LV_GRID_ALIGN_END, 0, 1,
-						 LV_GRID_ALIGN_CENTER, 0, 1);
+    btn_a->arrow = lv_img_create(btn_a->container);
+    lv_img_set_src(btn_a->arrow, &img_arrow1);
+    lv_obj_add_flag(btn_a->arrow, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_grid_cell(btn_a->arrow, LV_GRID_ALIGN_END, 0, 1,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
 
-
-	btn_a->btn = lv_btn_create(btn_a->container);
+    btn_a->btn = lv_btn_create(btn_a->container);
     btn_a->label = lv_label_create(btn_a->btn);
     lv_label_set_text(btn_a->label, name);
-	lv_obj_set_style_text_align(btn_a->label, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_font(btn_a->btn, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(btn_a->btn, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_bg_color(btn_a->btn, lv_color_make(19, 19, 19), 0);
-	lv_obj_set_style_bg_opa(btn_a->btn, 0x0, 0);
-	lv_obj_set_style_shadow_width(btn_a->btn, 0, 0);
-	lv_obj_set_style_pad_top(btn_a->btn, 12, 0);
+    lv_obj_set_style_text_align(btn_a->label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_font(btn_a->btn, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(btn_a->btn, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_bg_color(btn_a->btn, lv_color_make(19, 19, 19), 0);
+    lv_obj_set_style_bg_opa(btn_a->btn, 0x0, 0);
+    lv_obj_set_style_shadow_width(btn_a->btn, 0, 0);
+    lv_obj_set_style_pad_top(btn_a->btn, 12, 0);
     lv_obj_set_size(btn_a->btn, 160, 60);
-	lv_obj_set_grid_cell(btn_a->btn, LV_GRID_ALIGN_START, 1, 1,
-						 LV_GRID_ALIGN_CENTER, 0, 1);
+    lv_obj_set_grid_cell(btn_a->btn, LV_GRID_ALIGN_START, 1, 1,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
 
-	lv_obj_set_style_pad_column(btn_a->container,0,0);
+    lv_obj_set_style_pad_column(btn_a->container, 0, 0);
 }
 
-
-
-void btn_group_set_sel(btn_group_t *btn_group, int sel)
-{
-	//LOGI("set sel, valid=%d, sel=%d", btn_group->valid, sel);
-	for(int i=0; i<btn_group->valid; i++)
-	{
-		if(i == sel)
-		{
-			btn_group->current = sel;
-			lv_obj_clear_flag(btn_group->btn_a[i].arrow, LV_OBJ_FLAG_HIDDEN);
-		}else{
-			lv_obj_add_flag(btn_group->btn_a[i].arrow, LV_OBJ_FLAG_HIDDEN);
-		}
-	}
+void btn_group_set_sel(btn_group_t *btn_group, int sel) {
+    // LOGI("set sel, valid=%d, sel=%d", btn_group->valid, sel);
+    for (int i = 0; i < btn_group->valid; i++) {
+        if (i == sel) {
+            btn_group->current = sel;
+            lv_obj_clear_flag(btn_group->btn_a[i].arrow, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(btn_group->btn_a[i].arrow, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
 }
 
-int btn_group_get_sel(btn_group_t *btn_group)
-{
-	return btn_group->current;
+int btn_group_get_sel(btn_group_t *btn_group) {
+    return btn_group->current;
 }
-void btn_group_toggle_sel(btn_group_t *btn_group)
-{
-	int sel = btn_group_get_sel(btn_group); 
-	int total = btn_group->valid;
-	
-	if(sel < total -1)
-	{
-		sel++;
-	}
-	else{
-		sel = 0;
-	}
-	btn_group_set_sel(btn_group, sel);
+void btn_group_toggle_sel(btn_group_t *btn_group) {
+    int sel = btn_group_get_sel(btn_group);
+    int total = btn_group->valid;
+
+    if (sel < total - 1) {
+        sel++;
+    } else {
+        sel = 0;
+    }
+    btn_group_set_sel(btn_group, sel);
 }
 
+void create_btn_group_item(btn_group_t *btn_group, lv_obj_t *parent, int count, const char *name, const char *name0, const char *name1, const char *name2, const char *name3, int row) {
+    if (count > 3)
+        return;
+    btn_group->valid = count;
+    btn_group->current = 0;
 
-void create_btn_group_item(btn_group_t *btn_group, lv_obj_t *parent,int count,const char *name, const char *name0,const char *name1,const char *name2,const char *name3, int row)
-{
-	if(count > 3)
-		return;
-	btn_group->valid = count;
-	btn_group->current = 0;
-
-	lv_obj_t *label = lv_label_create(parent);
-   	lv_label_set_text(label, name);
-	lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_pad_top(label, 12, 0);
-	lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_t *label = lv_label_create(parent);
+    lv_label_set_text(label, name);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_pad_top(label, 12, 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_size(label, 320, 60);
-	lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2,
-						 LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 
-	create_btn_with_arrow(parent, &btn_group->btn_a[0],name0, row, 2);
-	if(count >= 2)
-	{
-	create_btn_with_arrow(parent, &btn_group->btn_a[1], name1, row, 3);
-	}
+    create_btn_with_arrow(parent, &btn_group->btn_a[0], name0, row, 2);
+    if (count >= 2) {
+        create_btn_with_arrow(parent, &btn_group->btn_a[1], name1, row, 3);
+    }
 
-	if(count >= 3)
-	{
-		create_btn_with_arrow(parent, &btn_group->btn_a[2],name2, row, 4);
-	}
+    if (count >= 3) {
+        create_btn_with_arrow(parent, &btn_group->btn_a[2], name2, row, 4);
+    }
 
-	btn_group_set_sel(btn_group, 0);
+    btn_group_set_sel(btn_group, 0);
 }
 
-void create_btn_group_item2(btn_group_t *btn_group, lv_obj_t *parent,int count,const char *name, const char *name0,const char *name1,\
-							const char *name2,const char *name3, const char *name4,const char *name5,int row)
-{
-	if(count > 6)
-		return;
-	btn_group->valid = count;
-	btn_group->current = 0;
+void create_btn_group_item2(btn_group_t *btn_group, lv_obj_t *parent, int count, const char *name, const char *name0, const char *name1,
+                            const char *name2, const char *name3, const char *name4, const char *name5, int row) {
+    if (count > 6)
+        return;
+    btn_group->valid = count;
+    btn_group->current = 0;
 
-	lv_obj_t *label = lv_label_create(parent);
-   	lv_label_set_text(label, name);
-	lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_pad_top(label, 12, 0);
-	lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_t *label = lv_label_create(parent);
+    lv_label_set_text(label, name);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_pad_top(label, 12, 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_size(label, 320, 60);
-	lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2,
-						 LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 
-	create_btn_with_arrow(parent, &btn_group->btn_a[0],name0, row, 2);
-	if(count >= 2)
-	{
-	create_btn_with_arrow(parent, &btn_group->btn_a[1], name1, row, 3);
-	}
+    create_btn_with_arrow(parent, &btn_group->btn_a[0], name0, row, 2);
+    if (count >= 2) {
+        create_btn_with_arrow(parent, &btn_group->btn_a[1], name1, row, 3);
+    }
 
-	if(count >= 3)
-	{
-		create_btn_with_arrow(parent, &btn_group->btn_a[2],name2, row, 4);
-	}
+    if (count >= 3) {
+        create_btn_with_arrow(parent, &btn_group->btn_a[2], name2, row, 4);
+    }
 
+    if (count >= 4) {
+        create_btn_with_arrow(parent, &btn_group->btn_a[3], name3, row + 1, 2);
+    }
 
-	if(count >= 4)
-	{
-		create_btn_with_arrow(parent, &btn_group->btn_a[3], name3, row+1, 2);
-	}
-	
-	if(count >= 5)
-	{
-		create_btn_with_arrow(parent, &btn_group->btn_a[4], name4, row+1, 3);
-	}
+    if (count >= 5) {
+        create_btn_with_arrow(parent, &btn_group->btn_a[4], name4, row + 1, 3);
+    }
 
-	if(count == 6)
-	{
-		create_btn_with_arrow(parent, &btn_group->btn_a[5], name5, row+1, 4);
-	}
+    if (count == 6) {
+        create_btn_with_arrow(parent, &btn_group->btn_a[5], name5, row + 1, 4);
+    }
 
-	btn_group_set_sel(btn_group, 0);
+    btn_group_set_sel(btn_group, 0);
 }

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -58,7 +58,7 @@ int create_text(struct menu_obj_s *s, lv_obj_t * parent, bool is_icon, const cha
     return 0;
 }
 
-void create_select_item(struct panel_arr *arr, lv_obj_t *parent)
+void create_select_item(panel_arr_t *arr, lv_obj_t *parent)
 {
     arr->panel0 = lv_obj_create(parent);
     arr->panel1 = lv_obj_create(parent);
@@ -118,7 +118,7 @@ void create_select_item(struct panel_arr *arr, lv_obj_t *parent)
 	lv_obj_set_grid_cell(arr->panel8, LV_GRID_ALIGN_STRETCH, 0, 6,
 						 LV_GRID_ALIGN_STRETCH, 8, 1);
 }
-void set_select_item(const struct panel_arr *arr, int row)
+void set_select_item(const panel_arr_t *arr, int row)
 {
 	lv_obj_add_flag(arr->panel0, LV_OBJ_FLAG_HIDDEN);
 	lv_obj_add_flag(arr->panel1, LV_OBJ_FLAG_HIDDEN);

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -4,65 +4,64 @@
 #include "defines.h"
 #include "ui/ui_style.h"
 
-#define TMP_DIR         "/tmp"
-#define MEDIA_FILES_DIR "/mnt/extsd/movies"
-#define AUDIO_SEL_SH    "/mnt/app/script/audio_sel.sh" 
-#define SETTING_INI 	"/mnt/app/setting.ini"
-#define TEST_INI 	    "/mnt/extsd/test.ini"
-#define REC_START   	"/mnt/app/app/record/gogglecmd -rec start"
-#define REC_STOP    	"/mnt/app/app/record/gogglecmd -rec stop"
-#define REC_CONF    	"/mnt/app/app/record/confs/record.conf"
-#define FC_OSD_LOCAL_PATH	"/mnt/app/resource/OSD/FC/"
-#define FC_OSD_SDCARD_PATH	"/mnt/extsd/resource/OSD/FC/"
+#define TMP_DIR            "/tmp"
+#define MEDIA_FILES_DIR    "/mnt/extsd/movies"
+#define AUDIO_SEL_SH       "/mnt/app/script/audio_sel.sh"
+#define SETTING_INI        "/mnt/app/setting.ini"
+#define TEST_INI           "/mnt/extsd/test.ini"
+#define REC_START          "/mnt/app/app/record/gogglecmd -rec start"
+#define REC_STOP           "/mnt/app/app/record/gogglecmd -rec stop"
+#define REC_CONF           "/mnt/app/app/record/confs/record.conf"
+#define FC_OSD_LOCAL_PATH  "/mnt/app/resource/OSD/FC/"
+#define FC_OSD_SDCARD_PATH "/mnt/extsd/resource/OSD/FC/"
 
-#define RESOURCE_PATH   "A:/mnt/app/app/resource/"
-#define recording_bmp   "recording.bmp"
-#define noSdcard_bmp    "noSdcard.bmp"
+#define RESOURCE_PATH "A:/mnt/app/app/resource/"
+#define recording_bmp "recording.bmp"
+#define noSdcard_bmp  "noSdcard.bmp"
 
-#define lowBattery_gif  "lowBattery.gif"
-#define fan1_bmp        "fan1.bmp"
-#define fan2_bmp        "fan2.bmp"
-#define fan3_bmp        "fan3.bmp"
-#define fan4_bmp        "fan4.bmp"
-#define fan5_bmp        "fan5.bmp"
-#define fan6_bmp        "fan6.bmp"
-#define VtxTemp1_bmp    "VtxTemp1.bmp"
-#define VtxTemp2_bmp    "VtxTemp2.bmp"
-#define VtxTemp3_bmp    "VtxTemp3.bmp"
-#define VtxTemp4_bmp    "VtxTemp4.bmp"
-#define VtxTemp5_bmp    "VtxTemp5.bmp"
-#define VtxTemp6_bmp    "VtxTemp6.bmp"
-#define VtxTemp7_bmp    "VtxTemp7.bmp"
-#define VrxTemp7_gif    "VrxTemp7.gif"
-#define ant1_bmp        "ant1.bmp"
-#define ant2_bmp        "ant2.bmp"
-#define ant3_bmp        "ant3.bmp"
-#define ant4_bmp        "ant4.bmp"
-#define ant5_bmp        "ant5.bmp"
-#define ant6_bmp        "ant6.bmp"
-#define VLQ1_bmp        "VLQ1.bmp"
-#define VLQ2_bmp        "VLQ2.bmp"
-#define VLQ3_bmp        "VLQ3.bmp"
-#define VLQ4_bmp        "VLQ4.bmp"
-#define VLQ5_bmp        "VLQ5.bmp"
-#define VLQ6_bmp        "VLQ6.bmp"
-#define VLQ7_bmp        "VLQ7.bmp"
-#define VLQ8_bmp        "VLQ8.bmp"
-#define VLQ9_bmp        "VLQ9.bmp"
-#define blank_bmp  		"blank36x36.bmp"
-#define LLOCK_bmp		"llock.bmp"
-#define DEF_VIDEOICON	"videoicon.jpg"
-
+#define lowBattery_gif "lowBattery.gif"
+#define fan1_bmp       "fan1.bmp"
+#define fan2_bmp       "fan2.bmp"
+#define fan3_bmp       "fan3.bmp"
+#define fan4_bmp       "fan4.bmp"
+#define fan5_bmp       "fan5.bmp"
+#define fan6_bmp       "fan6.bmp"
+#define VtxTemp1_bmp   "VtxTemp1.bmp"
+#define VtxTemp2_bmp   "VtxTemp2.bmp"
+#define VtxTemp3_bmp   "VtxTemp3.bmp"
+#define VtxTemp4_bmp   "VtxTemp4.bmp"
+#define VtxTemp5_bmp   "VtxTemp5.bmp"
+#define VtxTemp6_bmp   "VtxTemp6.bmp"
+#define VtxTemp7_bmp   "VtxTemp7.bmp"
+#define VrxTemp7_gif   "VrxTemp7.gif"
+#define ant1_bmp       "ant1.bmp"
+#define ant2_bmp       "ant2.bmp"
+#define ant3_bmp       "ant3.bmp"
+#define ant4_bmp       "ant4.bmp"
+#define ant5_bmp       "ant5.bmp"
+#define ant6_bmp       "ant6.bmp"
+#define VLQ1_bmp       "VLQ1.bmp"
+#define VLQ2_bmp       "VLQ2.bmp"
+#define VLQ3_bmp       "VLQ3.bmp"
+#define VLQ4_bmp       "VLQ4.bmp"
+#define VLQ5_bmp       "VLQ5.bmp"
+#define VLQ6_bmp       "VLQ6.bmp"
+#define VLQ7_bmp       "VLQ7.bmp"
+#define VLQ8_bmp       "VLQ8.bmp"
+#define VLQ9_bmp       "VLQ9.bmp"
+#define blank_bmp      "blank36x36.bmp"
+#define LLOCK_bmp      "llock.bmp"
+#define DEF_VIDEOICON  "videoicon.jpg"
 
 typedef struct {
-	uint8_t top_speed;
-	bool 	auto_mode;
-	uint8_t left_speed;
-	uint8_t right_speed;
+    uint8_t top_speed;
+    bool auto_mode;
+    uint8_t left_speed;
+    uint8_t right_speed;
 } setting_fan_t;
 
 typedef struct {
-	int channel;
+    int channel;
 } setting_scan_t;
 
 typedef enum {
@@ -80,51 +79,50 @@ typedef enum {
 } setting_source_t;
 
 typedef struct {
-	setting_status_t status;
-	setting_source_t last_source;
-	setting_source_t source;
+    setting_status_t status;
+    setting_source_t last_source;
+    setting_source_t source;
 } setting_autoscan_t;
 
 typedef struct {
-	int voltage;
-	bool display_voltage;
-	int warning_type; //0=beep,1=visual,2=both
+    int voltage;
+    bool display_voltage;
+    int warning_type; // 0=beep,1=visual,2=both
 } setting_power_t;
 
-
 typedef struct {
-	bool mode_manual;
-	bool format_ts;
-	bool osd;
-	bool audio;
-	int audio_source; //0=MIC,1=Line in,2=AV in
+    bool mode_manual;
+    bool format_ts;
+    bool osd;
+    bool audio;
+    int audio_source; // 0=MIC,1=Line in,2=AV in
 } setting_record_t;
 
 typedef struct {
-	uint8_t oled;
-	uint8_t brightness;
-	uint8_t saturation;
-	uint8_t contrast;
-	uint8_t auto_off; //0=3min,1=4min,2=5min,3=never,
+    uint8_t oled;
+    uint8_t brightness;
+    uint8_t saturation;
+    uint8_t contrast;
+    uint8_t auto_off; // 0=3min,1=4min,2=5min,3=never,
 } setting_image_t;
 
 typedef struct {
-	int enable;
+    int enable;
 } head_tracker_t;
 
 typedef struct {
-	int enable;
+    int enable;
 } elrs_t;
 
 typedef struct {
-	setting_scan_t scan;
-	setting_fan_t fans; 
-	setting_autoscan_t autoscan;
-	setting_power_t power;
-	setting_record_t record;
-	setting_image_t image;
-	head_tracker_t	ht;
-	elrs_t elrs;
+    setting_scan_t scan;
+    setting_fan_t fans;
+    setting_autoscan_t autoscan;
+    setting_power_t power;
+    setting_record_t record;
+    setting_image_t image;
+    head_tracker_t ht;
+    elrs_t elrs;
 } setting_t;
 
 typedef enum {
@@ -135,48 +133,48 @@ typedef enum {
 } source_t;
 
 typedef struct _source_info {
-	source_t source;
-	uint8_t hdmi_in_status; //0=not detected, 1= detected
-    uint8_t av_in_status;   //0=not detected, 1= detected
-    uint8_t av_bay_status;   //0=not detected, 1= detected
+    source_t source;
+    uint8_t hdmi_in_status; // 0=not detected, 1= detected
+    uint8_t av_in_status;   // 0=not detected, 1= detected
+    uint8_t av_bay_status;  // 0=not detected, 1= detected
 } source_info_t;
 
 typedef struct {
-	lv_obj_t *container;
-	lv_obj_t *arrow;
-	lv_obj_t *btn;
-	lv_obj_t *label;
+    lv_obj_t *container;
+    lv_obj_t *arrow;
+    lv_obj_t *btn;
+    lv_obj_t *label;
 } btn_with_arr_t;
 
 typedef struct {
-	btn_with_arr_t btn_a[6];
-	int valid;
-	int current;
+    btn_with_arr_t btn_a[6];
+    int valid;
+    int current;
 } btn_group_t;
 
 typedef struct {
-	lv_obj_t *slider;
-	lv_obj_t *label;
+    lv_obj_t *slider;
+    lv_obj_t *label;
 } slider_group_t;
 
 typedef struct {
-	lv_obj_t *panel0;
-	lv_obj_t *panel1;
-	lv_obj_t *panel2;
-	lv_obj_t *panel3;
-	lv_obj_t *panel4;
-	lv_obj_t *panel5;
-	lv_obj_t *panel6;
-	lv_obj_t *panel7;
-	lv_obj_t *panel8;
+    lv_obj_t *panel0;
+    lv_obj_t *panel1;
+    lv_obj_t *panel2;
+    lv_obj_t *panel3;
+    lv_obj_t *panel4;
+    lv_obj_t *panel5;
+    lv_obj_t *panel6;
+    lv_obj_t *panel7;
+    lv_obj_t *panel8;
 
-	int cur;
-	int max;
+    int cur;
+    int max;
 } panel_arr_t;
 
-struct menu_obj_s{
-	lv_obj_t *cont;
-	lv_obj_t *icon;
+struct menu_obj_s {
+    lv_obj_t *cont;
+    lv_obj_t *icon;
 };
 enum {
     LV_MENU_ITEM_BUILDER_VARIANT_1,
@@ -188,7 +186,7 @@ extern setting_t g_setting;
 extern op_level_t g_menu_op;
 extern bool g_sdcard_enable;
 extern bool g_sdcard_det_req;
-extern int  g_sdcard_size;
+extern int g_sdcard_size;
 extern bool g_autoscan_exit;
 extern bool g_scanning;
 extern bool g_showRXOSD;
@@ -196,20 +194,20 @@ extern bool g_latency_locked;
 extern bool g_test_en;
 extern source_info_t g_source_info;
 
-int create_text(struct menu_obj_s *s, lv_obj_t * parent, bool is_icon, const char * txt,
-                              lv_menu_builder_variant_t builder_variant);
+int create_text(struct menu_obj_s *s, lv_obj_t *parent, bool is_icon, const char *txt,
+                lv_menu_builder_variant_t builder_variant);
 
 void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const char *name, int range, int default_value, int row);
 
-void create_btn_item(lv_obj_t *parent, const char *name,int col, int row);
+void create_btn_item(lv_obj_t *parent, const char *name, int col, int row);
 
-lv_obj_t* create_label_item(lv_obj_t *parent, const char *name, int col, int row, int cols);
+lv_obj_t *create_label_item(lv_obj_t *parent, const char *name, int col, int row, int cols);
 
-void create_btn_group_item(btn_group_t *btn_group,lv_obj_t *parent,int count,const char *name, const char *name0,const char *name1,\
-							const char *name2,const char *name3, int row);
+void create_btn_group_item(btn_group_t *btn_group, lv_obj_t *parent, int count, const char *name, const char *name0, const char *name1,
+                           const char *name2, const char *name3, int row);
 
-void create_btn_group_item2(btn_group_t *btn_group, lv_obj_t *parent,int count,const char *name, const char *name0,const char *name1,\
-							const char *name2,const char *name3, const char *name4,const char *name5,int row);
+void create_btn_group_item2(btn_group_t *btn_group, lv_obj_t *parent, int count, const char *name, const char *name0, const char *name1,
+                            const char *name2, const char *name3, const char *name4, const char *name5, int row);
 
 void set_select_item(const panel_arr_t *arr, int row);
 

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -159,7 +159,7 @@ typedef struct {
 	lv_obj_t *label;
 } slider_group_t;
 
-struct panel_arr{
+typedef struct {
 	lv_obj_t *panel0;
 	lv_obj_t *panel1;
 	lv_obj_t *panel2;
@@ -172,7 +172,8 @@ struct panel_arr{
 
 	int cur;
 	int max;
-};
+} panel_arr_t;
+
 struct menu_obj_s{
 	lv_obj_t *cont;
 	lv_obj_t *icon;
@@ -210,9 +211,9 @@ void create_btn_group_item(btn_group_t *btn_group,lv_obj_t *parent,int count,con
 void create_btn_group_item2(btn_group_t *btn_group, lv_obj_t *parent,int count,const char *name, const char *name0,const char *name1,\
 							const char *name2,const char *name3, const char *name4,const char *name5,int row);
 
-void set_select_item(const struct panel_arr *arr, int row);
+void set_select_item(const panel_arr_t *arr, int row);
 
-void create_select_item(struct panel_arr *arr, lv_obj_t *parent);
+void create_select_item(panel_arr_t *arr, lv_obj_t *parent);
 
 void btn_group_set_sel(btn_group_t *btn_group, int sel);
 

--- a/src/ui/page_connections.c
+++ b/src/ui/page_connections.c
@@ -1,136 +1,129 @@
 #include "page_connections.h"
 
-#include <stdio.h>
-#include <stdint.h>
-#include <unistd.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
-#include <stdlib.h>
 #include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include <minIni.h>
 #include <log/log.h>
+#include <minIni.h>
 
-#include "ui/ui_style.h"
-#include "page_version.h"
-#include "page_common.h"
-#include "../driver/esp32.h"
 #include "../core/common.hh"
 #include "../core/elrs.h"
+#include "../driver/esp32.h"
+#include "page_common.h"
+#include "page_version.h"
+#include "ui/ui_style.h"
 
-
-static lv_coord_t col_dsc[] = {180,200,160,160,160,160, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,40,40,60,60,60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {180, 200, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 40, 40, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 static lv_obj_t *btn_wifi;
 static lv_obj_t *btn_bind;
 static btn_group_t elrs_group;
 static lv_obj_t *elrs_bar = NULL;
 
-lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
-    create_text(NULL,section, false, "Connect Options:", LV_MENU_ITEM_BUILDER_VARIANT_2);
+    create_text(NULL, section, false, "Connect Options:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
+    create_select_item(arr, cont);
 
-	create_btn_group_item(&elrs_group, cont, 2, "Backpack", "On", "Off", "","",  0);
-	btn_group_set_sel(&elrs_group, !g_setting.elrs.enable);
-	btn_wifi = create_label_item(cont, "Start Backpack Wifi", 1, 1, 1);
-	btn_bind = create_label_item(cont, "Start Backpack Binding", 1, 2, 1);
+    create_btn_group_item(&elrs_group, cont, 2, "Backpack", "On", "Off", "", "", 0);
+    btn_group_set_sel(&elrs_group, !g_setting.elrs.enable);
+    btn_wifi = create_label_item(cont, "Start Backpack Wifi", 1, 1, 1);
+    btn_bind = create_label_item(cont, "Start Backpack Binding", 1, 2, 1);
 
-	btn_group_t btn_group;
-	create_btn_group_item(&btn_group, cont, 2, "Wifi AP*", "On", "Off", "","",  3);
-	create_label_item(cont,  "Wifi Settings", 1, 4, 1);
-	create_label_item(cont,  "Configure", 2, 4, 1);
-	create_label_item(cont,  "SSID: HDZero", 2, 5, 1);
-	//create_label_item(cont,  "Pass: hdzero123", 2, 6, 1);
-	create_label_item(cont,  "Broadcast ID: Yes", 2, 6, 1);
+    btn_group_t btn_group;
+    create_btn_group_item(&btn_group, cont, 2, "Wifi AP*", "On", "Off", "", "", 3);
+    create_label_item(cont, "Wifi Settings", 1, 4, 1);
+    create_label_item(cont, "Configure", 2, 4, 1);
+    create_label_item(cont, "SSID: HDZero", 2, 5, 1);
+    // create_label_item(cont,  "Pass: hdzero123", 2, 6, 1);
+    create_label_item(cont, "Broadcast ID: Yes", 2, 6, 1);
 
-	create_label_item(cont, "< Back", 1, 7, 1);
+    create_label_item(cont, "< Back", 1, 7, 1);
 
-	lv_obj_t *label2 = lv_label_create(cont);
-   	lv_label_set_text(label2, "*Expansion module is required.");
-	lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
-	lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_color(label2, lv_color_make(255,255,255), 0);
-	lv_obj_set_style_pad_top(label2, 12, 0);
-	lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
-	lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
-						 LV_GRID_ALIGN_START, 8, 2);
+    lv_obj_t *label2 = lv_label_create(cont);
+    lv_label_set_text(label2, "*Expansion module is required.");
+    lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_color(label2, lv_color_make(255, 255, 255), 0);
+    lv_obj_set_style_pad_top(label2, 12, 0);
+    lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
+    lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
+                         LV_GRID_ALIGN_START, 8, 2);
 
-	elrs_bar = lv_bar_create(cont);
+    elrs_bar = lv_bar_create(cont);
     lv_obj_set_size(elrs_bar, 260, 20);
-	lv_obj_set_grid_cell(elrs_bar, LV_GRID_ALIGN_CENTER, 3, 3,
-						 LV_GRID_ALIGN_CENTER, 1, 1);
-	lv_obj_add_flag(elrs_bar, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_grid_cell(elrs_bar, LV_GRID_ALIGN_CENTER, 3, 3,
+                         LV_GRID_ALIGN_CENTER, 1, 1);
+    lv_obj_add_flag(elrs_bar, LV_OBJ_FLAG_HIDDEN);
 
-	return page;
+    return page;
 }
 
-void page_connections_reset()
-{
-	lv_label_set_text(btn_wifi, "Start Backpack Wifi");
-	lv_label_set_text(btn_bind, "Start Backpack Binding");
+void page_connections_reset() {
+    lv_label_set_text(btn_wifi, "Start Backpack Wifi");
+    lv_label_set_text(btn_bind, "Start Backpack Binding");
 }
 
-void connect_function(int sel)
-{
-	page_connections_reset();
-	if(sel == 0)
-	{
-		btn_group_toggle_sel(&elrs_group);
-		g_setting.elrs.enable = btn_group_get_sel(&elrs_group) == 0 ? 1 : 0;
-		ini_putl("elrs", "enable", g_setting.elrs.enable, SETTING_INI);
-		if(g_setting.elrs.enable)
-			enable_esp32();
-		else
-			disable_esp32();
-	}
-	else if(sel == 1) // start ESP Wifi
-	{
-		lv_label_set_text(btn_wifi, "Starting...");
-		msp_send_packet(MSP_SET_MODE, MSP_PACKET_COMMAND, 1, (uint8_t *)"W");
-		lv_timer_handler();
-		if (!msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"P", 1000))
-			lv_label_set_text(btn_wifi, "#FF0000 FAILED#");
-		else
-			lv_label_set_text(btn_wifi, "#00FF00 Success#");
-	}
-	else if(sel == 2) // start ESP bind
-	{
-		lv_label_set_text(btn_bind, "Binding...");
-		msp_send_packet(MSP_SET_MODE, MSP_PACKET_COMMAND, 1, (uint8_t *)"B");
-		lv_timer_handler();
-		if (!msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"P", 1000)) {
-			lv_label_set_text(btn_bind, "#FF0000 FAILED#");
-		} else {
-			if(!msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"O", 120000)) {
-				lv_label_set_text(btn_bind, "#FEBE00 Timeout#");
-			} else {
-				lv_label_set_text(btn_bind, "#00FF00 Success#");
-			}
-		}
-	}
+void connect_function(int sel) {
+    page_connections_reset();
+    if (sel == 0) {
+        btn_group_toggle_sel(&elrs_group);
+        g_setting.elrs.enable = btn_group_get_sel(&elrs_group) == 0 ? 1 : 0;
+        ini_putl("elrs", "enable", g_setting.elrs.enable, SETTING_INI);
+        if (g_setting.elrs.enable)
+            enable_esp32();
+        else
+            disable_esp32();
+    } else if (sel == 1) // start ESP Wifi
+    {
+        lv_label_set_text(btn_wifi, "Starting...");
+        msp_send_packet(MSP_SET_MODE, MSP_PACKET_COMMAND, 1, (uint8_t *)"W");
+        lv_timer_handler();
+        if (!msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"P", 1000))
+            lv_label_set_text(btn_wifi, "#FF0000 FAILED#");
+        else
+            lv_label_set_text(btn_wifi, "#00FF00 Success#");
+    } else if (sel == 2) // start ESP bind
+    {
+        lv_label_set_text(btn_bind, "Binding...");
+        msp_send_packet(MSP_SET_MODE, MSP_PACKET_COMMAND, 1, (uint8_t *)"B");
+        lv_timer_handler();
+        if (!msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"P", 1000)) {
+            lv_label_set_text(btn_bind, "#FF0000 FAILED#");
+        } else {
+            if (!msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"O", 120000)) {
+                lv_label_set_text(btn_bind, "#FEBE00 Timeout#");
+            } else {
+                lv_label_set_text(btn_bind, "#00FF00 Success#");
+            }
+        }
+    }
 }

--- a/src/ui/page_connections.c
+++ b/src/ui/page_connections.c
@@ -137,9 +137,9 @@ page_pack_t pp_connections = {
         .max = 8,
     },
 
-    .create = &page_connections_create,
+    .create = page_connections_create,
     .enter = NULL,
     .exit = NULL,
-    .on_roller = &page_connections_on_roller,
-    .on_click = &page_connections_on_click,
+    .on_roller = page_connections_on_roller,
+    .on_click = page_connections_on_click,
 };

--- a/src/ui/page_connections.c
+++ b/src/ui/page_connections.c
@@ -14,10 +14,9 @@
 #include <log/log.h>
 #include <minIni.h>
 
-#include "../core/common.hh"
-#include "../core/elrs.h"
-#include "../driver/esp32.h"
-#include "page_common.h"
+#include "core/common.hh"
+#include "core/elrs.h"
+#include "driver/esp32.h"
 #include "page_version.h"
 #include "ui/ui_style.h"
 
@@ -87,12 +86,16 @@ lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr) {
     return page;
 }
 
-void page_connections_reset() {
+static void page_connections_reset() {
     lv_label_set_text(btn_wifi, "Start Backpack Wifi");
     lv_label_set_text(btn_bind, "Start Backpack Binding");
 }
 
-void connect_function(int sel) {
+static void page_connections_on_roller(uint8_t key) {
+    page_connections_reset();
+}
+
+static void page_connections_on_click(uint8_t key, int sel) {
     page_connections_reset();
     if (sel == 0) {
         btn_group_toggle_sel(&elrs_group);
@@ -127,3 +130,15 @@ void connect_function(int sel) {
         }
     }
 }
+
+page_pack_t pp_connections = {
+    .p_arr = {
+        .cur = 0,
+        .max = 8,
+    },
+
+    .enter = NULL,
+    .exit = NULL,
+    .on_roller = &page_connections_on_roller,
+    .on_click = &page_connections_on_click,
+};

--- a/src/ui/page_connections.c
+++ b/src/ui/page_connections.c
@@ -27,7 +27,7 @@ static lv_obj_t *btn_bind;
 static btn_group_t elrs_group;
 static lv_obj_t *elrs_bar = NULL;
 
-lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -137,6 +137,7 @@ page_pack_t pp_connections = {
         .max = 8,
     },
 
+    .create = &page_connections_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = &page_connections_on_roller,

--- a/src/ui/page_connections.c
+++ b/src/ui/page_connections.c
@@ -29,7 +29,7 @@ static lv_obj_t *btn_bind;
 static btn_group_t elrs_group;
 static lv_obj_t *elrs_bar = NULL;
 
-lv_obj_t *page_connections_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_connections.h
+++ b/src/ui/page_connections.h
@@ -1,10 +1,12 @@
 #ifndef _PAGE_CONNECTIONS_H
 #define _PAGE_CONNECTIONS_H
 
+#include <lvgl/lvgl.h>
 
-#include "lvgl/lvgl.h"
 #include "page_common.h"
+
 lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr);
+
 void connect_function(int sel);
 void page_connections_reset();
 

--- a/src/ui/page_connections.h
+++ b/src/ui/page_connections.h
@@ -7,6 +7,4 @@
 
 extern page_pack_t pp_connections;
 
-lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr);
-
 #endif

--- a/src/ui/page_connections.h
+++ b/src/ui/page_connections.h
@@ -3,11 +3,10 @@
 
 #include <lvgl/lvgl.h>
 
-#include "page_common.h"
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_connections;
 
 lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr);
-
-void connect_function(int sel);
-void page_connections_reset();
 
 #endif

--- a/src/ui/page_connections.h
+++ b/src/ui/page_connections.h
@@ -4,7 +4,7 @@
 
 #include "lvgl/lvgl.h"
 #include "page_common.h"
-lv_obj_t *page_connections_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_connections_create(lv_obj_t *parent, panel_arr_t *arr);
 void connect_function(int sel);
 void page_connections_reset();
 

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -27,7 +27,7 @@ static btn_group_t btn_group_fans;
 
 static slider_group_t slider_group[2];
 
-lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -340,6 +340,7 @@ page_pack_t pp_fans = {
         .max = 4,
     },
 
+    .create = &page_fans_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -5,10 +5,9 @@
 #include <log/log.h>
 #include <minIni.h>
 
-#include "../core/common.hh"
-#include "../driver/fans.h"
-#include "../driver/nct75.h"
-#include "fans.h"
+#include "core/common.hh"
+#include "driver/fans.h"
+#include "driver/nct75.h"
 #include "ui/page_common.h"
 #include "ui/page_fans.h"
 #include "ui/ui_style.h"
@@ -142,7 +141,7 @@ void fans_speed_dec(void) {
     }
 }
 
-void fans_mode_toggle(int sel) {
+static void page_fans_mode_on_click(uint8_t key, int sel) {
     lv_obj_t *slider = slider_group[0].slider;
     int value = 0;
 
@@ -174,9 +173,6 @@ void fans_mode_toggle(int sel) {
         g_menu_op = PAGE_FAN_SLIDE;
         lv_obj_add_style(slider, &style_silder_select, LV_PART_MAIN);
     }
-}
-
-void page_fans_key(uint8_t key) {
 }
 
 void step_topfan() {
@@ -337,3 +333,15 @@ void fans_auto_ctrl() {
         }
     }
 }
+
+page_pack_t pp_fans = {
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    },
+
+    .enter = NULL,
+    .exit = NULL,
+    .on_roller = NULL,
+    .on_click = &page_fans_mode_on_click,
+};

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -30,7 +30,7 @@ static btn_group_t btn_group_fans;
 static slider_group_t slider_group[2];
 
 
-lv_obj_t *page_fans_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -340,9 +340,9 @@ page_pack_t pp_fans = {
         .max = 4,
     },
 
-    .create = &page_fans_create,
+    .create = page_fans_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,
-    .on_click = &page_fans_mode_on_click,
+    .on_click = page_fans_mode_on_click,
 };

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -2,365 +2,338 @@
 
 #include <stdio.h>
 
-#include <minIni.h>
 #include <log/log.h>
+#include <minIni.h>
 
-#include "fans.h"
-#include "ui/ui_style.h"
-#include "ui_attribute.h"
 #include "../core/common.hh"
 #include "../driver/fans.h"
 #include "../driver/nct75.h"
+#include "fans.h"
 #include "ui/page_common.h"
 #include "ui/page_fans.h"
+#include "ui/ui_style.h"
+#include "ui_attribute.h"
 
 typedef enum {
-	FANS_MODE_TOP = 0,
-	FANS_MODE_SIDE,
+    FANS_MODE_TOP = 0,
+    FANS_MODE_SIDE,
 } fans_mode_t;
 
-static lv_coord_t col_dsc[] = {160,160,160,160,140,160, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {160, 160, 160, 160, 140, 160, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 fans_mode_t fans_mode = FANS_MODE_TOP;
-
 
 static btn_group_t btn_group_fans;
 
 static slider_group_t slider_group[2];
 
-
-lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
-    create_text(NULL,section, false, "Fans:", LV_MENU_ITEM_BUILDER_VARIANT_2);
+    create_text(NULL, section, false, "Fans:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
+    create_select_item(arr, cont);
 
-	create_btn_group_item(&btn_group_fans, cont, 2, "Auto Control", "On", "Off", "","",  0);
-	create_slider_item(&slider_group[0], cont, "Top Fan", MAX_FAN_TOP, 2, 1);
-	create_slider_item(&slider_group[1], cont, "Side Fans", MAX_FAN_SIDE, 2, 2);
+    create_btn_group_item(&btn_group_fans, cont, 2, "Auto Control", "On", "Off", "", "", 0);
+    create_slider_item(&slider_group[0], cont, "Top Fan", MAX_FAN_TOP, 2, 1);
+    create_slider_item(&slider_group[1], cont, "Side Fans", MAX_FAN_SIDE, 2, 2);
 
-	create_label_item(cont, "< Back", 1, 3,1);
-	
-	btn_group_set_sel(&btn_group_fans, !g_setting.fans.auto_mode);
-	
-	lv_slider_set_value(slider_group[0].slider, g_setting.fans.top_speed, LV_ANIM_OFF);	
-	lv_slider_set_value(slider_group[1].slider, g_setting.fans.left_speed, LV_ANIM_OFF);	
+    create_label_item(cont, "< Back", 1, 3, 1);
 
-	char buf[5];
-	sprintf(buf, "%d", g_setting.fans.top_speed);
-	lv_label_set_text(slider_group[0].label, buf);
-	sprintf(buf, "%d", g_setting.fans.left_speed);
-	lv_label_set_text(slider_group[1].label, buf);
+    btn_group_set_sel(&btn_group_fans, !g_setting.fans.auto_mode);
 
-	return page;
+    lv_slider_set_value(slider_group[0].slider, g_setting.fans.top_speed, LV_ANIM_OFF);
+    lv_slider_set_value(slider_group[1].slider, g_setting.fans.left_speed, LV_ANIM_OFF);
+
+    char buf[5];
+    sprintf(buf, "%d", g_setting.fans.top_speed);
+    lv_label_set_text(slider_group[0].label, buf);
+    sprintf(buf, "%d", g_setting.fans.left_speed);
+    lv_label_set_text(slider_group[1].label, buf);
+
+    return page;
 }
 
-void fans_speed_inc(void)
-{
-	int32_t value = 0;
-	char buf[5];
+void fans_speed_inc(void) {
+    int32_t value = 0;
+    char buf[5];
 
-	if( fans_mode == FANS_MODE_TOP)
-	{
-		 value = lv_slider_get_value(slider_group[0].slider);
-		if(value < MAX_FAN_TOP)
-			value += 1;
+    if (fans_mode == FANS_MODE_TOP) {
+        value = lv_slider_get_value(slider_group[0].slider);
+        if (value < MAX_FAN_TOP)
+            value += 1;
 
-		lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);	
+        lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
 
-		sprintf(buf, "%d", value);
-		lv_label_set_text(slider_group[0].label, buf);
+        sprintf(buf, "%d", value);
+        lv_label_set_text(slider_group[0].label, buf);
 
-		fans_top_setspeed(value);
+        fans_top_setspeed(value);
 
-		g_setting.fans.top_speed = value;
-  		ini_putl("fans", "top_speed", value, SETTING_INI);
-	}
-	else if( fans_mode == FANS_MODE_SIDE)
-	{
-		 value = lv_slider_get_value(slider_group[1].slider);
-		if(value < MAX_FAN_SIDE)
-			value += 1;
+        g_setting.fans.top_speed = value;
+        ini_putl("fans", "top_speed", value, SETTING_INI);
+    } else if (fans_mode == FANS_MODE_SIDE) {
+        value = lv_slider_get_value(slider_group[1].slider);
+        if (value < MAX_FAN_SIDE)
+            value += 1;
 
-		lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);	
-		
-		sprintf(buf, "%d", value);
-		lv_label_set_text(slider_group[1].label, buf);
+        lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
 
-		g_setting.fans.left_speed = value;
-  		ini_putl("fans", "left_speed", value, SETTING_INI);
-		g_setting.fans.right_speed = value;
-  		ini_putl("fans", "right_speed", value, SETTING_INI);
-	}
+        sprintf(buf, "%d", value);
+        lv_label_set_text(slider_group[1].label, buf);
+
+        g_setting.fans.left_speed = value;
+        ini_putl("fans", "left_speed", value, SETTING_INI);
+        g_setting.fans.right_speed = value;
+        ini_putl("fans", "right_speed", value, SETTING_INI);
+    }
 }
-void fans_speed_dec(void)
-{
-	int32_t value = 0;
-	char buf[5];
-	
-	if( fans_mode == FANS_MODE_TOP)
-	{
-		value = lv_slider_get_value(slider_group[0].slider);
+void fans_speed_dec(void) {
+    int32_t value = 0;
+    char buf[5];
 
-		if(value > 0)
-			value -= 1;
+    if (fans_mode == FANS_MODE_TOP) {
+        value = lv_slider_get_value(slider_group[0].slider);
 
-		lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);	
-		sprintf(buf, "%d", value);
-		lv_label_set_text(slider_group[0].label, buf);
+        if (value > 0)
+            value -= 1;
 
-		fans_top_setspeed(value);
+        lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
+        sprintf(buf, "%d", value);
+        lv_label_set_text(slider_group[0].label, buf);
 
-		g_setting.fans.top_speed = (uint8_t)value;
-  		ini_putl("fans", "top_speed", value, SETTING_INI);
-	}
-	else if( fans_mode == FANS_MODE_SIDE)
-	{
-		value = lv_slider_get_value(slider_group[1].slider);
+        fans_top_setspeed(value);
 
-		if(value > 0)
-			value -= 1;
+        g_setting.fans.top_speed = (uint8_t)value;
+        ini_putl("fans", "top_speed", value, SETTING_INI);
+    } else if (fans_mode == FANS_MODE_SIDE) {
+        value = lv_slider_get_value(slider_group[1].slider);
 
-		lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);	
-		sprintf(buf, "%d", value);
-		lv_label_set_text(slider_group[1].label, buf);
+        if (value > 0)
+            value -= 1;
 
-		g_setting.fans.left_speed = value;
-  		ini_putl("fans", "left_speed", value, SETTING_INI);
-		g_setting.fans.right_speed = value;
-  		ini_putl("fans", "right_speed", value, SETTING_INI);
-	}
+        lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
+        sprintf(buf, "%d", value);
+        lv_label_set_text(slider_group[1].label, buf);
+
+        g_setting.fans.left_speed = value;
+        ini_putl("fans", "left_speed", value, SETTING_INI);
+        g_setting.fans.right_speed = value;
+        ini_putl("fans", "right_speed", value, SETTING_INI);
+    }
 }
 
-void fans_mode_toggle(int sel)
-{
-	lv_obj_t *slider = slider_group[0].slider;
-	int value = 0;
+void fans_mode_toggle(int sel) {
+    lv_obj_t *slider = slider_group[0].slider;
+    int value = 0;
 
-	if(sel == 0)
-	{
-		btn_group_toggle_sel(&btn_group_fans);		
+    if (sel == 0) {
+        btn_group_toggle_sel(&btn_group_fans);
 
-		value = btn_group_get_sel(&btn_group_fans) == 0 ? 1 : 0;
-		if(value)
-			ini_puts("fans", "auto", "enable", SETTING_INI);
-		else
-			ini_puts("fans", "auto", "disable", SETTING_INI);
-		
-		g_setting.fans.auto_mode = value;
-		return;
-	}
-	else if(sel == 1)
-	{
-		slider = slider_group[0].slider;
-		fans_mode = FANS_MODE_TOP;
-	}
-	else if(sel == 2)
-	{
-		slider = slider_group[1].slider;
-		fans_mode = FANS_MODE_SIDE;
-	}
-	else{
-		return;
-	}
+        value = btn_group_get_sel(&btn_group_fans) == 0 ? 1 : 0;
+        if (value)
+            ini_puts("fans", "auto", "enable", SETTING_INI);
+        else
+            ini_puts("fans", "auto", "disable", SETTING_INI);
 
-	if(g_menu_op == PAGE_FAN_SLIDE)
-	{
-		g_menu_op = OPLEVEL_SUBMENU;
-		lv_obj_add_style(slider, &style_silder_main, LV_PART_MAIN);
-	}else{
-		g_menu_op = PAGE_FAN_SLIDE;
-		lv_obj_add_style(slider, &style_silder_select, LV_PART_MAIN);
-	}
+        g_setting.fans.auto_mode = value;
+        return;
+    } else if (sel == 1) {
+        slider = slider_group[0].slider;
+        fans_mode = FANS_MODE_TOP;
+    } else if (sel == 2) {
+        slider = slider_group[1].slider;
+        fans_mode = FANS_MODE_SIDE;
+    } else {
+        return;
+    }
 
+    if (g_menu_op == PAGE_FAN_SLIDE) {
+        g_menu_op = OPLEVEL_SUBMENU;
+        lv_obj_add_style(slider, &style_silder_main, LV_PART_MAIN);
+    } else {
+        g_menu_op = PAGE_FAN_SLIDE;
+        lv_obj_add_style(slider, &style_silder_select, LV_PART_MAIN);
+    }
 }
 
-void page_fans_key(uint8_t key)
-{
-	
+void page_fans_key(uint8_t key) {
 }
 
-void step_topfan()
-{
-	char str[10];
-	
-	if(g_setting.fans.top_speed == MAX_FAN_TOP)  g_setting.fans.top_speed = 0;
-	else g_setting.fans.top_speed++;
+void step_topfan() {
+    char str[10];
 
-	fans_top_setspeed(g_setting.fans.top_speed);
-	ini_putl("fans", "top_speed", g_setting.fans.top_speed, SETTING_INI);
+    if (g_setting.fans.top_speed == MAX_FAN_TOP)
+        g_setting.fans.top_speed = 0;
+    else
+        g_setting.fans.top_speed++;
+
+    fans_top_setspeed(g_setting.fans.top_speed);
+    ini_putl("fans", "top_speed", g_setting.fans.top_speed, SETTING_INI);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // Auto control side fans
-static uint16_t respeed_cnt[2] = {0,0}; //[0]=right,[1]=left
-static bool respeeding[2] = {false,false}; 
+static uint16_t respeed_cnt[2] = {0, 0}; //[0]=right,[1]=left
+static bool respeeding[2] = {false, false};
 
-uint8_t adj_speed(uint8_t cur_speed, int tempe,uint8_t is_left)
-{
-	uint8_t new_speed = cur_speed;
+uint8_t adj_speed(uint8_t cur_speed, int tempe, uint8_t is_left) {
+    uint8_t new_speed = cur_speed;
 
-	if(tempe > FAN_TEMPERATURE_THR_H) {
-		if(new_speed != MAX_FAN_SIDE) {
-			new_speed++;
-			respeeding[is_left] = true;  respeed_cnt[is_left] = 0;
-		}
-	}
-	else if(tempe < FAN_TEMPERATURE_THR_L) {
-		if(new_speed != 0) {
-			new_speed--;
-			respeeding[is_left] = true;  respeed_cnt[is_left] = 0;
-		}
-	}
+    if (tempe > FAN_TEMPERATURE_THR_H) {
+        if (new_speed != MAX_FAN_SIDE) {
+            new_speed++;
+            respeeding[is_left] = true;
+            respeed_cnt[is_left] = 0;
+        }
+    } else if (tempe < FAN_TEMPERATURE_THR_L) {
+        if (new_speed != 0) {
+            new_speed--;
+            respeeding[is_left] = true;
+            respeed_cnt[is_left] = 0;
+        }
+    }
 
-	if(cur_speed != new_speed)
-		LOGI("%s Fan speed: %d (T=%d)", is_left? "Left": "Right",new_speed,tempe);
+    if (cur_speed != new_speed)
+        LOGI("%s Fan speed: %d (T=%d)", is_left ? "Left" : "Right", new_speed, tempe);
 
-	return new_speed;
+    return new_speed;
 }
 
-void fans_auto_ctrl_core(bool is_left,int tempe, bool binit)
-{
-	static uint8_t speed[2]={2,2};
-	uint8_t new_spd;
+void fans_auto_ctrl_core(bool is_left, int tempe, bool binit) {
+    static uint8_t speed[2] = {2, 2};
+    uint8_t new_spd;
 
-	//////////////////////////////////////////////////////////////////////////////////
-	//reinit auto speed
-	if(binit) {
-		speed[0] = speed[1] = 2;  //Initial fan speed for auto mode
-		respeed_cnt[0] = respeed_cnt[1] = 0;
-		respeeding[0] = respeeding[1] = false;
-		fans_right_setspeed(speed[0]);
-		fans_left_setspeed(speed[1]);
-	}
+    //////////////////////////////////////////////////////////////////////////////////
+    // reinit auto speed
+    if (binit) {
+        speed[0] = speed[1] = 2; // Initial fan speed for auto mode
+        respeed_cnt[0] = respeed_cnt[1] = 0;
+        respeeding[0] = respeeding[1] = false;
+        fans_right_setspeed(speed[0]);
+        fans_left_setspeed(speed[1]);
+    }
 
-	if(respeeding[is_left]) {
-		respeed_cnt[is_left]++;
-		if(respeed_cnt[is_left] == RESPEED_WAIT_TIME) {
-			respeeding[is_left] = false;
-			respeed_cnt[is_left] = 0;
-		}
-		return;
-	}
+    if (respeeding[is_left]) {
+        respeed_cnt[is_left]++;
+        if (respeed_cnt[is_left] == RESPEED_WAIT_TIME) {
+            respeeding[is_left] = false;
+            respeed_cnt[is_left] = 0;
+        }
+        return;
+    }
 
-	new_spd = adj_speed(speed[is_left],tempe, is_left);
-	if(new_spd != speed[is_left]) {
-		speed[is_left] = new_spd;
-		if(is_left)
-			fans_left_setspeed(speed[1]);
-		else	
-			fans_right_setspeed(speed[0]);
-	}
+    new_spd = adj_speed(speed[is_left], tempe, is_left);
+    if (new_spd != speed[is_left]) {
+        speed[is_left] = new_spd;
+        if (is_left)
+            fans_left_setspeed(speed[1]);
+        else
+            fans_right_setspeed(speed[0]);
+    }
 }
 
-bool rescue_from_hot()
-{
-	static uint8_t speeds_saved[3];
-	static bool    respeeding[3] = {false,false,false};
+bool rescue_from_hot() {
+    static uint8_t speeds_saved[3];
+    static bool respeeding[3] = {false, false, false};
 
-	//Right
-	if(g_temperature.right > SIDE_TEMPERATURE_RISKH) {
-		if(!respeeding[0]) {
-			speeds_saved[0] = fan_speeds[0];
-			respeeding[0] = true;
-			fans_right_setspeed(MAX_FAN_SIDE);
-			LOGI("Right fan: rescue ON.\n");
-		}
-	}
-	else if(respeeding[0] &&(g_temperature.right < FAN_TEMPERATURE_THR_L)) {
-		fans_right_setspeed(speeds_saved[0]);
-		respeeding[0] = false;
-		LOGI("Right fan: rescue OFF.");
-	}
+    // Right
+    if (g_temperature.right > SIDE_TEMPERATURE_RISKH) {
+        if (!respeeding[0]) {
+            speeds_saved[0] = fan_speeds[0];
+            respeeding[0] = true;
+            fans_right_setspeed(MAX_FAN_SIDE);
+            LOGI("Right fan: rescue ON.\n");
+        }
+    } else if (respeeding[0] && (g_temperature.right < FAN_TEMPERATURE_THR_L)) {
+        fans_right_setspeed(speeds_saved[0]);
+        respeeding[0] = false;
+        LOGI("Right fan: rescue OFF.");
+    }
 
-	//Left
-	if(g_temperature.left > SIDE_TEMPERATURE_RISKH) {
-		if(!respeeding[1]) {
-			speeds_saved[1] = fan_speeds[1];
-			respeeding[1] = true;
-			fans_left_setspeed(MAX_FAN_SIDE);
-			LOGI("Left fan: rescue ON.\n");
-		}
-	}
-	else if(respeeding[1] &&(g_temperature.left < FAN_TEMPERATURE_THR_L)) {
-		fans_left_setspeed(speeds_saved[1]);
-		respeeding[1] = false;
-		LOGI("Left fan: rescue OFF.");
-	}
+    // Left
+    if (g_temperature.left > SIDE_TEMPERATURE_RISKH) {
+        if (!respeeding[1]) {
+            speeds_saved[1] = fan_speeds[1];
+            respeeding[1] = true;
+            fans_left_setspeed(MAX_FAN_SIDE);
+            LOGI("Left fan: rescue ON.\n");
+        }
+    } else if (respeeding[1] && (g_temperature.left < FAN_TEMPERATURE_THR_L)) {
+        fans_left_setspeed(speeds_saved[1]);
+        respeeding[1] = false;
+        LOGI("Left fan: rescue OFF.");
+    }
 
-	//Top 
-	if(g_temperature.top > TOP_TEMPERATURE_RISKH) {
-		if(!respeeding[2]) {
-			speeds_saved[2] = fan_speeds[2];
-			respeeding[2] = true;
-			fans_top_setspeed(MAX_FAN_TOP);
-			LOGI("Top fan: rescue ON.\n");
-		}
-	}
-	else if(respeeding[2] &&(g_temperature.top < TOP_TEMPERATURE_NORM)) {
-		fans_top_setspeed(speeds_saved[2]);
-		respeeding[2] = false;
-		LOGI("Top fan: rescue OFF.");
-	}
+    // Top
+    if (g_temperature.top > TOP_TEMPERATURE_RISKH) {
+        if (!respeeding[2]) {
+            speeds_saved[2] = fan_speeds[2];
+            respeeding[2] = true;
+            fans_top_setspeed(MAX_FAN_TOP);
+            LOGI("Top fan: rescue ON.\n");
+        }
+    } else if (respeeding[2] && (g_temperature.top < TOP_TEMPERATURE_NORM)) {
+        fans_top_setspeed(speeds_saved[2]);
+        respeeding[2] = false;
+        LOGI("Top fan: rescue OFF.");
+    }
 
-	g_temperature.is_rescuing = respeeding[0] || respeeding[1] || respeeding[2];
-	return  g_temperature.is_rescuing;
+    g_temperature.is_rescuing = respeeding[0] || respeeding[1] || respeeding[2];
+    return g_temperature.is_rescuing;
 }
 
-void fans_auto_ctrl()
-{
-	static uint8_t auto_mode_d;
-	static uint8_t speeds[3];
-	uint8_t binit_r,binit_f;
+void fans_auto_ctrl() {
+    static uint8_t auto_mode_d;
+    static uint8_t speeds[3];
+    uint8_t binit_r, binit_f;
 
-	if(rescue_from_hot()) return;
+    if (rescue_from_hot())
+        return;
 
-	binit_r = (auto_mode_d == 0) && (g_setting.fans.auto_mode == 1);  //Manual mode -> Auto
-	binit_f = (auto_mode_d == 1) && (g_setting.fans.auto_mode == 0);  //Auto   mode -> manual
-	auto_mode_d = g_setting.fans.auto_mode;
-	
-	if(g_setting.fans.auto_mode) {
-		fans_auto_ctrl_core(false, g_temperature.right, binit_r);
-		fans_auto_ctrl_core(true, g_temperature.left, binit_r);
-	}
-	else {
-		if(binit_f) 
-			speeds[0] = speeds[1] = speeds[2] = 0xFF;
+    binit_r = (auto_mode_d == 0) && (g_setting.fans.auto_mode == 1); // Manual mode -> Auto
+    binit_f = (auto_mode_d == 1) && (g_setting.fans.auto_mode == 0); // Auto   mode -> manual
+    auto_mode_d = g_setting.fans.auto_mode;
 
-		if(speeds[0] != g_setting.fans.right_speed) {
-			fans_right_setspeed(g_setting.fans.right_speed);
-			speeds[0] = g_setting.fans.right_speed;
-		}
+    if (g_setting.fans.auto_mode) {
+        fans_auto_ctrl_core(false, g_temperature.right, binit_r);
+        fans_auto_ctrl_core(true, g_temperature.left, binit_r);
+    } else {
+        if (binit_f)
+            speeds[0] = speeds[1] = speeds[2] = 0xFF;
 
-		if(speeds[1] != g_setting.fans.left_speed) {
-			fans_left_setspeed(g_setting.fans.left_speed);
-			speeds[1] = g_setting.fans.left_speed;
-		}
+        if (speeds[0] != g_setting.fans.right_speed) {
+            fans_right_setspeed(g_setting.fans.right_speed);
+            speeds[0] = g_setting.fans.right_speed;
+        }
 
-		if(speeds[2] != g_setting.fans.top_speed) {
-			fans_top_setspeed(g_setting.fans.top_speed);
-			speeds[2] = g_setting.fans.top_speed;
-		}
-	}
+        if (speeds[1] != g_setting.fans.left_speed) {
+            fans_left_setspeed(g_setting.fans.left_speed);
+            speeds[1] = g_setting.fans.left_speed;
+        }
+
+        if (speeds[2] != g_setting.fans.top_speed) {
+            fans_top_setspeed(g_setting.fans.top_speed);
+            speeds[2] = g_setting.fans.top_speed;
+        }
+    }
 }

--- a/src/ui/page_fans.h
+++ b/src/ui/page_fans.h
@@ -12,13 +12,14 @@
 #define TOP_TEMPERATURE_RISKH  500 //
 #define TOP_TEMPERATURE_NORM   400 //
 
-#include "page_common.h"
-
 #include <lvgl/lvgl.h>
+
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_fans;
 
 lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr);
 
-void fans_mode_toggle(int sel);
 void fans_speed_dec(void);
 void fans_speed_inc(void);
 void step_topfan();

--- a/src/ui/page_fans.h
+++ b/src/ui/page_fans.h
@@ -15,7 +15,7 @@
 #include "lvgl/lvgl.h"
 #include "page_common.h"
 
-lv_obj_t *page_fans_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr);
 
 void fans_mode_toggle(int sel);
 void fans_speed_dec(void);

--- a/src/ui/page_fans.h
+++ b/src/ui/page_fans.h
@@ -18,8 +18,6 @@
 
 extern page_pack_t pp_fans;
 
-lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr);
-
 void fans_speed_dec(void);
 void fans_speed_inc(void);
 void step_topfan();

--- a/src/ui/page_fans.h
+++ b/src/ui/page_fans.h
@@ -1,19 +1,20 @@
 #ifndef _PAGE_FANS_H
 #define _PAGE_FANS_H
 
-#define MAX_FAN_TOP     5  //0:5
-#define MAX_FAN_SIDE    9  //0:9
+#define MAX_FAN_TOP  5 // 0:5
+#define MAX_FAN_SIDE 9 // 0:9
 
-#define FAN_TEMPERATURE_THR_H  750  //75C
-#define FAN_TEMPERATURE_THR_L  650  //65C
-#define RESPEED_WAIT_TIME      50   //200 = 30s 
+#define FAN_TEMPERATURE_THR_H 750 // 75C
+#define FAN_TEMPERATURE_THR_L 650 // 65C
+#define RESPEED_WAIT_TIME     50  // 200 = 30s
 
-#define SIDE_TEMPERATURE_RISKH 850  //85C Risk high
-#define TOP_TEMPERATURE_RISKH  500  //
-#define TOP_TEMPERATURE_NORM   400  //
+#define SIDE_TEMPERATURE_RISKH 850 // 85C Risk high
+#define TOP_TEMPERATURE_RISKH  500 //
+#define TOP_TEMPERATURE_NORM   400 //
 
-#include "lvgl/lvgl.h"
 #include "page_common.h"
+
+#include <lvgl/lvgl.h>
 
 lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr);
 

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -12,7 +12,7 @@ static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 160, LV_GRID_TEMPLATE_LA
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 lv_obj_t *label_cali;
 
-lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -72,6 +72,7 @@ page_pack_t pp_headtracker = {
         .max = 3,
     },
 
+    .create = &page_headtracker_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -1,6 +1,8 @@
 #include "page_headtracker.h"
+
+#include <minIni.h>
+
 #include "ht.h"
-#include "minIni.h"
 #include "page_common.h"
 #include "ui/ui_style.h"
 

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -48,7 +48,7 @@ lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     return page;
 }
 
-void headtracker_set_toggle(int sel) {
+static void page_headtracker_on_click(uint8_t key, int sel) {
     if (sel == 0) {
         btn_group_toggle_sel(&btn_group);
         g_setting.ht.enable = btn_group_get_sel(&btn_group) == 0 ? 1 : 0;
@@ -65,3 +65,15 @@ void headtracker_set_toggle(int sel) {
         lv_timer_handler();
     }
 }
+
+page_pack_t pp_headtracker = {
+    .p_arr = {
+        .cur = 0,
+        .max = 3,
+    },
+
+    .enter = NULL,
+    .exit = NULL,
+    .on_roller = NULL,
+    .on_click = &page_headtracker_on_click,
+};

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -72,9 +72,9 @@ page_pack_t pp_headtracker = {
         .max = 3,
     },
 
-    .create = &page_headtracker_create,
+    .create = page_headtracker_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,
-    .on_click = &page_headtracker_on_click,
+    .on_click = page_headtracker_on_click,
 };

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -10,7 +10,7 @@ static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 160, LV_GRID_TEMPLATE_LA
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 lv_obj_t *label_cali;
 
-lv_obj_t *page_headtracker_create(lv_obj_t *parent, struct panel_arr *arr) {
+lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);

--- a/src/ui/page_headtracker.h
+++ b/src/ui/page_headtracker.h
@@ -5,7 +5,7 @@
 #include "lvgl/lvgl.h"
 #include "page_common.h"
 
-lv_obj_t *page_headtracker_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr);
 void headtracker_set_toggle(int sel);
 
 #endif

--- a/src/ui/page_headtracker.h
+++ b/src/ui/page_headtracker.h
@@ -3,10 +3,10 @@
 
 #include <lvgl/lvgl.h>
 
-#include "page_common.h"
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_headtracker;
 
 lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr);
-
-void headtracker_set_toggle(int sel);
 
 #endif

--- a/src/ui/page_headtracker.h
+++ b/src/ui/page_headtracker.h
@@ -1,11 +1,12 @@
 #ifndef _PAGE_HEADTRACKER_H
 #define _PAGE_HEADTRACKER_H
 
+#include <lvgl/lvgl.h>
 
-#include "lvgl/lvgl.h"
 #include "page_common.h"
 
 lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr);
+
 void headtracker_set_toggle(int sel);
 
 #endif

--- a/src/ui/page_headtracker.h
+++ b/src/ui/page_headtracker.h
@@ -7,6 +7,4 @@
 
 extern page_pack_t pp_headtracker;
 
-lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr);
-
 #endif

--- a/src/ui/page_imagesettings.c
+++ b/src/ui/page_imagesettings.c
@@ -22,7 +22,7 @@ static slider_group_t slider_group2;
 static slider_group_t slider_group3;
 static slider_group_t slider_group4;
 
-lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -132,6 +132,7 @@ page_pack_t pp_imagesettings = {
         .max = 6,
     },
 
+    .create = &page_imagesettings_create,
     .enter = &page_imagesettings_enter,
     .exit = NULL,
     .on_roller = NULL,

--- a/src/ui/page_imagesettings.c
+++ b/src/ui/page_imagesettings.c
@@ -22,7 +22,7 @@ static slider_group_t slider_group2;
 static slider_group_t slider_group3;
 static slider_group_t slider_group4;
 
-lv_obj_t *page_imagesettings_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_imagesettings.c
+++ b/src/ui/page_imagesettings.c
@@ -99,7 +99,7 @@ void set_slider_value() {
     lv_slider_set_value(slider_group4.slider, g_setting.image.auto_off, LV_ANIM_OFF);
 }
 
-void page_ims_click() {
+static void page_imagesettings_enter() {
     g_menu_op = OPLEVEL_IMS;
     switch (g_source_info.source) {
     case SOURCE_HDZERO:
@@ -125,3 +125,15 @@ void page_ims_click() {
         break;
     }
 }
+
+page_pack_t pp_imagesettings = {
+    .p_arr = {
+        .cur = 0,
+        .max = 6,
+    },
+
+    .enter = &page_imagesettings_enter,
+    .exit = NULL,
+    .on_roller = NULL,
+    .on_click = NULL,
+};

--- a/src/ui/page_imagesettings.c
+++ b/src/ui/page_imagesettings.c
@@ -132,8 +132,8 @@ page_pack_t pp_imagesettings = {
         .max = 6,
     },
 
-    .create = &page_imagesettings_create,
-    .enter = &page_imagesettings_enter,
+    .create = page_imagesettings_create,
+    .enter = page_imagesettings_enter,
     .exit = NULL,
     .on_roller = NULL,
     .on_click = NULL,

--- a/src/ui/page_imagesettings.c
+++ b/src/ui/page_imagesettings.c
@@ -1,20 +1,20 @@
 #include "page_imagesettings.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "../core/common.hh"
 #include "../driver/hardware.h"
 #include "oled.h"
 #include "page_common.h"
 #include "page_scannow.h"
 #include "page_source.h"
-#include "ui/ui_style.h"
 #include "ui/ui_image_setting.h"
 #include "ui/ui_main_menu.h"
+#include "ui/ui_style.h"
 
-
-#include <stdlib.h>
-#include <stdio.h>
-static lv_coord_t col_dsc[] = {160,160,160,160,140,220, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {160, 160, 160, 160, 140, 220, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 static slider_group_t slider_group;
 static slider_group_t slider_group1;
@@ -22,112 +22,106 @@ static slider_group_t slider_group2;
 static slider_group_t slider_group3;
 static slider_group_t slider_group4;
 
-lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
-
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
     create_text(NULL, section, false, "Image Settings:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
-    lv_obj_t * cont = lv_obj_create(section);
+    lv_obj_t *cont = lv_obj_create(section);
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
+    create_select_item(arr, cont);
 
-	create_slider_item(&slider_group, cont,  "OLED", 12, g_setting.image.oled, 0);
-	create_slider_item(&slider_group1, cont, "Brightness", 78, g_setting.image.brightness, 1);
-	create_slider_item(&slider_group2, cont, "Saturation", 47, g_setting.image.saturation, 2);
-	create_slider_item(&slider_group3, cont, "Contrast", 47, g_setting.image.contrast, 3);
-	create_slider_item(&slider_group4, cont, "OLED Auto off", 3, g_setting.image.auto_off, 4);
+    create_slider_item(&slider_group, cont, "OLED", 12, g_setting.image.oled, 0);
+    create_slider_item(&slider_group1, cont, "Brightness", 78, g_setting.image.brightness, 1);
+    create_slider_item(&slider_group2, cont, "Saturation", 47, g_setting.image.saturation, 2);
+    create_slider_item(&slider_group3, cont, "Contrast", 47, g_setting.image.contrast, 3);
+    create_slider_item(&slider_group4, cont, "OLED Auto off", 3, g_setting.image.auto_off, 4);
 
-	create_label_item(cont, "< Back", 1, 5, 1);
+    create_label_item(cont, "< Back", 1, 5, 1);
 
-	lv_obj_t *label2 = lv_label_create(cont);
-   	lv_label_set_text(label2, "To change image settings, click the Enter button to enter video mode. \nMake sure a HDZero VTX or analog VTX is powered on for live video.");
-	lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
-	lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_color(label2, lv_color_make(255,255,255), 0);
-	lv_obj_set_style_pad_top(label2, 12, 0);
-	lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
-	lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
-						 LV_GRID_ALIGN_START, 6, 2);
+    lv_obj_t *label2 = lv_label_create(cont);
+    lv_label_set_text(label2, "To change image settings, click the Enter button to enter video mode. \nMake sure a HDZero VTX or analog VTX is powered on for live video.");
+    lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_color(label2, lv_color_make(255, 255, 255), 0);
+    lv_obj_set_style_pad_top(label2, 12, 0);
+    lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
+    lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
+                         LV_GRID_ALIGN_START, 6, 2);
 
+    set_slider_value();
 
-	 set_slider_value();
-
-	return page;
+    return page;
 }
 
-void set_slider_value()
-{
-	char buf[32];
-//	LOGI("set_slider_value %d %d %d %d.",g_setting.image.oled,g_setting.image.brightness,
-//											 g_setting.image.saturation,g_setting.image.contrast);
+void set_slider_value() {
+    char buf[32];
+    //	LOGI("set_slider_value %d %d %d %d.",g_setting.image.oled,g_setting.image.brightness,
+    //											 g_setting.image.saturation,g_setting.image.contrast);
 
-	sprintf(buf,"%d",g_setting.image.oled);
-	lv_label_set_text(slider_group.label, buf);
-	lv_slider_set_value(slider_group.slider,  g_setting.image.oled, LV_ANIM_OFF);	
+    sprintf(buf, "%d", g_setting.image.oled);
+    lv_label_set_text(slider_group.label, buf);
+    lv_slider_set_value(slider_group.slider, g_setting.image.oled, LV_ANIM_OFF);
 
-	sprintf(buf,"%d",g_setting.image.brightness);
-	lv_label_set_text(slider_group1.label, buf);
-	lv_slider_set_value(slider_group1.slider,  g_setting.image.brightness, LV_ANIM_OFF);	
+    sprintf(buf, "%d", g_setting.image.brightness);
+    lv_label_set_text(slider_group1.label, buf);
+    lv_slider_set_value(slider_group1.slider, g_setting.image.brightness, LV_ANIM_OFF);
 
-	sprintf(buf,"%d",g_setting.image.saturation);
-	lv_label_set_text(slider_group2.label, buf);
-	lv_slider_set_value(slider_group2.slider,  g_setting.image.saturation, LV_ANIM_OFF);	
+    sprintf(buf, "%d", g_setting.image.saturation);
+    lv_label_set_text(slider_group2.label, buf);
+    lv_slider_set_value(slider_group2.slider, g_setting.image.saturation, LV_ANIM_OFF);
 
-	sprintf(buf,"%d",g_setting.image.contrast);
-	lv_label_set_text(slider_group3.label, buf);
-	lv_slider_set_value(slider_group3.slider,  g_setting.image.contrast, LV_ANIM_OFF);	
+    sprintf(buf, "%d", g_setting.image.contrast);
+    lv_label_set_text(slider_group3.label, buf);
+    lv_slider_set_value(slider_group3.slider, g_setting.image.contrast, LV_ANIM_OFF);
 
-
-	if(g_setting.image.auto_off == 3)
-		strcpy(buf,"Never");
-	else	
-		sprintf(buf,"%d min",g_setting.image.auto_off*2+3);
-	lv_label_set_text(slider_group4.label, buf);
-	lv_slider_set_value(slider_group4.slider,  g_setting.image.auto_off, LV_ANIM_OFF);	
+    if (g_setting.image.auto_off == 3)
+        strcpy(buf, "Never");
+    else
+        sprintf(buf, "%d min", g_setting.image.auto_off * 2 + 3);
+    lv_label_set_text(slider_group4.label, buf);
+    lv_slider_set_value(slider_group4.slider, g_setting.image.auto_off, LV_ANIM_OFF);
 }
 
-void page_ims_click()
-{
-	g_menu_op = OPLEVEL_IMS;
-	switch(g_source_info.source) {
-		case SOURCE_HDZERO:
-			progress_bar.start  = 1;
-			HDZero_open();
-			switch_to_video(true);	
-			g_bShowIMS = true;
-			break;
+void page_ims_click() {
+    g_menu_op = OPLEVEL_IMS;
+    switch (g_source_info.source) {
+    case SOURCE_HDZERO:
+        progress_bar.start = 1;
+        HDZero_open();
+        switch_to_video(true);
+        g_bShowIMS = true;
+        break;
 
-		case SOURCE_HDMI_IN: //no image setting support for HDMI in
-			g_menu_op = OPLEVEL_SUBMENU;
-			g_bShowIMS = false;
-			break;
+    case SOURCE_HDMI_IN: // no image setting support for HDMI in
+        g_menu_op = OPLEVEL_SUBMENU;
+        g_bShowIMS = false;
+        break;
 
-		case SOURCE_AV_IN:
-			switch_to_analog(0);
-			g_bShowIMS = true;
-			break;
+    case SOURCE_AV_IN:
+        switch_to_analog(0);
+        g_bShowIMS = true;
+        break;
 
-		case SOURCE_EXPANSION:
-			switch_to_analog(1);
-			g_bShowIMS = true;
-			break;
-	}
+    case SOURCE_EXPANSION:
+        switch_to_analog(1);
+        g_bShowIMS = true;
+        break;
+    }
 }

--- a/src/ui/page_imagesettings.h
+++ b/src/ui/page_imagesettings.h
@@ -4,7 +4,7 @@
 
 #include "lvgl/lvgl.h"
 #include "page_common.h"
-lv_obj_t *page_imagesettings_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr);
 
 void page_ims_click();
 void set_slider_value();

--- a/src/ui/page_imagesettings.h
+++ b/src/ui/page_imagesettings.h
@@ -1,12 +1,14 @@
 #ifndef _PAGE_IMAGESETTINGS_H
 #define _PAGE_IMAGESETTINGS_H
 
-#include "page_common.h"
 #include <lvgl/lvgl.h>
+
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_imagesettings;
 
 lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr);
 
-void page_ims_click();
 void set_slider_value();
 
 #endif

--- a/src/ui/page_imagesettings.h
+++ b/src/ui/page_imagesettings.h
@@ -1,11 +1,12 @@
 #ifndef _PAGE_IMAGESETTINGS_H
 #define _PAGE_IMAGESETTINGS_H
 
-
-#include "lvgl/lvgl.h"
 #include "page_common.h"
+#include <lvgl/lvgl.h>
+
 lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr);
 
 void page_ims_click();
 void set_slider_value();
+
 #endif

--- a/src/ui/page_imagesettings.h
+++ b/src/ui/page_imagesettings.h
@@ -7,8 +7,6 @@
 
 extern page_pack_t pp_imagesettings;
 
-lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr);
-
 void set_slider_value();
 
 #endif

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -240,10 +240,19 @@ static void update_page() {
     }
 }
 
-int init_pb() {
+static void page_playback_exit() {
+    clear_videofile_cnt();
+    update_page();
+}
+
+static void page_playback_enter() {
     const int ret = walk_sdcard();
     update_page();
-    return ret;
+
+    if (ret == 0) {
+        // no files found, back out
+        page_playback_exit();
+    }
 }
 
 void pb_key(uint8_t key) {
@@ -290,9 +299,23 @@ void pb_key(uint8_t key) {
         break;
 
     case DIAL_KEY_PRESS: // long press
-        clear_videofile_cnt();
-        update_page();
+        page_playback_exit();
         break;
     }
     done = true;
 }
+
+static void page_playback_on_roller(uint8_t key) {
+    pb_key(key);
+}
+
+static void page_playback_on_click(uint8_t key, int sel) {
+    pb_key(key);
+}
+
+page_pack_t pp_playback = {
+    .enter = &page_playback_enter,
+    .exit = &page_playback_exit,
+    .on_roller = &page_playback_on_roller,
+    .on_click = &page_playback_on_click,
+};

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -24,7 +24,7 @@ static lv_coord_t row_dsc[] = {150, 30, 150, 30, 150, 30, 30, LV_GRID_TEMPLATE_L
 static media_db_t media_db;
 static pb_ui_item_t pb_ui[ITEMS_LAYOUT_CNT];
 
-lv_obj_t *page_playback_create(lv_obj_t *parent) {
+static lv_obj_t *page_playback_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1142, 900);
@@ -314,6 +314,7 @@ static void page_playback_on_click(uint8_t key, int sel) {
 }
 
 page_pack_t pp_playback = {
+    .create = &page_playback_create,
     .enter = &page_playback_enter,
     .exit = &page_playback_exit,
     .on_roller = &page_playback_on_roller,

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -314,9 +314,9 @@ static void page_playback_on_click(uint8_t key, int sel) {
 }
 
 page_pack_t pp_playback = {
-    .create = &page_playback_create,
-    .enter = &page_playback_enter,
-    .exit = &page_playback_exit,
-    .on_roller = &page_playback_on_roller,
-    .on_click = &page_playback_on_click,
+    .create = page_playback_create,
+    .enter = page_playback_enter,
+    .exit = page_playback_exit,
+    .on_roller = page_playback_on_roller,
+    .on_click = page_playback_on_click,
 };

--- a/src/ui/page_playback.h
+++ b/src/ui/page_playback.h
@@ -45,8 +45,6 @@ typedef struct {
 
 extern page_pack_t pp_playback;
 
-lv_obj_t *page_playback_create(lv_obj_t *parent);
-
 void pb_key(uint8_t key);
 
 int get_videofile_cnt();

--- a/src/ui/page_playback.h
+++ b/src/ui/page_playback.h
@@ -3,6 +3,8 @@
 
 #include <lvgl/lvgl.h>
 
+#include "ui/ui_main_menu.h"
+
 #define ITEMS_LAYOUT_ROWS 3
 #define ITEMS_LAYOUT_COLS 3
 #define ITEMS_LAYOUT_CNT  (ITEMS_LAYOUT_ROWS * ITEMS_LAYOUT_COLS)
@@ -41,9 +43,10 @@ typedef struct {
     uint8_t state; // 0: invisible; 1=highlighted; 2= normal
 } pb_ui_item_t;
 
+extern page_pack_t pp_playback;
+
 lv_obj_t *page_playback_create(lv_obj_t *parent);
 
-int init_pb();
 void pb_key(uint8_t key);
 
 int get_videofile_cnt();

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -17,7 +17,7 @@ static lv_coord_t col_dsc[] = {160, 200, 160, 160, 120, 160, LV_GRID_TEMPLATE_LA
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 lv_obj_t *label_s;
 
-lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -128,6 +128,7 @@ page_pack_t pp_power = {
         .max = 4,
     },
 
+    .create = &page_power_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -128,9 +128,9 @@ page_pack_t pp_power = {
         .max = 4,
     },
 
-    .create = &page_power_create,
+    .create = page_power_create,
     .enter = NULL,
     .exit = NULL,
     .on_roller = NULL,
-    .on_click = &page_power_on_click,
+    .on_click = page_power_on_click,
 };

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -5,29 +5,28 @@
 #include <log/log.h>
 #include <minIni.h>
 
+#include "../core/common.hh"
+#include "mcp3021.h"
 #include "page_common.h"
 #include "ui/ui_style.h"
-#include "mcp3021.h"
-#include "../core/common.hh"
 
 static btn_group_t btn_group1;
 static slider_group_t slider_group;
 
-static lv_coord_t col_dsc[] = {160,200,160,160,120,160, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
-lv_obj_t* label_s;
+static lv_coord_t col_dsc[] = {160, 200, 160, 160, 120, 160, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
+lv_obj_t *label_s;
 
-lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
     create_text(NULL, section, false, "Power:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
@@ -35,99 +34,90 @@ lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr)
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
+    create_select_item(arr, cont);
 
-	char str[5];
-	create_label_item(cont,  "Battery", 1, 0, 1);
-	label_s = create_label_item(cont,  "-S", 2, 0, 1);
-	sprintf(str, "%d.%d", g_setting.power.voltage/10, g_setting.power.voltage%10);
+    char str[5];
+    create_label_item(cont, "Battery", 1, 0, 1);
+    label_s = create_label_item(cont, "-S", 2, 0, 1);
+    sprintf(str, "%d.%d", g_setting.power.voltage / 10, g_setting.power.voltage % 10);
 
-	create_slider_item(&slider_group, cont, "Voltage", 42, g_setting.power.voltage , 1);
-	create_btn_group_item(&btn_group1, cont, 3, "Warning Type", "Beep", "Visual", "Both","",  2);
+    create_slider_item(&slider_group, cont, "Voltage", 42, g_setting.power.voltage, 1);
+    create_btn_group_item(&btn_group1, cont, 3, "Warning Type", "Beep", "Visual", "Both", "", 2);
     lv_slider_set_range(slider_group.slider, 28, 42);
-   	lv_label_set_text(slider_group.label, str);
-	create_label_item(cont, "< Back", 1, 3, 1);
+    lv_label_set_text(slider_group.label, str);
+    create_label_item(cont, "< Back", 1, 3, 1);
 
-	return page;
+    return page;
 }
 
-void set_battery_S()
-{
-	char str[10];
-	g_battery.type = mcp_detect_type();
-	sprintf(str, "%dS", g_battery.type);
-	lv_label_set_text(label_s,str);
+void set_battery_S() {
+    char str[10];
+    g_battery.type = mcp_detect_type();
+    sprintf(str, "%dS", g_battery.type);
+    lv_label_set_text(label_s, str);
 }
 
-void set_voltage(int val)
-{
-	lv_slider_set_value(slider_group.slider, val, LV_ANIM_OFF);
-	set_battery_S();
+void set_voltage(int val) {
+    lv_slider_set_value(slider_group.slider, val, LV_ANIM_OFF);
+    set_battery_S();
 }
 
-void set_warning_type(int type)
-{
-	btn_group_set_sel(&btn_group1, type);
-}
-void power_voltage_inc(void)
-{
-	int32_t value = 0;
-
-	value = lv_slider_get_value(slider_group.slider);
-	if(value <= 41)
-		value += 1;
-
-	lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);	
-
-	char buf[5];
-	sprintf(buf, "%d.%d", value/10, value%10);
-   	lv_label_set_text(slider_group.label, buf);
-
-	g_setting.power.voltage = value;
-	LOGI("vol:%d", g_setting.power.voltage);
-	ini_putl("power", "voltage", g_setting.power.voltage, SETTING_INI);
-}
-void power_voltage_dec(void)
-{
-	int32_t value = 0;
-
-	value = lv_slider_get_value(slider_group.slider);
-	if(value > 28)
-		value -= 1;
-
-	lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);	
-	char buf[5];
-	sprintf(buf, "%d.%d", value/10, value%10);
-   	lv_label_set_text(slider_group.label, buf);
-
-	g_setting.power.voltage = value;
-	LOGI("vol:%d", g_setting.power.voltage);
-	ini_putl("power", "voltage", g_setting.power.voltage, SETTING_INI);
+void set_warning_type(int type) {
+    btn_group_set_sel(&btn_group1, type);
 }
 
-void power_set_toggle(int sel)
-{
-	if(sel == 1)	
-	{
-		if(g_menu_op == PAGE_POWER_SLIDE)
-		{
-			g_menu_op = OPLEVEL_SUBMENU;
-			lv_obj_add_style(slider_group.slider, &style_silder_main, LV_PART_MAIN);
-		}else{
-			g_menu_op = PAGE_POWER_SLIDE;
-			lv_obj_add_style(slider_group.slider, &style_silder_select, LV_PART_MAIN);
-		}
-	}
-	else if(sel == 2)
-	{
-		btn_group_toggle_sel(&btn_group1);
-		g_setting.power.warning_type = btn_group_get_sel(&btn_group1);
-		ini_putl("power", "warning_type", g_setting.power.warning_type, SETTING_INI);
-	}
+void power_voltage_inc(void) {
+    int32_t value = 0;
+
+    value = lv_slider_get_value(slider_group.slider);
+    if (value <= 41)
+        value += 1;
+
+    lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);
+
+    char buf[5];
+    sprintf(buf, "%d.%d", value / 10, value % 10);
+    lv_label_set_text(slider_group.label, buf);
+
+    g_setting.power.voltage = value;
+    LOGI("vol:%d", g_setting.power.voltage);
+    ini_putl("power", "voltage", g_setting.power.voltage, SETTING_INI);
+}
+void power_voltage_dec(void) {
+    int32_t value = 0;
+
+    value = lv_slider_get_value(slider_group.slider);
+    if (value > 28)
+        value -= 1;
+
+    lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);
+    char buf[5];
+    sprintf(buf, "%d.%d", value / 10, value % 10);
+    lv_label_set_text(slider_group.label, buf);
+
+    g_setting.power.voltage = value;
+    LOGI("vol:%d", g_setting.power.voltage);
+    ini_putl("power", "voltage", g_setting.power.voltage, SETTING_INI);
+}
+
+void power_set_toggle(int sel) {
+    if (sel == 1) {
+        if (g_menu_op == PAGE_POWER_SLIDE) {
+            g_menu_op = OPLEVEL_SUBMENU;
+            lv_obj_add_style(slider_group.slider, &style_silder_main, LV_PART_MAIN);
+        } else {
+            g_menu_op = PAGE_POWER_SLIDE;
+            lv_obj_add_style(slider_group.slider, &style_silder_select, LV_PART_MAIN);
+        }
+    } else if (sel == 2) {
+        btn_group_toggle_sel(&btn_group1);
+        g_setting.power.warning_type = btn_group_get_sel(&btn_group1);
+        ini_putl("power", "warning_type", g_setting.power.warning_type, SETTING_INI);
+    }
 }

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -5,7 +5,7 @@
 #include <log/log.h>
 #include <minIni.h>
 
-#include "../core/common.hh"
+#include "core/common.hh"
 #include "mcp3021.h"
 #include "page_common.h"
 #include "ui/ui_style.h"
@@ -106,7 +106,7 @@ void power_voltage_dec(void) {
     ini_putl("power", "voltage", g_setting.power.voltage, SETTING_INI);
 }
 
-void power_set_toggle(int sel) {
+static void page_power_on_click(uint8_t key, int sel) {
     if (sel == 1) {
         if (g_menu_op == PAGE_POWER_SLIDE) {
             g_menu_op = OPLEVEL_SUBMENU;
@@ -121,3 +121,15 @@ void power_set_toggle(int sel) {
         ini_putl("power", "warning_type", g_setting.power.warning_type, SETTING_INI);
     }
 }
+
+page_pack_t pp_power = {
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    },
+
+    .enter = NULL,
+    .exit = NULL,
+    .on_roller = NULL,
+    .on_click = &page_power_on_click,
+};

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -17,7 +17,7 @@ static lv_coord_t col_dsc[] = {160,200,160,160,120,160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
 lv_obj_t* label_s;
 
-lv_obj_t *page_power_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_power.h
+++ b/src/ui/page_power.h
@@ -9,8 +9,6 @@
 
 extern page_pack_t pp_power;
 
-lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr);
-
 void set_voltage(int val);
 void set_warning_type(int type);
 void power_voltage_inc(void);

--- a/src/ui/page_power.h
+++ b/src/ui/page_power.h
@@ -3,9 +3,12 @@
 
 #include <stdbool.h>
 
-#include "lvgl/lvgl.h"
+#include <lvgl/lvgl.h>
+
 #include "page_common.h"
+
 lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr);
+
 void set_voltage(int val);
 void set_warning_type(int type);
 void power_set_toggle(int sel);

--- a/src/ui/page_power.h
+++ b/src/ui/page_power.h
@@ -5,14 +5,16 @@
 
 #include <lvgl/lvgl.h>
 
-#include "page_common.h"
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_power;
 
 lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr);
 
 void set_voltage(int val);
 void set_warning_type(int type);
-void power_set_toggle(int sel);
 void power_voltage_inc(void);
 void power_voltage_dec(void);
 void set_battery_S();
+
 #endif

--- a/src/ui/page_power.h
+++ b/src/ui/page_power.h
@@ -5,7 +5,7 @@
 
 #include "lvgl/lvgl.h"
 #include "page_common.h"
-lv_obj_t *page_power_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr);
 void set_voltage(int val);
 void set_warning_type(int type);
 void power_set_toggle(int sel);

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -72,7 +72,24 @@ lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     return page;
 }
 
-void record_set_toggle(int sel) {
+static void page_record_cancel() {
+    bConfirmed = false;
+    lv_label_set_text(label_formatSD, "Format SD Card");
+}
+
+static void page_record_enter() {
+    page_record_cancel();
+}
+
+static void page_record_exit() {
+    page_record_cancel();
+}
+
+static void page_record_on_roller(uint8_t key) {
+    page_record_cancel();
+}
+
+static void page_record_on_click(uint8_t key, int sel) {
     if (sel != 5)
         bConfirmed = false;
 
@@ -131,7 +148,14 @@ void record_set_toggle(int sel) {
     }
 }
 
-void formatsd_negtive() {
-    bConfirmed = false;
-    lv_label_set_text(label_formatSD, "Format SD Card");
-}
+page_pack_t pp_record = {
+    .p_arr = {
+        .cur = 0,
+        .max = 7,
+    },
+
+    .enter = &page_record_enter,
+    .exit = &page_record_exit,
+    .on_roller = &page_record_on_roller,
+    .on_click = &page_record_on_click,
+};

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -154,9 +154,9 @@ page_pack_t pp_record = {
         .max = 7,
     },
 
-    .create = &page_record_create,
-    .enter = &page_record_enter,
-    .exit = &page_record_exit,
-    .on_roller = &page_record_on_roller,
-    .on_click = &page_record_on_click,
+    .create = page_record_create,
+    .enter = page_record_enter,
+    .exit = page_record_exit,
+    .on_roller = page_record_on_roller,
+    .on_click = page_record_on_click,
 };

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -17,7 +17,7 @@ static lv_coord_t col_dsc[] = {160,200,200,160,120,120, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
 static bool bConfirmed = false;
 
-lv_obj_t *page_record_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -20,7 +20,7 @@ static lv_coord_t col_dsc[] = {160, 200, 200, 160, 120, 120, LV_GRID_TEMPLATE_LA
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 static bool bConfirmed = false;
 
-lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -154,6 +154,7 @@ page_pack_t pp_record = {
         .max = 7,
     },
 
+    .create = &page_record_create,
     .enter = &page_record_enter,
     .exit = &page_record_exit,
     .on_roller = &page_record_on_roller,

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -1,33 +1,35 @@
-#include <stdlib.h>
 #include "page_record.h"
-#include "page_common.h"
-#include "ui/ui_style.h"
-#include "minIni.h"
-#include "ui/page_playback.h"
+
+#include <stdlib.h>
+
+#include <minIni.h>
+
 #include "../core/common.hh"
+#include "page_common.h"
+#include "ui/page_playback.h"
+#include "ui/ui_style.h"
 
 static btn_group_t btn_group0;
 static btn_group_t btn_group1;
 static btn_group_t btn_group2;
 static btn_group_t btn_group3;
 static btn_group_t btn_group4;
-static lv_obj_t *  label_formatSD;
+static lv_obj_t *label_formatSD;
 
-static lv_coord_t col_dsc[] = {160,200,200,160,120,120, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {160, 200, 200, 160, 120, 120, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 static bool bConfirmed = false;
 
-lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
     create_text(NULL, section, false, "Record Options:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
@@ -35,115 +37,101 @@ lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr)
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
+    create_select_item(arr, cont);
 
-	create_btn_group_item(&btn_group0, cont, 2, "Record Mode", "Auto", "Manual", "","",  0);
-	create_btn_group_item(&btn_group1, cont, 2, "Record Format", "MP4", "TS", "","",  1);
-	create_btn_group_item(&btn_group2, cont, 2, "Record OSD", "Yes", "No", "","",  2);
-	create_btn_group_item(&btn_group3, cont, 2, "Record Audio", "Yes", "No", "","",  3);
-	create_btn_group_item(&btn_group4, cont, 3, "Audio Source", "Mic", "Line In", "A/V In", "", 4);
-	label_formatSD = create_label_item(cont, "Format SD Card", 1, 5,3);
-	create_label_item(cont, "< Back", 1, 6,1);
+    create_btn_group_item(&btn_group0, cont, 2, "Record Mode", "Auto", "Manual", "", "", 0);
+    create_btn_group_item(&btn_group1, cont, 2, "Record Format", "MP4", "TS", "", "", 1);
+    create_btn_group_item(&btn_group2, cont, 2, "Record OSD", "Yes", "No", "", "", 2);
+    create_btn_group_item(&btn_group3, cont, 2, "Record Audio", "Yes", "No", "", "", 3);
+    create_btn_group_item(&btn_group4, cont, 3, "Audio Source", "Mic", "Line In", "A/V In", "", 4);
+    label_formatSD = create_label_item(cont, "Format SD Card", 1, 5, 3);
+    create_label_item(cont, "< Back", 1, 6, 1);
 
-	btn_group_set_sel(&btn_group0, g_setting.record.mode_manual ? 1 : 0);
-	btn_group_set_sel(&btn_group1, g_setting.record.format_ts ? 1 : 0);
-	btn_group_set_sel(&btn_group2, g_setting.record.osd ? 0 : 1);
-	btn_group_set_sel(&btn_group3, g_setting.record.audio ? 0 : 1);
-	btn_group_set_sel(&btn_group4, g_setting.record.audio_source );
+    btn_group_set_sel(&btn_group0, g_setting.record.mode_manual ? 1 : 0);
+    btn_group_set_sel(&btn_group1, g_setting.record.format_ts ? 1 : 0);
+    btn_group_set_sel(&btn_group2, g_setting.record.osd ? 0 : 1);
+    btn_group_set_sel(&btn_group3, g_setting.record.audio ? 0 : 1);
+    btn_group_set_sel(&btn_group4, g_setting.record.audio_source);
 
-	lv_obj_t *label2 = lv_label_create(cont);
-   	lv_label_set_text(label2, "MP4 format requires properly closing files or the files will be corrupt. \nTS format is highly recommended.");
-	lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
-	lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_color(label2, lv_color_make(255,255,255), 0);
-	lv_obj_set_style_pad_top(label2, 12, 0);
-	lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
-	lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
-						 LV_GRID_ALIGN_START, 7, 3);
+    lv_obj_t *label2 = lv_label_create(cont);
+    lv_label_set_text(label2, "MP4 format requires properly closing files or the files will be corrupt. \nTS format is highly recommended.");
+    lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_color(label2, lv_color_make(255, 255, 255), 0);
+    lv_obj_set_style_pad_top(label2, 12, 0);
+    lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
+    lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
+                         LV_GRID_ALIGN_START, 7, 3);
 
-
-	return page;
+    return page;
 }
 
+void record_set_toggle(int sel) {
+    if (sel != 5)
+        bConfirmed = false;
 
-void record_set_toggle(int sel)
-{
-	if(sel != 5) bConfirmed = false;
-
-	if(sel == 0)
-	{
-		btn_group_toggle_sel(&btn_group0);
-		g_setting.record.mode_manual = btn_group_get_sel(&btn_group0);
-		if(g_setting.record.mode_manual){
-			ini_puts("record", "mode_manual", "enable", SETTING_INI);
-		}else{
-			ini_puts("record", "mode_manual", "disable", SETTING_INI);
-		}
-	}
-	else if(sel == 1)
-	{
-		btn_group_toggle_sel(&btn_group1);
-		g_setting.record.format_ts = btn_group_get_sel(&btn_group1);
-		if(g_setting.record.format_ts){
-			ini_puts("record", "format_ts", "enable", SETTING_INI);
-			ini_puts("record", "type", "ts", REC_CONF);
-		}else{
-			ini_puts("record", "format_ts", "disable", SETTING_INI);
-			ini_puts("record", "type", "mp4", REC_CONF);
-		}
-	}
-	else if(sel == 2)
-	{
-		btn_group_toggle_sel(&btn_group2);
-		g_setting.record.osd = !btn_group_get_sel(&btn_group2);
-		if(g_setting.record.osd){
-			ini_puts("record", "osd", "enable", SETTING_INI);
-		}else{
-			ini_puts("record", "osd", "disable", SETTING_INI);
-		}
-	}
-	else if(sel == 3)
-	{
-		btn_group_toggle_sel(&btn_group3);
-		g_setting.record.audio = !btn_group_get_sel(&btn_group3);
-		if(g_setting.record.audio){
-			ini_puts("record", "audio", "enable", SETTING_INI);
-		}else{
-			ini_puts("record", "audio", "disable", SETTING_INI);
-		}
-	}
-	else if(sel == 4)
-	{
-		btn_group_toggle_sel(&btn_group4);
-		g_setting.record.audio_source = btn_group_get_sel(&btn_group4);
-		ini_putl("record", "audio_source", g_setting.record.audio_source, SETTING_INI);
-	}
-	else if(sel == 5) { //format sd card
-		if(bConfirmed) {
-			lv_label_set_text(label_formatSD, "Formatting...");
-			lv_timer_handler();
-			system("/mnt/app/script/formatsd.sh");
-			clear_videofile_cnt();
-			lv_label_set_text(label_formatSD, "Format SD Card");
-			lv_timer_handler();
-			bConfirmed = false;
-		}
-		else {
-			lv_label_set_text(label_formatSD, "#FFFF00 Formatting will delete all data on the SD Card. Press Enter to confirm...#");
-			lv_timer_handler();
-			bConfirmed = true;
-		}
-	}
+    if (sel == 0) {
+        btn_group_toggle_sel(&btn_group0);
+        g_setting.record.mode_manual = btn_group_get_sel(&btn_group0);
+        if (g_setting.record.mode_manual) {
+            ini_puts("record", "mode_manual", "enable", SETTING_INI);
+        } else {
+            ini_puts("record", "mode_manual", "disable", SETTING_INI);
+        }
+    } else if (sel == 1) {
+        btn_group_toggle_sel(&btn_group1);
+        g_setting.record.format_ts = btn_group_get_sel(&btn_group1);
+        if (g_setting.record.format_ts) {
+            ini_puts("record", "format_ts", "enable", SETTING_INI);
+            ini_puts("record", "type", "ts", REC_CONF);
+        } else {
+            ini_puts("record", "format_ts", "disable", SETTING_INI);
+            ini_puts("record", "type", "mp4", REC_CONF);
+        }
+    } else if (sel == 2) {
+        btn_group_toggle_sel(&btn_group2);
+        g_setting.record.osd = !btn_group_get_sel(&btn_group2);
+        if (g_setting.record.osd) {
+            ini_puts("record", "osd", "enable", SETTING_INI);
+        } else {
+            ini_puts("record", "osd", "disable", SETTING_INI);
+        }
+    } else if (sel == 3) {
+        btn_group_toggle_sel(&btn_group3);
+        g_setting.record.audio = !btn_group_get_sel(&btn_group3);
+        if (g_setting.record.audio) {
+            ini_puts("record", "audio", "enable", SETTING_INI);
+        } else {
+            ini_puts("record", "audio", "disable", SETTING_INI);
+        }
+    } else if (sel == 4) {
+        btn_group_toggle_sel(&btn_group4);
+        g_setting.record.audio_source = btn_group_get_sel(&btn_group4);
+        ini_putl("record", "audio_source", g_setting.record.audio_source, SETTING_INI);
+    } else if (sel == 5) { // format sd card
+        if (bConfirmed) {
+            lv_label_set_text(label_formatSD, "Formatting...");
+            lv_timer_handler();
+            system("/mnt/app/script/formatsd.sh");
+            clear_videofile_cnt();
+            lv_label_set_text(label_formatSD, "Format SD Card");
+            lv_timer_handler();
+            bConfirmed = false;
+        } else {
+            lv_label_set_text(label_formatSD, "#FFFF00 Formatting will delete all data on the SD Card. Press Enter to confirm...#");
+            lv_timer_handler();
+            bConfirmed = true;
+        }
+    }
 }
 
-void formatsd_negtive()
-{
-	bConfirmed = false;
-	lv_label_set_text(label_formatSD, "Format SD Card");
+void formatsd_negtive() {
+    bConfirmed = false;
+    lv_label_set_text(label_formatSD, "Format SD Card");
 }

--- a/src/ui/page_record.h
+++ b/src/ui/page_record.h
@@ -1,10 +1,13 @@
 #ifndef _PAGE_RECORD_H
 #define _PAGE_RECORD_H
 
+#include <lvgl/lvgl.h>
 
-#include "lvgl/lvgl.h"
 #include "page_common.h"
+
 lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr);
+
 void record_set_toggle(int sel);
 void formatsd_negtive();
+
 #endif

--- a/src/ui/page_record.h
+++ b/src/ui/page_record.h
@@ -3,11 +3,10 @@
 
 #include <lvgl/lvgl.h>
 
-#include "page_common.h"
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_record;
 
 lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr);
-
-void record_set_toggle(int sel);
-void formatsd_negtive();
 
 #endif

--- a/src/ui/page_record.h
+++ b/src/ui/page_record.h
@@ -4,7 +4,7 @@
 
 #include "lvgl/lvgl.h"
 #include "page_common.h"
-lv_obj_t *page_record_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr);
 void record_set_toggle(int sel);
 void formatsd_negtive();
 #endif

--- a/src/ui/page_record.h
+++ b/src/ui/page_record.h
@@ -7,6 +7,4 @@
 
 extern page_pack_t pp_record;
 
-lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr);
-
 #endif

--- a/src/ui/page_scannow.c
+++ b/src/ui/page_scannow.c
@@ -1,40 +1,39 @@
 #include "page_scannow.h"
 
-#include <stdio.h>
-#include <stdint.h>
-#include <unistd.h>
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
-#include <minIni.h>
 #include <log/log.h>
+#include <minIni.h>
 
-#include "fbtools.h"
-#include "msp_displayport.h"
-#include "page_common.h"
-#include "ui/ui_style.h"
 #include "../core/common.hh"
 #include "../core/defines.h"
-#include "ui/ui_main_menu.h"
 #include "../core/osd.h"
 #include "../driver/dm5680.h"
 #include "../driver/dm6302.h"
 #include "../driver/hardware.h"
 #include "../driver/i2c.h"
 #include "../driver/oled.h"
-#include "ui/ui_porting.h"
 #include "../driver/uart.h"
+#include "fbtools.h"
+#include "msp_displayport.h"
+#include "page_common.h"
+#include "ui/ui_main_menu.h"
+#include "ui/ui_porting.h"
+#include "ui/ui_style.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-//local
-static lv_obj_t * progressbar;
+// local
+static lv_obj_t *progressbar;
 static lv_obj_t *label;
-static lv_coord_t col_dsc[] = {500,20,1164-520, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,80, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {500, 20, 1164 - 520, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 80, LV_GRID_TEMPLATE_LAST};
 
-static lv_coord_t col_dsc2[] = {120, 80,80,180,100,80,80,180, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc2[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc2[] = {120, 80, 80, 180, 100, 80, 80, 180, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc2[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 LV_IMG_DECLARE(img_signal_status);
 LV_IMG_DECLARE(img_signal_status2);
@@ -56,140 +55,118 @@ LV_IMG_DECLARE(img_ant13);
 LV_IMG_DECLARE(img_ant14);
 
 typedef struct {
-	bool is_valid;
-	int gain;
-}channel_status_t;
+    bool is_valid;
+    int gain;
+} channel_status_t;
 
 typedef struct {
-	lv_obj_t *img0;	
-	lv_obj_t *label;	
-	lv_obj_t *img1;	
-}channel_t;
+    lv_obj_t *img0;
+    lv_obj_t *label;
+    lv_obj_t *img1;
+} channel_t;
 
 channel_t channel_tb[10];
 channel_status_t channel_status_tb[10];
 
-static void select_signal(channel_t *channel)
-{
-	for(int i=0; i<10; i++)
-	{
-		if(channel_status_tb[i].is_valid)
-		{
-			lv_img_set_src(channel_tb[i].img0, &img_signal_status2);
-		}else{
-			lv_img_set_src(channel_tb[i].img0, &img_signal_status);
-		}
-	}
-	lv_img_set_src(channel->img0, &img_signal_status3);
+static void select_signal(channel_t *channel) {
+    for (int i = 0; i < 10; i++) {
+        if (channel_status_tb[i].is_valid) {
+            lv_img_set_src(channel_tb[i].img0, &img_signal_status2);
+        } else {
+            lv_img_set_src(channel_tb[i].img0, &img_signal_status);
+        }
+    }
+    lv_img_set_src(channel->img0, &img_signal_status3);
 }
 
-static void set_signal(channel_t *channel, bool is_valid, int gain)
-{
-	if(!is_valid)
-	{
-		lv_img_set_src(channel->img0, &img_signal_status);
+static void set_signal(channel_t *channel, bool is_valid, int gain) {
+    if (!is_valid) {
+        lv_img_set_src(channel->img0, &img_signal_status);
 
-		if(gain < 5){
-    		lv_img_set_src(channel->img1, &img_ant1);
-		}
-		else if(gain < 10){
-    		lv_img_set_src(channel->img1, &img_ant3);
-		}
-		else if(gain < 15){
-    		lv_img_set_src(channel->img1, &img_ant4);
-		}
-		else if(gain < 16){
-    		lv_img_set_src(channel->img1, &img_ant5);
-		}
-		else if(gain < 20){
-    		lv_img_set_src(channel->img1, &img_ant6);
-		}
-		else if(gain < 30){
-    		lv_img_set_src(channel->img1, &img_ant7);
-		}
-		else if(gain <= 77){
-    		lv_img_set_src(channel->img1, &img_ant7);
-		}
-		else {
-    		lv_img_set_src(channel->img1, &img_ant1);
-		}
+        if (gain < 5) {
+            lv_img_set_src(channel->img1, &img_ant1);
+        } else if (gain < 10) {
+            lv_img_set_src(channel->img1, &img_ant3);
+        } else if (gain < 15) {
+            lv_img_set_src(channel->img1, &img_ant4);
+        } else if (gain < 16) {
+            lv_img_set_src(channel->img1, &img_ant5);
+        } else if (gain < 20) {
+            lv_img_set_src(channel->img1, &img_ant6);
+        } else if (gain < 30) {
+            lv_img_set_src(channel->img1, &img_ant7);
+        } else if (gain <= 77) {
+            lv_img_set_src(channel->img1, &img_ant7);
+        } else {
+            lv_img_set_src(channel->img1, &img_ant1);
+        }
 
-	}else{
-		lv_img_set_src(channel->img0, &img_signal_status2);
-		if(gain < 5){
-    		lv_img_set_src(channel->img1, &img_ant8);
-		}
-		else if(gain < 10){
-    		lv_img_set_src(channel->img1, &img_ant10);
-		}
-		else if(gain < 15){
-    		lv_img_set_src(channel->img1, &img_ant11);
-		}
-		else if(gain < 16){
-    		lv_img_set_src(channel->img1, &img_ant12);
-		}
-		else if(gain < 20){
-    		lv_img_set_src(channel->img1, &img_ant13);
-		}
-		else if(gain < 30){
-    		lv_img_set_src(channel->img1, &img_ant14);
-		}
-		else if(gain <= 77){
-    		lv_img_set_src(channel->img1, &img_ant14);
-		}
-		else {
-    		lv_img_set_src(channel->img1, &img_ant8);
-		}
-	}
-
+    } else {
+        lv_img_set_src(channel->img0, &img_signal_status2);
+        if (gain < 5) {
+            lv_img_set_src(channel->img1, &img_ant8);
+        } else if (gain < 10) {
+            lv_img_set_src(channel->img1, &img_ant10);
+        } else if (gain < 15) {
+            lv_img_set_src(channel->img1, &img_ant11);
+        } else if (gain < 16) {
+            lv_img_set_src(channel->img1, &img_ant12);
+        } else if (gain < 20) {
+            lv_img_set_src(channel->img1, &img_ant13);
+        } else if (gain < 30) {
+            lv_img_set_src(channel->img1, &img_ant14);
+        } else if (gain <= 77) {
+            lv_img_set_src(channel->img1, &img_ant14);
+        } else {
+            lv_img_set_src(channel->img1, &img_ant8);
+        }
+    }
 }
-//gain, 0-60
-static void draw_signal(lv_obj_t *parent, const char *name, int col, int row, channel_t *channel) 
-{
+// gain, 0-60
+static void draw_signal(lv_obj_t *parent, const char *name, int col, int row, channel_t *channel) {
 
     channel->img0 = lv_img_create(parent);
     lv_img_set_src(channel->img0, &img_signal_status);
     lv_obj_set_size(channel->img0, 77, 77);
-	lv_obj_set_grid_cell(channel->img0, LV_GRID_ALIGN_START, col, 1,
-						 LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_grid_cell(channel->img0, LV_GRID_ALIGN_START, col, 1,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 
-	channel->label = lv_label_create(parent);
-   	lv_label_set_text(channel->label, name);
-	lv_obj_set_style_text_font(channel->label, &lv_font_montserrat_40, 0);
-	lv_obj_set_style_text_align(channel->label, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_color(channel->label, lv_color_make(255,255,255), 0);
-	lv_obj_set_style_pad_top(channel->label, 12, 0);
-	lv_label_set_long_mode(channel->label, LV_LABEL_LONG_SCROLL_CIRCULAR);
-	lv_obj_set_grid_cell(channel->label, LV_GRID_ALIGN_START, col+1, 1,
-						 LV_GRID_ALIGN_CENTER, row, 1);
+    channel->label = lv_label_create(parent);
+    lv_label_set_text(channel->label, name);
+    lv_obj_set_style_text_font(channel->label, &lv_font_montserrat_40, 0);
+    lv_obj_set_style_text_align(channel->label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_color(channel->label, lv_color_make(255, 255, 255), 0);
+    lv_obj_set_style_pad_top(channel->label, 12, 0);
+    lv_label_set_long_mode(channel->label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_set_grid_cell(channel->label, LV_GRID_ALIGN_START, col + 1, 1,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 
     channel->img1 = lv_img_create(parent);
     lv_img_set_src(channel->img1, &img_ant1);
     lv_obj_set_size(channel->img1, 164, 78);
-	lv_obj_set_grid_cell(channel->img1, LV_GRID_ALIGN_START, col+2, 1,
-						 LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_grid_cell(channel->img1, LV_GRID_ALIGN_START, col + 2, 1,
+                         LV_GRID_ALIGN_CENTER, row, 1);
 }
 
-//1920-500
-//1420
-//1420*0.18
-//255.6
-//1420-256
-//1164
-lv_obj_t *page_scannow_create(lv_obj_t *parent)
-{
+// 1920-500
+// 1420
+// 1420*0.18
+// 255.6
+// 1420-256
+// 1164
+lv_obj_t *page_scannow_create(lv_obj_t *parent) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1158, 900);
-	lv_obj_add_style(page, &style_scan, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 60, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1158, 900);
+    lv_obj_add_style(page, &style_scan, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 60, 0);
 
     lv_obj_t *cont = lv_obj_create(page);
     lv_obj_set_size(cont, 1158, 250);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_scan, LV_PART_MAIN);
-	lv_obj_set_style_bg_opa(cont, 0, 0);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_scan, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(cont, 0, 0);
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
@@ -197,171 +174,160 @@ lv_obj_t *page_scannow_create(lv_obj_t *parent)
     lv_obj_set_size(progressbar, 500, 50);
     lv_obj_center(progressbar);
     lv_bar_set_value(progressbar, 0, LV_ANIM_OFF);
-	lv_obj_set_style_bg_color(progressbar, lv_color_make(0xff, 0xff, 0xff), LV_PART_MAIN);
-	lv_obj_set_style_radius(progressbar, 0, LV_PART_MAIN);
-	lv_obj_set_style_bg_color(progressbar, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
-	lv_obj_set_style_radius(progressbar, 0, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_color(progressbar, lv_color_make(0xff, 0xff, 0xff), LV_PART_MAIN);
+    lv_obj_set_style_radius(progressbar, 0, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(progressbar, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
+    lv_obj_set_style_radius(progressbar, 0, LV_PART_INDICATOR);
 
-	lv_obj_set_grid_cell(progressbar, LV_GRID_ALIGN_START, 0, 1,
-						 LV_GRID_ALIGN_CENTER, 1, 1);
+    lv_obj_set_grid_cell(progressbar, LV_GRID_ALIGN_START, 0, 1,
+                         LV_GRID_ALIGN_CENTER, 1, 1);
 
-	label = lv_label_create(cont);
-   	lv_label_set_text(label, "Scan Ready");
-	lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_color(label, lv_color_make(255,255,255), 0);
-	lv_obj_set_style_pad_top(label, 12, 0);
-	lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
-	lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 0, 1,
-						 LV_GRID_ALIGN_CENTER, 0, 1);
+    label = lv_label_create(cont);
+    lv_label_set_text(label, "Scan Ready");
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_color(label, lv_color_make(255, 255, 255), 0);
+    lv_obj_set_style_pad_top(label, 12, 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 0, 1,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
 
-	lv_obj_t *label2 = lv_label_create(cont);
-   	lv_label_set_text(label2, "When scanning is complete,use the\n dial to select a channel and press\n the Enter button to choose");
-	lv_obj_set_style_text_font(label2, &lv_font_montserrat_26, 0);
-	lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
-	lv_obj_set_style_text_color(label2, lv_color_make(255,255,255), 0);
-	lv_obj_set_style_pad_top(label2, 12, 0);
-	lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
-	lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 2, 1,
-						 LV_GRID_ALIGN_START, 0, 3);
+    lv_obj_t *label2 = lv_label_create(cont);
+    lv_label_set_text(label2, "When scanning is complete,use the\n dial to select a channel and press\n the Enter button to choose");
+    lv_obj_set_style_text_font(label2, &lv_font_montserrat_26, 0);
+    lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_text_color(label2, lv_color_make(255, 255, 255), 0);
+    lv_obj_set_style_pad_top(label2, 12, 0);
+    lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
+    lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 2, 1,
+                         LV_GRID_ALIGN_START, 0, 3);
 
     lv_obj_t *cont2 = lv_obj_create(page);
     lv_obj_set_size(cont2, 1164, 500);
     lv_obj_set_layout(cont2, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont2, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont2, &style_scan, LV_PART_MAIN);
-	lv_obj_set_style_bg_opa(cont2, 0, 0);
+    lv_obj_clear_flag(cont2, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont2, &style_scan, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(cont2, 0, 0);
     lv_obj_set_style_grid_column_dsc_array(cont2, col_dsc2, 0);
     lv_obj_set_style_grid_row_dsc_array(cont2, row_dsc2, 0);
 
-
-	draw_signal(cont2, "R1", 1, 0, &channel_tb[0]);
-	draw_signal(cont2, "R2", 1, 1, &channel_tb[1]);
-	draw_signal(cont2, "R3", 1, 2, &channel_tb[2]);
-	draw_signal(cont2, "R4", 1, 3, &channel_tb[3]);
-	draw_signal(cont2, "R5", 1, 4, &channel_tb[4]);
-	draw_signal(cont2, "R6", 5, 0, &channel_tb[5]);
-	draw_signal(cont2, "R7", 5, 1, &channel_tb[6]);
-	draw_signal(cont2, "R8", 5, 2, &channel_tb[7]);
-	draw_signal(cont2, "F2", 5, 3, &channel_tb[8]);
-	draw_signal(cont2, "F4", 5, 4, &channel_tb[9]);
-	return page;
+    draw_signal(cont2, "R1", 1, 0, &channel_tb[0]);
+    draw_signal(cont2, "R2", 1, 1, &channel_tb[1]);
+    draw_signal(cont2, "R3", 1, 2, &channel_tb[2]);
+    draw_signal(cont2, "R4", 1, 3, &channel_tb[3]);
+    draw_signal(cont2, "R5", 1, 4, &channel_tb[4]);
+    draw_signal(cont2, "R6", 5, 0, &channel_tb[5]);
+    draw_signal(cont2, "R7", 5, 1, &channel_tb[6]);
+    draw_signal(cont2, "R8", 5, 2, &channel_tb[7]);
+    draw_signal(cont2, "F2", 5, 3, &channel_tb[8]);
+    draw_signal(cont2, "F4", 5, 4, &channel_tb[9]);
+    return page;
 }
 
 static int valid_channel_tb[11];
 static int user_select_index = 0;
-void user_select(uint8_t key)
-{
-	if(valid_channel_tb[0] == -1) return;
+void user_select(uint8_t key) {
+    if (valid_channel_tb[0] == -1)
+        return;
 
-	if(key == DIAL_KEY_UP) {
-		if(valid_channel_tb[user_select_index+1] != -1)
-			user_select_index++;
-	}
-	else if(key == DIAL_KEY_DOWN) {
-		if(user_select_index > 0)
-			user_select_index--;
-	}
-	select_signal(&channel_tb[valid_channel_tb[user_select_index]]);
+    if (key == DIAL_KEY_UP) {
+        if (valid_channel_tb[user_select_index + 1] != -1)
+            user_select_index++;
+    } else if (key == DIAL_KEY_DOWN) {
+        if (user_select_index > 0)
+            user_select_index--;
+    }
+    select_signal(&channel_tb[valid_channel_tb[user_select_index]]);
 }
 
-static void user_select_signal(void)
-{
-	if(valid_channel_tb[0] == -1)
-		return;
+static void user_select_signal(void) {
+    if (valid_channel_tb[0] == -1)
+        return;
 
-	user_select_index = 0;
-	select_signal(&channel_tb[valid_channel_tb[0]]);
+    user_select_index = 0;
+    select_signal(&channel_tb[valid_channel_tb[0]]);
 }
 
-static void user_clear_signal(void)
-{
-	user_select_index = 0;
+static void user_clear_signal(void) {
+    user_select_index = 0;
 
-	for(int i=0; i<10; i++)
-	{
-		lv_img_set_src(channel_tb[i].img0, &img_signal_status);
-		lv_img_set_src(channel_tb[i].img1, &img_ant1);
-	}
-
+    for (int i = 0; i < 10; i++) {
+        lv_img_set_src(channel_tb[i].img0, &img_signal_status);
+        lv_img_set_src(channel_tb[i].img1, &img_ant1);
+    }
 }
 
-uint8_t max4(uint8_t a1,uint8_t a2,uint8_t a3,uint8_t a4)
-{
-	uint8_t b1 = (a1 > a2)? a1 : a2;
-	uint8_t b2 = (a3 > a4)? a3 : a4;
-	return       (b1 > b2)? b1 : b2;
+uint8_t max4(uint8_t a1, uint8_t a2, uint8_t a3, uint8_t a4) {
+    uint8_t b1 = (a1 > a2) ? a1 : a2;
+    uint8_t b2 = (a3 > a4) ? a3 : a4;
+    return (b1 > b2) ? b1 : b2;
 }
 
-void scan_channel(uint8_t channel, uint8_t *gain_ret, bool *valid)
-{
-	uint8_t vld0,vld1;
+void scan_channel(uint8_t channel, uint8_t *gain_ret, bool *valid) {
+    uint8_t vld0, vld1;
     uint8_t gain[4];
 
-	DM6302_SetChannel(channel);
+    DM6302_SetChannel(channel);
 
-	usleep(100000);
-    DM5680_clear_vldflg(); 
-    DM5680_req_vldflg(); 
+    usleep(100000);
+    DM5680_clear_vldflg();
+    DM5680_req_vldflg();
 
-	DM6302_get_gain(gain);
-	*gain_ret = max4(gain[0],gain[1],gain[2],gain[3]);
-	
-   	vld0 = rx_status[0].rx_valid;
-	vld1 = rx_status[1].rx_valid;
-	*valid = vld0 | vld1;
-  
+    DM6302_get_gain(gain);
+    *gain_ret = max4(gain[0], gain[1], gain[2], gain[3]);
+
+    vld0 = rx_status[0].rx_valid;
+    vld1 = rx_status[1].rx_valid;
+    *valid = vld0 | vld1;
+
     LOGI("Scan channel%d: valid:%d, gain:%d", channel, *valid, *gain_ret);
 }
 
-int8_t scan_now(void)
-{
-	uint8_t ch,gain;
-	bool 	valid;
-	uint8_t valid_index = 0;
+int8_t scan_now(void) {
+    uint8_t ch, gain;
+    bool valid;
+    uint8_t valid_index = 0;
 
-   	lv_label_set_text(label, "Scanning...");
+    lv_label_set_text(label, "Scanning...");
     lv_bar_set_value(progressbar, 0, LV_ANIM_OFF);
-	lv_timer_handler();
-	//dm5680_init();
+    lv_timer_handler();
+    // dm5680_init();
 
     lv_bar_set_value(progressbar, 5, LV_ANIM_OFF);
-	lv_timer_handler();
-	//DM6302_init(0);
+    lv_timer_handler();
+    // DM6302_init(0);
     lv_bar_set_value(progressbar, 10, LV_ANIM_OFF);
-		lv_timer_handler();
-	
-	HDZero_open();
+    lv_timer_handler();
 
-	//clear
-	for(int i=0; i<10; i++)
-	{
-		valid_channel_tb[i] = -1;
-	}
-	
-    for(ch=0; ch<FREQ_NUM; ch++)
-	{
-		scan_channel(ch, &gain, &valid);
+    HDZero_open();
 
-		if(valid){
-			valid_channel_tb[valid_index++] = ch;
-		}
+    // clear
+    for (int i = 0; i < 10; i++) {
+        valid_channel_tb[i] = -1;
+    }
 
-		channel_status_tb[ch].is_valid = valid;
-		channel_status_tb[ch].gain = gain;
+    for (ch = 0; ch < FREQ_NUM; ch++) {
+        scan_channel(ch, &gain, &valid);
 
-    	lv_bar_set_value(progressbar, 10 + ch*10, LV_ANIM_OFF);
-		lv_timer_handler();
-		set_signal(&channel_tb[ch], valid, gain);
-	}
+        if (valid) {
+            valid_channel_tb[valid_index++] = ch;
+        }
 
-	user_select_signal();
+        channel_status_tb[ch].is_valid = valid;
+        channel_status_tb[ch].gain = gain;
 
-   	lv_label_set_text(label, "Scanning done");
-	if(valid_channel_tb[0] == -1)
-		return -1;
+        lv_bar_set_value(progressbar, 10 + ch * 10, LV_ANIM_OFF);
+        lv_timer_handler();
+        set_signal(&channel_tb[ch], valid, gain);
+    }
 
-	return valid_index;
+    user_select_signal();
+
+    lv_label_set_text(label, "Scanning done");
+    if (valid_channel_tb[0] == -1)
+        return -1;
+
+    return valid_index;
 }
 
 static bool is_720p60 = false;
@@ -370,71 +336,65 @@ static bool is_720p60 = false;
 // is_default:
 //    true = load from g_settings
 //    false = user selected from auto scan page
-void switch_to_video(bool is_default)
-{
-	int ch  = valid_channel_tb[user_select_index];
+void switch_to_video(bool is_default) {
+    int ch = valid_channel_tb[user_select_index];
 
-	if(is_default)
-	{
-		ch = g_setting.scan.channel - 1;
-	}
-	else{
-		g_setting.scan.channel = ch + 1;
-		ini_putl("scan", "channel", g_setting.scan.channel, SETTING_INI);
-	}
-	
-	LOGI("switch to ch:%d, CAM_MODE=%d 4:3=%d", g_setting.scan.channel, CAM_MODE,cam_4_3);
+    if (is_default) {
+        ch = g_setting.scan.channel - 1;
+    } else {
+        g_setting.scan.channel = ch + 1;
+        ini_putl("scan", "channel", g_setting.scan.channel, SETTING_INI);
+    }
+
+    LOGI("switch to ch:%d, CAM_MODE=%d 4:3=%d", g_setting.scan.channel, CAM_MODE, cam_4_3);
     DM6302_SetChannel(ch);
-    DM5680_clear_vldflg(); 
-    DM5680_req_vldflg(); 
-	progress_bar.start  = 0;
+    DM5680_clear_vldflg();
+    DM5680_req_vldflg();
+    progress_bar.start = 0;
 
-	is_720p60 = true;
-	switch(CAM_MODE){
-		case VR_720P50:
-		case VR_720P60:
-		case VR_960x720P60:
-			is_720p60 = true;
-			Display_720P60_50(CAM_MODE,cam_4_3);
-			break;
+    is_720p60 = true;
+    switch (CAM_MODE) {
+    case VR_720P50:
+    case VR_720P60:
+    case VR_960x720P60:
+        is_720p60 = true;
+        Display_720P60_50(CAM_MODE, cam_4_3);
+        break;
 
-		case VR_540P90:	
-		case VR_540P90_CROP:	
-			is_720p60 = false;
-			Display_720P90(CAM_MODE);
-			break;
+    case VR_540P90:
+    case VR_540P90_CROP:
+        is_720p60 = false;
+        Display_720P90(CAM_MODE);
+        break;
 
-		default:
-			perror("switch_to_video CaM_MODE error");
-	}
-	
-	channel_osd_mode = CHANNEL_SHOWTIME;
-	osd_show(true);
-	
-	lvgl_switch_to_720p();
-	draw_osd_clear();
-	lv_timer_handler();
+    default:
+        perror("switch_to_video CaM_MODE error");
+    }
 
-	Display_Osd(g_setting.record.osd); 
-	g_setting.autoscan.last_source = SETTING_SOURCE_HDZERO;
-	ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
+    channel_osd_mode = CHANNEL_SHOWTIME;
+    osd_show(true);
+
+    lvgl_switch_to_720p();
+    draw_osd_clear();
+    lv_timer_handler();
+
+    Display_Osd(g_setting.record.osd);
+    g_setting.autoscan.last_source = SETTING_SOURCE_HDZERO;
+    ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
 }
 
-int scan_reinit(void)
-{
-   	lv_label_set_text(label, "Scanning ready");
-	lv_bar_set_value(progressbar, 0, LV_ANIM_OFF);
-	user_clear_signal();
-	lv_timer_handler();
-	return 0;
+int scan_reinit(void) {
+    lv_label_set_text(label, "Scanning ready");
+    lv_bar_set_value(progressbar, 0, LV_ANIM_OFF);
+    user_clear_signal();
+    lv_timer_handler();
+    return 0;
 }
 
-
-int scan(void)
-{
-	g_scanning = true;
-	g_source_info.source = SOURCE_HDZERO;
-	int8_t ret = scan_now();
-	g_scanning = false;
-	return ret;
+int scan(void) {
+    g_scanning = true;
+    g_source_info.source = SOURCE_HDZERO;
+    int8_t ret = scan_now();
+    g_scanning = false;
+    return ret;
 }

--- a/src/ui/page_scannow.c
+++ b/src/ui/page_scannow.c
@@ -158,7 +158,7 @@ static void draw_signal(lv_obj_t *parent, const char *name, int col, int row, ch
 // 255.6
 // 1420-256
 // 1164
-lv_obj_t *page_scannow_create(lv_obj_t *parent) {
+static lv_obj_t *page_scannow_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1158, 900);
@@ -438,6 +438,7 @@ static void page_scannow_on_click(uint8_t key, int sel) {
 }
 
 page_pack_t pp_scannow = {
+    .create = &page_scannow_create,
     .enter = &page_scannow_enter,
     .exit = &page_scannow_exit,
     .on_roller = &page_scannow_on_roller,

--- a/src/ui/page_scannow.c
+++ b/src/ui/page_scannow.c
@@ -438,9 +438,9 @@ static void page_scannow_on_click(uint8_t key, int sel) {
 }
 
 page_pack_t pp_scannow = {
-    .create = &page_scannow_create,
-    .enter = &page_scannow_enter,
-    .exit = &page_scannow_exit,
-    .on_roller = &page_scannow_on_roller,
-    .on_click = &page_scannow_on_click,
+    .create = page_scannow_create,
+    .enter = page_scannow_enter,
+    .exit = page_scannow_exit,
+    .on_roller = page_scannow_on_roller,
+    .on_click = page_scannow_on_click,
 };

--- a/src/ui/page_scannow.h
+++ b/src/ui/page_scannow.h
@@ -3,13 +3,16 @@
 
 #include <lvgl/lvgl.h>
 
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_scannow;
+
 lv_obj_t *page_scannow_create(lv_obj_t *parent);
 
 int scan(void);
 int scan_reinit(void);
 
-void user_select(uint8_t key);
-
 void switch_to_video(bool is_default);
+void autoscan_exit(void);
 
 #endif

--- a/src/ui/page_scannow.h
+++ b/src/ui/page_scannow.h
@@ -1,8 +1,8 @@
 #ifndef _PAGE_SCANNOW_H
 #define _PAGE_SCANNOW_H
 
+#include <lvgl/lvgl.h>
 
-#include "lvgl/lvgl.h"
 lv_obj_t *page_scannow_create(lv_obj_t *parent);
 
 int scan(void);
@@ -11,4 +11,5 @@ int scan_reinit(void);
 void user_select(uint8_t key);
 
 void switch_to_video(bool is_default);
+
 #endif

--- a/src/ui/page_scannow.h
+++ b/src/ui/page_scannow.h
@@ -7,8 +7,6 @@
 
 extern page_pack_t pp_scannow;
 
-lv_obj_t *page_scannow_create(lv_obj_t *parent);
-
 int scan(void);
 int scan_reinit(void);
 

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -1,40 +1,42 @@
-#include <unistd.h>
 #include "page_source.h"
-#include "../driver/hardware.h"
-#include "../core/osd.h"
+
 #include <stdio.h>
-#include "page_common.h"
-#include "ui/ui_style.h"
-#include "ui/ui_porting.h"
-#include "../driver/oled.h"
-#include "../driver/it66121.h"
+#include <unistd.h>
+
+#include <minIni.h>
+
 #include "../core/common.hh"
-#include "ui/ui_main_menu.h"
+#include "../core/osd.h"
+#include "../driver/hardware.h"
+#include "../driver/it66121.h"
+#include "../driver/oled.h"
+#include "page_common.h"
 #include "page_scannow.h"
-#include "minIni.h"
+#include "ui/ui_main_menu.h"
+#include "ui/ui_porting.h"
+#include "ui/ui_style.h"
 
 /////////////////////////////////////////////////////////////////////////
 // global
-bool in_sourcepage = false; 
+bool in_sourcepage = false;
 
-//local
-static lv_coord_t col_dsc[] = {160,160,160,160,160,160, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
+// local
+static lv_coord_t col_dsc[] = {160, 160, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
-static lv_obj_t* label[5];
-static uint8_t oled_tst_mode = 0; //0=Normal,1=CB; 2-Grid; 3=All Black; 4=All White,5=Boot logo
+static lv_obj_t *label[5];
+static uint8_t oled_tst_mode = 0; // 0=Normal,1=CB; 2-Grid; 3=All Black; 4=All White,5=Boot logo
 
-lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
     create_text(NULL, section, false, "Sources:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
@@ -42,157 +44,150 @@ lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr)
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
+    create_select_item(arr, cont);
 
-	label[0] = create_label_item(cont,  "HDZero", 1, 0, 3);
-	label[1] = create_label_item(cont,  "HDMI In", 1, 1, 3);
-	label[2] = create_label_item(cont,  "AV In", 1, 2, 3);
-	label[3] = create_label_item(cont,  "Expansion Module", 1, 3, 3);
-	if(g_test_en) {
-		label[4] = create_label_item(cont, "OLED Pattern: Normal", 1, 4,3);
-		create_label_item(cont, "< Back", 1, 5,3);
-	}
-	else {
-		label[4] = NULL;
-		create_label_item(cont, "< Back", 1, 4,3);
-	}
+    label[0] = create_label_item(cont, "HDZero", 1, 0, 3);
+    label[1] = create_label_item(cont, "HDMI In", 1, 1, 3);
+    label[2] = create_label_item(cont, "AV In", 1, 2, 3);
+    label[3] = create_label_item(cont, "Expansion Module", 1, 3, 3);
+    if (g_test_en) {
+        label[4] = create_label_item(cont, "OLED Pattern: Normal", 1, 4, 3);
+        create_label_item(cont, "< Back", 1, 5, 3);
+    } else {
+        label[4] = NULL;
+        create_label_item(cont, "< Back", 1, 4, 3);
+    }
 
-	return page;
+    return page;
 }
 
-char* state2string(uint8_t status)
-{
-	return status? "#00FF00 Detected#" : "#C0C0C0 Disconnected";
+char *state2string(uint8_t status) {
+    return status ? "#00FF00 Detected#" : "#C0C0C0 Disconnected";
 }
 
-void source_status_timer()
-{
-	char buf[64];
+void source_status_timer() {
+    char buf[64];
 
-	if(!in_sourcepage) return;
+    if (!in_sourcepage)
+        return;
 
-	if(g_setting.scan.channel > 8)
-		sprintf(buf, "HDZero: F%d", (g_setting.scan.channel - 8)*2);
-	else
-		sprintf(buf, "HDZero: R%d", g_setting.scan.channel);
-	lv_label_set_text(label[0], buf);
- 	
-	sprintf(buf,"HDMI In: %s", 	state2string(g_source_info.hdmi_in_status));
-	lv_label_set_text(label[1], buf);
+    if (g_setting.scan.channel > 8)
+        sprintf(buf, "HDZero: F%d", (g_setting.scan.channel - 8) * 2);
+    else
+        sprintf(buf, "HDZero: R%d", g_setting.scan.channel);
+    lv_label_set_text(label[0], buf);
 
-	sprintf(buf,"AV In: %s",   state2string(g_source_info.av_in_status));
-	lv_label_set_text(label[2], buf);
+    sprintf(buf, "HDMI In: %s", state2string(g_source_info.hdmi_in_status));
+    lv_label_set_text(label[1], buf);
 
-	sprintf(buf,"Expansion Module: %s",state2string(g_source_info.av_bay_status));
-	lv_label_set_text(label[3], buf);
+    sprintf(buf, "AV In: %s", state2string(g_source_info.av_in_status));
+    lv_label_set_text(label[2], buf);
 
-	if(g_test_en && label[3]) {
-		uint8_t oled_tm = oled_tst_mode & 0x0F;
-		char* pattern_label[6] = {"Normal","Color Bar","Grid","All Black","All White","Boot logo"};
-		char str[32];
-		sprintf(str,"OLED Pattern: %s",pattern_label[oled_tm]);
-		lv_label_set_text(label[4], str);
-	}
+    sprintf(buf, "Expansion Module: %s", state2string(g_source_info.av_bay_status));
+    lv_label_set_text(label[3], buf);
+
+    if (g_test_en && label[3]) {
+        uint8_t oled_tm = oled_tst_mode & 0x0F;
+        char *pattern_label[6] = {"Normal", "Color Bar", "Grid", "All Black", "All White", "Boot logo"};
+        char str[32];
+        sprintf(str, "OLED Pattern: %s", pattern_label[oled_tm]);
+        lv_label_set_text(label[4], str);
+    }
 }
 
-void source_mode_set(int sel)
-{
-	switch(sel) {
-		case 0:
-			progress_bar.start  = 1;
-			HDZero_open();
-			switch_to_video(true);
-			g_menu_op = OPLEVEL_VIDEO;
-			g_source_info.source = SOURCE_HDZERO;
-			sel_audio_source(2);
-			enable_line_out(true);			
-			break;
+void source_mode_set(int sel) {
+    switch (sel) {
+    case 0:
+        progress_bar.start = 1;
+        HDZero_open();
+        switch_to_video(true);
+        g_menu_op = OPLEVEL_VIDEO;
+        g_source_info.source = SOURCE_HDZERO;
+        sel_audio_source(2);
+        enable_line_out(true);
+        break;
 
-		case 1:
-			if(g_source_info.hdmi_in_status) 
-				switch_to_hdmiin();
-			break;
+    case 1:
+        if (g_source_info.hdmi_in_status)
+            switch_to_hdmiin();
+        break;
 
-		case 2://AV in
-			switch_to_analog(0);
-			g_menu_op = OPLEVEL_VIDEO;
-			g_source_info.source = SOURCE_AV_IN;
-			sel_audio_source(2);
-			enable_line_out(true);
-			break;
+    case 2: // AV in
+        switch_to_analog(0);
+        g_menu_op = OPLEVEL_VIDEO;
+        g_source_info.source = SOURCE_AV_IN;
+        sel_audio_source(2);
+        enable_line_out(true);
+        break;
 
-		case 3: //Module in
-			switch_to_analog(1);
-			g_menu_op = OPLEVEL_VIDEO;
-			g_source_info.source = SOURCE_EXPANSION;
-			sel_audio_source(2);
-			enable_line_out(true);
-			break;
+    case 3: // Module in
+        switch_to_analog(1);
+        g_menu_op = OPLEVEL_VIDEO;
+        g_source_info.source = SOURCE_EXPANSION;
+        sel_audio_source(2);
+        enable_line_out(true);
+        break;
 
-		case 4:
-		if(g_test_en && label[4]) {
-			uint8_t oled_te = (oled_tst_mode != 0);
-			uint8_t oled_tm = (oled_tst_mode & 0x0F)-1;
-			//LOGI("OLED TE=%d,TM=%d",oled_te,oled_tm);
-			OLED_Pattern(oled_te,oled_tm,4);
-			oled_tst_mode++;
-			if(oled_tst_mode >=6)
-				oled_tst_mode = 0;
-			break;
-		}
-	}
+    case 4:
+        if (g_test_en && label[4]) {
+            uint8_t oled_te = (oled_tst_mode != 0);
+            uint8_t oled_tm = (oled_tst_mode & 0x0F) - 1;
+            // LOGI("OLED TE=%d,TM=%d",oled_te,oled_tm);
+            OLED_Pattern(oled_te, oled_tm, 4);
+            oled_tst_mode++;
+            if (oled_tst_mode >= 6)
+                oled_tst_mode = 0;
+            break;
+        }
+    }
 }
 
-void pp_source_exit()
-{
-	//LOGI("pp_source_exit %d",oled_tst_mode);
-	if((oled_tst_mode != 0) && g_test_en) {
-		OLED_Pattern(0,0,4);
-		oled_tst_mode = 0;
-	}
+void pp_source_exit() {
+    // LOGI("pp_source_exit %d",oled_tst_mode);
+    if ((oled_tst_mode != 0) && g_test_en) {
+        OLED_Pattern(0, 0, 4);
+        oled_tst_mode = 0;
+    }
 }
 
+void switch_to_analog(bool is_bay) {
+    Source_AV(is_bay);
 
-void switch_to_analog(bool is_bay)
-{
-	Source_AV(is_bay);
+    osd_show(true);
 
-	osd_show(true);
-	
-	lvgl_switch_to_720p();
-	draw_osd_clear();
-	lv_timer_handler();
+    lvgl_switch_to_720p();
+    draw_osd_clear();
+    lv_timer_handler();
 
-	Display_Osd(g_setting.record.osd); 
+    Display_Osd(g_setting.record.osd);
 
-	g_setting.autoscan.last_source = is_bay ? SETTING_SOURCE_EXPANSION : SETTING_SOURCE_AV_IN;
-	ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
+    g_setting.autoscan.last_source = is_bay ? SETTING_SOURCE_EXPANSION : SETTING_SOURCE_AV_IN;
+    ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
 }
 
-void switch_to_hdmiin()
-{
-	Source_HDMI_in();
-	IT66121_close(); 
-	sleep(2);
-	
-	if(g_hw_stat.hdmiin_vtmg == 1) 
-		lvgl_switch_to_1080p();
-	else 
-		lvgl_switch_to_720p();
-	
-	osd_show(true); 
-	draw_osd_clear();
-	lv_timer_handler();
-	
-	g_menu_op = OPLEVEL_VIDEO;
-	g_source_info.source = SOURCE_HDMI_IN;
-	enable_line_out(false);
-	g_setting.autoscan.last_source = SETTING_SOURCE_HDMI_IN;
-	ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
+void switch_to_hdmiin() {
+    Source_HDMI_in();
+    IT66121_close();
+    sleep(2);
+
+    if (g_hw_stat.hdmiin_vtmg == 1)
+        lvgl_switch_to_1080p();
+    else
+        lvgl_switch_to_720p();
+
+    osd_show(true);
+    draw_osd_clear();
+    lv_timer_handler();
+
+    g_menu_op = OPLEVEL_VIDEO;
+    g_source_info.source = SOURCE_HDMI_IN;
+    enable_line_out(false);
+    g_setting.autoscan.last_source = SETTING_SOURCE_HDMI_IN;
+    ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
 }

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -24,7 +24,7 @@ static lv_obj_t *label[5];
 static uint8_t oled_tst_mode = 0; // 0=Normal,1=CB; 2-Grid; 3=All Black; 4=All White,5=Boot logo
 static bool in_sourcepage = false;
 
-lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -54,9 +54,11 @@ lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
     label[2] = create_label_item(cont, "AV In", 1, 2, 3);
     label[3] = create_label_item(cont, "Expansion Module", 1, 3, 3);
     if (g_test_en) {
+        pp_source.p_arr.max = 6;
         label[4] = create_label_item(cont, "OLED Pattern: Normal", 1, 4, 3);
         create_label_item(cont, "< Back", 1, 5, 3);
     } else {
+        pp_source.p_arr.max = 5;
         label[4] = NULL;
         create_label_item(cont, "< Back", 1, 4, 3);
     }
@@ -200,6 +202,7 @@ page_pack_t pp_source = {
         .max = 4,
     },
 
+    .create = &page_source_create,
     .enter = &page_source_enter,
     .exit = &page_source_exit,
     .on_roller = NULL,

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -24,7 +24,7 @@ static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_L
 static lv_obj_t* label[5];
 static uint8_t oled_tst_mode = 0; //0=Normal,1=CB; 2-Grid; 3=All Black; 4=All White,5=Boot logo
 
-lv_obj_t *page_source_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -202,9 +202,9 @@ page_pack_t pp_source = {
         .max = 4,
     },
 
-    .create = &page_source_create,
-    .enter = &page_source_enter,
-    .exit = &page_source_exit,
+    .create = page_source_create,
+    .enter = page_source_enter,
+    .exit = page_source_exit,
     .on_roller = NULL,
-    .on_click = &page_source_on_click,
+    .on_click = page_source_on_click,
 };

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -16,16 +16,13 @@
 #include "ui/ui_porting.h"
 #include "ui/ui_style.h"
 
-/////////////////////////////////////////////////////////////////////////
-// global
-bool in_sourcepage = false;
-
 // local
 static lv_coord_t col_dsc[] = {160, 160, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 static lv_obj_t *label[5];
 static uint8_t oled_tst_mode = 0; // 0=Normal,1=CB; 2-Grid; 3=All Black; 4=All White,5=Boot logo
+static bool in_sourcepage = false;
 
 lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
@@ -101,7 +98,7 @@ void source_status_timer() {
     }
 }
 
-void source_mode_set(int sel) {
+static void page_source_on_click(uint8_t key, int sel) {
     switch (sel) {
     case 0:
         progress_bar.start = 1;
@@ -148,12 +145,17 @@ void source_mode_set(int sel) {
     }
 }
 
-void pp_source_exit() {
-    // LOGI("pp_source_exit %d",oled_tst_mode);
+static void page_source_enter() {
+    in_sourcepage = true;
+}
+
+static void page_source_exit() {
+    // LOGI("page_source_exit %d",oled_tst_mode);
     if ((oled_tst_mode != 0) && g_test_en) {
         OLED_Pattern(0, 0, 4);
         oled_tst_mode = 0;
     }
+    in_sourcepage = false;
 }
 
 void switch_to_analog(bool is_bay) {
@@ -191,3 +193,15 @@ void switch_to_hdmiin() {
     g_setting.autoscan.last_source = SETTING_SOURCE_HDMI_IN;
     ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
 }
+
+page_pack_t pp_source = {
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    },
+
+    .enter = &page_source_enter,
+    .exit = &page_source_exit,
+    .on_roller = NULL,
+    .on_click = &page_source_on_click,
+};

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -7,8 +7,6 @@
 
 extern page_pack_t pp_source;
 
-lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr);
-
 void source_status_timer();
 void switch_to_analog(bool is_bay);
 void switch_to_hdmiin();

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -1,9 +1,8 @@
 #ifndef _PAGE_SOURCE_H
 #define _PAGE_SOURCE_H
 
-
-#include "lvgl/lvgl.h"
 #include "page_common.h"
+#include <lvgl/lvgl.h>
 
 lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr);
 

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -1,21 +1,16 @@
 #ifndef _PAGE_SOURCE_H
 #define _PAGE_SOURCE_H
 
-#include "page_common.h"
 #include <lvgl/lvgl.h>
+
+#include "ui/ui_main_menu.h"
+
+extern page_pack_t pp_source;
 
 lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr);
 
-void source_mode_set(int sel);
-
 void source_status_timer();
-
-void pp_source_exit();
-
 void switch_to_analog(bool is_bay);
-
 void switch_to_hdmiin();
-
-extern bool in_sourcepage;
 
 #endif

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -5,7 +5,7 @@
 #include "lvgl/lvgl.h"
 #include "page_common.h"
 
-lv_obj_t *page_source_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr);
 
 void source_mode_set(int sel);
 

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -1,27 +1,26 @@
 #include "page_version.h"
 
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
+#include <unistd.h>
 
-#include <minIni.h>
 #include <log/log.h>
+#include <minIni.h>
 
-#include "common.hh"
-#include "ui/ui_style.h"
-#include "ui/page_common.h"
-#include "../driver/i2c.h"
-#include "../driver/uart.h"
-#include "../driver/fans.h"
+#include "../core/elrs.h"
+#include "../core/esp32_flash.h"
 #include "../driver/dm5680.h"
 #include "../driver/esp32.h"
+#include "../driver/fans.h"
+#include "../driver/i2c.h"
+#include "../driver/uart.h"
+#include "common.hh"
+#include "ui/page_common.h"
 #include "ui/ui_main_menu.h"
-#include "../core/esp32_flash.h"
-#include "../core/elrs.h"
+#include "ui/ui_style.h"
 
-static lv_coord_t col_dsc[] = {160,160,160,160,160,160,160, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60,60,60,60,60,60,60,60,60,60, LV_GRID_TEMPLATE_LAST};
-
+static lv_coord_t col_dsc[] = {160, 160, 160, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 static lv_obj_t *bar_vtx = NULL;
 static lv_obj_t *btn_vtx = NULL;
@@ -30,473 +29,445 @@ static lv_obj_t *btn_goggle = NULL;
 static lv_obj_t *bar_esp = NULL;
 static lv_obj_t *btn_esp = NULL;
 
-#define ADDR_AL 0x65
-#define ADDR_FPGA 0x64
-#define I2C_Write(s, a, d)  i2c_write(2, s, a, d)
-#define I2C_Read(s, a)      i2c_read(2, s, a)
+#define ADDR_AL            0x65
+#define ADDR_FPGA          0x64
+#define I2C_Write(s, a, d) i2c_write(2, s, a, d)
+#define I2C_Read(s, a)     i2c_read(2, s, a)
 
 static bool is_need_update_progress = false;
 static bool reboot_flag = false;
-static lv_obj_t* cur_ver_label;
-
+static lv_obj_t *cur_ver_label;
 
 #undef RETURN_ON_ERROR
-#define RETURN_ON_ERROR(m, x) do {      \
-    esp_loader_error_t _err_ = (x);     \
-    if (_err_ != ESP_LOADER_SUCCESS) {  \
-		LOGE("ERR %s: %d", m, _err_);   \
-        return _err_;                   \
-    }                                   \
-} while(0)
+#define RETURN_ON_ERROR(m, x)              \
+    do {                                   \
+        esp_loader_error_t _err_ = (x);    \
+        if (_err_ != ESP_LOADER_SUCCESS) { \
+            LOGE("ERR %s: %d", m, _err_);  \
+            return _err_;                  \
+        }                                  \
+    } while (0)
 
-static esp_loader_error_t flash_esp32_file(char *path, uint32_t offset)
-{
-	char fpath[80];
-	strcpy(fpath, "/mnt/extsd/ELRS/");
-	strcat(fpath, path);
+static esp_loader_error_t flash_esp32_file(char *path, uint32_t offset) {
+    char fpath[80];
+    strcpy(fpath, "/mnt/extsd/ELRS/");
+    strcat(fpath, path);
 
-	FILE *image = fopen(fpath, "r");
+    FILE *image = fopen(fpath, "r");
     if (image == NULL) {
         LOGI("Firmware file does not exist %s", fpath);
         return ESP_LOADER_SUCCESS;
     }
 
-	lv_label_set_text(btn_esp, path);
-	lv_timer_handler();
+    lv_label_set_text(btn_esp, path);
+    lv_timer_handler();
 
     fseek(image, 0L, SEEK_END);
     size_t size = ftell(image);
     rewind(image);
 
-	uint8_t buffer[4096];
-	RETURN_ON_ERROR("start", esp_loader_flash_start(offset, size, sizeof(buffer)));
-	uint32_t read, current = 0;
-	while((read = fread(buffer, 1, sizeof(buffer), image))) {
-		RETURN_ON_ERROR("write", esp_loader_flash_write(buffer, read));
-		current += read;
-		int percent = (current * 100) / size;
-		lv_bar_set_value(bar_esp, percent, LV_ANIM_OFF);
-		lv_timer_handler();
-		LOGD("%d %d %d", current, size, percent);
-	}
-	return ESP_LOADER_SUCCESS;
+    uint8_t buffer[4096];
+    RETURN_ON_ERROR("start", esp_loader_flash_start(offset, size, sizeof(buffer)));
+    uint32_t read, current = 0;
+    while ((read = fread(buffer, 1, sizeof(buffer), image))) {
+        RETURN_ON_ERROR("write", esp_loader_flash_write(buffer, read));
+        current += read;
+        int percent = (current * 100) / size;
+        lv_bar_set_value(bar_esp, percent, LV_ANIM_OFF);
+        lv_timer_handler();
+        LOGD("%d %d %d", current, size, percent);
+    }
+    return ESP_LOADER_SUCCESS;
 }
 
-static esp_loader_error_t flash_esp32()
-{
-	disable_esp32();
+static esp_loader_error_t flash_esp32() {
+    disable_esp32();
 
-	esp_loader_connect_args_t config = ESP_LOADER_CONNECT_DEFAULT();
-	RETURN_ON_ERROR("init", loader_port_init());
-	RETURN_ON_ERROR("connect", esp_loader_connect(&config));
-	RETURN_ON_ERROR("get_target", esp_loader_get_target() == ESP32_CHIP ? ESP_LOADER_SUCCESS : ESP_LOADER_ERROR_UNSUPPORTED_CHIP);
+    esp_loader_connect_args_t config = ESP_LOADER_CONNECT_DEFAULT();
+    RETURN_ON_ERROR("init", loader_port_init());
+    RETURN_ON_ERROR("connect", esp_loader_connect(&config));
+    RETURN_ON_ERROR("get_target", esp_loader_get_target() == ESP32_CHIP ? ESP_LOADER_SUCCESS : ESP_LOADER_ERROR_UNSUPPORTED_CHIP);
 
-	lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
-	RETURN_ON_ERROR("flash", flash_esp32_file("bootloader.bin", 0x1000));
-	lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
-	RETURN_ON_ERROR("flash", flash_esp32_file("partitions.bin", 0x8000));
-	lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
-	RETURN_ON_ERROR("flash", flash_esp32_file("boot_app0.bin", 0xE000));
-	lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
-	RETURN_ON_ERROR("flash", flash_esp32_file("firmware.bin", 0x10000));
+    lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
+    RETURN_ON_ERROR("flash", flash_esp32_file("bootloader.bin", 0x1000));
+    lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
+    RETURN_ON_ERROR("flash", flash_esp32_file("partitions.bin", 0x8000));
+    lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
+    RETURN_ON_ERROR("flash", flash_esp32_file("boot_app0.bin", 0xE000));
+    lv_bar_set_value(bar_esp, 0, LV_ANIM_OFF);
+    RETURN_ON_ERROR("flash", flash_esp32_file("firmware.bin", 0x10000));
 
-	RETURN_ON_ERROR("finish", esp_loader_flash_finish(true));
-	loader_port_close();
+    RETURN_ON_ERROR("finish", esp_loader_flash_finish(true));
+    loader_port_close();
 
-	if (g_setting.elrs.enable)
-		enable_esp32();
+    if (g_setting.elrs.enable)
+        enable_esp32();
 
-	return ESP_LOADER_SUCCESS;
+    return ESP_LOADER_SUCCESS;
 }
 
-static bool flash_elrs()
-{
-	esp_loader_error_t ret = flash_esp32();
-	loader_port_close();
+static bool flash_elrs() {
+    esp_loader_error_t ret = flash_esp32();
+    loader_port_close();
 
-	if (g_setting.elrs.enable)
-		enable_esp32();
+    if (g_setting.elrs.enable)
+        enable_esp32();
 
-	return ret;
+    return ret;
 }
 
-int generate_current_version(sys_version_t *sys_ver)
-{
-	char strline[128];
-	char strtmp[25];
-	memset(strtmp, 0, sizeof(strtmp));
-	sys_ver->va = I2C_Read(ADDR_FPGA, 0xff);
-	sys_ver->app = 0;
-	sys_ver->rx = rx_status[0].rx_ver;
+int generate_current_version(sys_version_t *sys_ver) {
+    char strline[128];
+    char strtmp[25];
+    memset(strtmp, 0, sizeof(strtmp));
+    sys_ver->va = I2C_Read(ADDR_FPGA, 0xff);
+    sys_ver->app = 0;
+    sys_ver->rx = rx_status[0].rx_ver;
 
-	FILE *fp = fopen("/mnt/app/version", "r");
-	if(!fp)
-		goto err_open;
+    FILE *fp = fopen("/mnt/app/version", "r");
+    if (!fp)
+        goto err_open;
 
-	while(!feof(fp))
-	{
-		char *p = fgets(strline, sizeof(strline), fp);
-		if(!p)
-			goto err_fget;
+    while (!feof(fp)) {
+        char *p = fgets(strline, sizeof(strline), fp);
+        if (!p)
+            goto err_fget;
 
-		if(strncmp(strline, "major", 5) == 0)
-		{
-			strcat(strtmp, &strline[7]);
-			sys_ver->app = atoi(strtmp);
-			break;
-		}
-		LOGI(">>%s", strline);
-	}
+        if (strncmp(strline, "major", 5) == 0) {
+            strcat(strtmp, &strline[7]);
+            sys_ver->app = atoi(strtmp);
+            break;
+        }
+        LOGI(">>%s", strline);
+    }
 
-	LOGI("va:%d, rx:%d, app:%d", sys_ver->va,
-							sys_ver->rx,
-							sys_ver->app);
-	fclose(fp);
+    LOGI("va:%d, rx:%d, app:%d", sys_ver->va,
+         sys_ver->rx,
+         sys_ver->app);
+    fclose(fp);
 
-	sprintf(sys_ver->current, "%d.%d.%d",
-							sys_ver->app,
-							sys_ver->rx,
-							sys_ver->va);
-	return 0;
+    sprintf(sys_ver->current, "%d.%d.%d",
+            sys_ver->app,
+            sys_ver->rx,
+            sys_ver->va);
+    return 0;
 
 err_fget:
-	fclose(fp);
+    fclose(fp);
 err_open:
-	return -1;
+    return -1;
 }
 
-lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr)
-{
+lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
-	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_set_size(page, 1053, 900);
-	lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
-	lv_obj_set_style_pad_top(page, 94, 0);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, 1053, 900);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
-	lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 1053, 894);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 1053, 894);
 
-    create_text(NULL,section, false, "Firmware:", LV_MENU_ITEM_BUILDER_VARIANT_2);
+    create_text(NULL, section, false, "Firmware:", LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
     lv_obj_set_size(cont, 960, 600);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
-	lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
+    lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(cont, &style_context, LV_PART_MAIN);
 
     lv_obj_set_style_grid_column_dsc_array(cont, col_dsc, 0);
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
-	create_select_item(arr, cont);
-	cur_ver_label = create_label_item(cont, "Current Version:", 1, 0, 2);
+    create_select_item(arr, cont);
+    cur_ver_label = create_label_item(cont, "Current Version:", 1, 0, 2);
 
-	btn_vtx = create_label_item(cont, "Update VTX", 1, 1, 2);
-	btn_goggle = create_label_item(cont, "Update Goggle", 1, 2, 2);
-	btn_esp = create_label_item(cont, "Update ESP32", 1, 3, 2);
-	create_label_item(cont, "< Back", 1, 4, 1);
+    btn_vtx = create_label_item(cont, "Update VTX", 1, 1, 2);
+    btn_goggle = create_label_item(cont, "Update Goggle", 1, 2, 2);
+    btn_esp = create_label_item(cont, "Update ESP32", 1, 3, 2);
+    create_label_item(cont, "< Back", 1, 4, 1);
 
-	bar_vtx = lv_bar_create(cont);
+    bar_vtx = lv_bar_create(cont);
     lv_obj_set_size(bar_vtx, 320, 20);
-	lv_obj_set_grid_cell(bar_vtx, LV_GRID_ALIGN_CENTER, 3, 3,
-						 LV_GRID_ALIGN_CENTER, 1, 1);
-	lv_obj_add_flag(bar_vtx, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_grid_cell(bar_vtx, LV_GRID_ALIGN_CENTER, 3, 3,
+                         LV_GRID_ALIGN_CENTER, 1, 1);
+    lv_obj_add_flag(bar_vtx, LV_OBJ_FLAG_HIDDEN);
 
-	bar_goggle = lv_bar_create(cont);
+    bar_goggle = lv_bar_create(cont);
     lv_obj_set_size(bar_goggle, 320, 20);
-	lv_obj_set_grid_cell(bar_goggle, LV_GRID_ALIGN_CENTER, 3, 3,
-						 LV_GRID_ALIGN_CENTER, 2, 1);
-	lv_obj_add_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_grid_cell(bar_goggle, LV_GRID_ALIGN_CENTER, 3, 3,
+                         LV_GRID_ALIGN_CENTER, 2, 1);
+    lv_obj_add_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
 
-	bar_esp = lv_bar_create(cont);
+    bar_esp = lv_bar_create(cont);
     lv_obj_set_size(bar_esp, 320, 20);
-	lv_obj_set_grid_cell(bar_esp, LV_GRID_ALIGN_CENTER, 3, 3,
-						 LV_GRID_ALIGN_CENTER, 3, 1);
-	lv_obj_add_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_grid_cell(bar_esp, LV_GRID_ALIGN_CENTER, 3, 3,
+                         LV_GRID_ALIGN_CENTER, 3, 1);
+    lv_obj_add_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
 
-	return page;
+    return page;
 }
 
-uint8_t command_monitor(char* cmd)
-{
-	FILE   *stream;
-	char   buf[128];
-	size_t rsize = 0;
-	uint8_t ret;
+uint8_t command_monitor(char *cmd) {
+    FILE *stream;
+    char buf[128];
+    size_t rsize = 0;
+    uint8_t ret;
 
-	stream = popen(cmd , "r" );
-	if(!stream) return 0;
+    stream = popen(cmd, "r");
+    if (!stream)
+        return 0;
 
-	LOGI("---%s---", cmd);
-	ret = 0;
-	do{
-		rsize = fread( buf, sizeof(char), sizeof(buf),  stream);
-		LOGI("%s", buf);
-		if(strstr(buf, "all done"))  {ret = 1; break;}
-		else if(strstr(buf, "skip"))  {ret = 2; break;}
-		else if(strstr(buf, "repeat"))  {ret = 3; break;}
-	} while(rsize  == sizeof(buf));
-	pclose( stream );
-	LOGI("");
-	return ret;
+    LOGI("---%s---", cmd);
+    ret = 0;
+    do {
+        rsize = fread(buf, sizeof(char), sizeof(buf), stream);
+        LOGI("%s", buf);
+        if (strstr(buf, "all done")) {
+            ret = 1;
+            break;
+        } else if (strstr(buf, "skip")) {
+            ret = 2;
+            break;
+        } else if (strstr(buf, "repeat")) {
+            ret = 3;
+            break;
+        }
+    } while (rsize == sizeof(buf));
+    pclose(stream);
+    LOGI("");
+    return ret;
 }
 
-void version_update(int sel)
-{
-	version_update_title();
-	if(sel == 0) {
-		FILE* fp;
-		char buf[80];
-		int dat[16];
-		fp = fopen("/tmp/wr_reg","r");
-		if(fp) {
-			while(fgets(buf,80,fp)) {
-				sscanf(buf,"%x %x %x",&dat[0],&dat[1],&dat[2]);
-				DM5680_WriteReg(dat[0], dat[1], dat[2]);
-				LOGI("DM5680 REG[%02x,%02x]<-%02x", dat[0], dat[1], dat[2]);
-				usleep(100000);
-			}
-			fclose(fp);
-			//system("rm /tmp/wr_reg");
-		}
+void version_update(int sel) {
+    version_update_title();
+    if (sel == 0) {
+        FILE *fp;
+        char buf[80];
+        int dat[16];
+        fp = fopen("/tmp/wr_reg", "r");
+        if (fp) {
+            while (fgets(buf, 80, fp)) {
+                sscanf(buf, "%x %x %x", &dat[0], &dat[1], &dat[2]);
+                DM5680_WriteReg(dat[0], dat[1], dat[2]);
+                LOGI("DM5680 REG[%02x,%02x]<-%02x", dat[0], dat[1], dat[2]);
+                usleep(100000);
+            }
+            fclose(fp);
+            // system("rm /tmp/wr_reg");
+        }
 
-		fp = fopen("/tmp/rd_reg","r");
-		if(!fp) return;
-		while(fgets(buf,80,fp)) {
-			sscanf(buf,"%x %x",&dat[0],&dat[1]);
-			DM5680_ReadReg(dat[0], dat[1]);
-			sleep(1);
-			LOGI("DM5680_0 REG[%02x,%02x]-> %02x", dat[0], dat[1], rx_status[0].rx_regval);
-			LOGI("DM5680_1 REG[%02x,%02x]-> %02x", dat[0], dat[1], rx_status[1].rx_regval);
-		}
-		fclose(fp);
-		//system("rm /tmp/rd_reg");
-	}
+        fp = fopen("/tmp/rd_reg", "r");
+        if (!fp)
+            return;
+        while (fgets(buf, 80, fp)) {
+            sscanf(buf, "%x %x", &dat[0], &dat[1]);
+            DM5680_ReadReg(dat[0], dat[1]);
+            sleep(1);
+            LOGI("DM5680_0 REG[%02x,%02x]-> %02x", dat[0], dat[1], rx_status[0].rx_regval);
+            LOGI("DM5680_1 REG[%02x,%02x]-> %02x", dat[0], dat[1], rx_status[1].rx_regval);
+        }
+        fclose(fp);
+        // system("rm /tmp/rd_reg");
+    } else if (sel == 1) {
+        uint8_t ret;
+        lv_obj_clear_flag(bar_vtx, LV_OBJ_FLAG_HIDDEN);
+        lv_label_set_text(btn_vtx, "Flashing...");
+        lv_timer_handler();
 
-	else if(sel == 1) {
-		uint8_t ret;
-		lv_obj_clear_flag(bar_vtx, LV_OBJ_FLAG_HIDDEN);
-		lv_label_set_text(btn_vtx, "Flashing...");
-		lv_timer_handler();
+        is_need_update_progress = true;
+        ret = command_monitor("/mnt/app/script/update_vtx.sh");
+        is_need_update_progress = false;
 
-		is_need_update_progress = true;
-		ret = command_monitor("/mnt/app/script/update_vtx.sh");
-		is_need_update_progress = false;
+        if (ret == 1) {
+            if (file_compare("/tmp/HDZERO_TX.bin", "/tmp/HDZERO_TX_RB.bin")) {
+                lv_label_set_text(btn_vtx, "#000FF00 SUCCESS#");
+            } else
+                lv_label_set_text(btn_vtx, "#FF0000 Verification failed, try it again#");
+        } else if (ret == 2) {
+            lv_label_set_text(btn_vtx, "#FFFF00 No firmware found.#");
+        } else {
+            lv_label_set_text(btn_vtx, "#FF0000 Failed, check connection...#");
+        }
+        system("rm /tmp/HDZERO_TX.bin");
+        system("rm /tmp/HDZERO_TX_RB.bin");
+        lv_obj_add_flag(bar_vtx, LV_OBJ_FLAG_HIDDEN);
+    } else if ((sel == 2) && !reboot_flag) {
+        uint8_t ret = 0;
+        lv_obj_clear_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
+        lv_label_set_text(btn_goggle, "WAIT... DO NOT POWER OFF... ");
+        lv_timer_handler();
 
-		if(ret == 1){
-			if(file_compare("/tmp/HDZERO_TX.bin","/tmp/HDZERO_TX_RB.bin")) {
-				lv_label_set_text(btn_vtx, "#000FF00 SUCCESS#");
-			}
-			else
-				lv_label_set_text(btn_vtx, "#FF0000 Verification failed, try it again#");
-		}
-		else if(ret == 2) {
-			lv_label_set_text(btn_vtx, "#FFFF00 No firmware found.#");
-		}
-		else{
-			lv_label_set_text(btn_vtx, "#FF0000 Failed, check connection...#");
-		}
-		system("rm /tmp/HDZERO_TX.bin");
-		system("rm /tmp/HDZERO_TX_RB.bin");
-		lv_obj_add_flag(bar_vtx, LV_OBJ_FLAG_HIDDEN);
-	}
-	else if((sel == 2) && !reboot_flag) {
-		uint8_t ret = 0;
-		lv_obj_clear_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
-		lv_label_set_text(btn_goggle, "WAIT... DO NOT POWER OFF... ");
-		lv_timer_handler();
-
-		is_need_update_progress = true;
-		ret = command_monitor("/mnt/app/script/update_goggle.sh");
-		is_need_update_progress = false;
-		lv_obj_add_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
-		if(ret == 1)
-		{
-			//bool b1 = file_compare("/tmp//tmp/goggle_update/HDZERO_RX.bin","/tmp//tmp/goggle_update/HDZERO_RX_RBL.bin");
-			//bool b2 = file_compare("/tmp//tmp/goggle_update/HDZERO_RX.bin","/tmp//tmp/goggle_update/HDZERO_RX_RBR.bin");
-			//bool b3 = file_compare("/tmp//tmp/goggle_update/HDZERO_VA.bin","/tmp//tmp/goggle_update/HDZERO_VA_RB.bin");
-			//LOGI("Verify result: %d %d %d", b1,b2,b3);
-			//if(b1 && b2 && b3) {
-			if(1){
-				lv_timer_handler();
-				lv_label_set_text(btn_goggle, "#00FF00 Update success, repower goggle NOW!#");
-				beep();usleep(1000000); beep();usleep(1000000);beep();
-			}
-			else
-				lv_label_set_text(btn_goggle, "#FF0000 FAILED#");
-			reboot_flag = true;
-			lv_timer_handler();
-			while(1); //dead loop
-		}
-		else if(ret == 2)
-		{
-			lv_label_set_text(btn_goggle, "#FFFF00 No firmware found.#");
-		}
-		else if(ret == 3)
-		{
-			lv_label_set_text(btn_goggle, "#FFFF00 Multiple versions been found. Keep only one.#");
-		}
-		else
-			lv_label_set_text(btn_goggle, "#FF0000 FAILED#");
-		lv_obj_add_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
-	}
-	else if(sel == 3) { // flash ESP via SD
-		lv_obj_clear_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
-		lv_label_set_text(btn_esp, "Flashing...");
-		lv_timer_handler();
-		esp_loader_error_t ret = flash_elrs();
-		lv_obj_add_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
-		if(ret == ESP_LOADER_SUCCESS)
-			lv_label_set_text(btn_esp, "#00FF00 Success#");
-		else
-			lv_label_set_text(btn_esp, "#FF0000 FAILED#");
-	}
+        is_need_update_progress = true;
+        ret = command_monitor("/mnt/app/script/update_goggle.sh");
+        is_need_update_progress = false;
+        lv_obj_add_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
+        if (ret == 1) {
+            // bool b1 = file_compare("/tmp//tmp/goggle_update/HDZERO_RX.bin","/tmp//tmp/goggle_update/HDZERO_RX_RBL.bin");
+            // bool b2 = file_compare("/tmp//tmp/goggle_update/HDZERO_RX.bin","/tmp//tmp/goggle_update/HDZERO_RX_RBR.bin");
+            // bool b3 = file_compare("/tmp//tmp/goggle_update/HDZERO_VA.bin","/tmp//tmp/goggle_update/HDZERO_VA_RB.bin");
+            // LOGI("Verify result: %d %d %d", b1,b2,b3);
+            // if(b1 && b2 && b3) {
+            if (1) {
+                lv_timer_handler();
+                lv_label_set_text(btn_goggle, "#00FF00 Update success, repower goggle NOW!#");
+                beep();
+                usleep(1000000);
+                beep();
+                usleep(1000000);
+                beep();
+            } else
+                lv_label_set_text(btn_goggle, "#FF0000 FAILED#");
+            reboot_flag = true;
+            lv_timer_handler();
+            while (1)
+                ; // dead loop
+        } else if (ret == 2) {
+            lv_label_set_text(btn_goggle, "#FFFF00 No firmware found.#");
+        } else if (ret == 3) {
+            lv_label_set_text(btn_goggle, "#FFFF00 Multiple versions been found. Keep only one.#");
+        } else
+            lv_label_set_text(btn_goggle, "#FF0000 FAILED#");
+        lv_obj_add_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
+    } else if (sel == 3) { // flash ESP via SD
+        lv_obj_clear_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
+        lv_label_set_text(btn_esp, "Flashing...");
+        lv_timer_handler();
+        esp_loader_error_t ret = flash_elrs();
+        lv_obj_add_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
+        if (ret == ESP_LOADER_SUCCESS)
+            lv_label_set_text(btn_esp, "#00FF00 Success#");
+        else
+            lv_label_set_text(btn_esp, "#FF0000 FAILED#");
+    }
 }
 
 void process_bar_update(const int value0,
-		const int value1)
-{
-	if(bar_vtx && bar_goggle)
-	{
-		//LOGI("v0=%d, v1=%d\n", value0, value1);
-		lv_bar_set_value(bar_vtx, value0, LV_ANIM_OFF);
-		lv_bar_set_value(bar_goggle, value1, LV_ANIM_OFF);
-	}
+                        const int value1) {
+    if (bar_vtx && bar_goggle) {
+        // LOGI("v0=%d, v1=%d\n", value0, value1);
+        lv_bar_set_value(bar_vtx, value0, LV_ANIM_OFF);
+        lv_bar_set_value(bar_goggle, value1, LV_ANIM_OFF);
+    }
 }
 
-void bar_update(int sel, int value)
-{
-	if(bar_goggle && sel)
-		lv_bar_set_value(bar_goggle, value, LV_ANIM_OFF);
-	else if(bar_vtx && !sel)
-		lv_bar_set_value(bar_vtx, value, LV_ANIM_OFF);
-	lv_timer_handler();
+void bar_update(int sel, int value) {
+    if (bar_goggle && sel)
+        lv_bar_set_value(bar_goggle, value, LV_ANIM_OFF);
+    else if (bar_vtx && !sel)
+        lv_bar_set_value(bar_vtx, value, LV_ANIM_OFF);
+    lv_timer_handler();
 }
 
-void update_current_version()
-{
-	char strtmp[128];
-	static bool bInit = true;
-	if(bInit) {
-		sys_version_t sys_version;
-		generate_current_version(&sys_version);
-		memset(strtmp, 0, sizeof(strtmp));
-		strcat(strtmp, "Current Version: ");
-		strcat(strtmp, sys_version.current);
-		lv_label_set_text(cur_ver_label, strtmp);
-		bInit = false;
-	}
+void update_current_version() {
+    char strtmp[128];
+    static bool bInit = true;
+    if (bInit) {
+        sys_version_t sys_version;
+        generate_current_version(&sys_version);
+        memset(strtmp, 0, sizeof(strtmp));
+        strcat(strtmp, "Current Version: ");
+        strcat(strtmp, sys_version.current);
+        lv_label_set_text(cur_ver_label, strtmp);
+        bInit = false;
+    }
 }
 
-void version_update_title()
-{
-	update_current_version();
-	lv_label_set_text(btn_vtx, "Update VTX");
-	if(!reboot_flag)
-		lv_label_set_text(btn_goggle, "Update Goggle");
-	lv_label_set_text(btn_esp, "Update ESP32");
+void version_update_title() {
+    update_current_version();
+    lv_label_set_text(btn_vtx, "Update VTX");
+    if (!reboot_flag)
+        lv_label_set_text(btn_goggle, "Update Goggle");
+    lv_label_set_text(btn_esp, "Update ESP32");
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // for progress info
-static int get_progress_info(int *v0, int *v1)
-{
-		FILE   *stream;
-		char   buf[128];
-		memset( buf, '\0', sizeof(buf) );
-		stream = popen( "/mnt/app/script/get_progress_info.sh" , "r" );
-		fread( buf, sizeof(char), sizeof(buf),  stream);
-		pclose( stream );
+static int get_progress_info(int *v0, int *v1) {
+    FILE *stream;
+    char buf[128];
+    memset(buf, '\0', sizeof(buf));
+    stream = popen("/mnt/app/script/get_progress_info.sh", "r");
+    fread(buf, sizeof(char), sizeof(buf), stream);
+    pclose(stream);
 
-		char *pos = strchr(buf, 0xa);
-		char buf_v0[10];
-		char buf_v1[10];
-		memset( buf_v0, '\0', sizeof(buf_v0) );
-		memset( buf_v1, '\0', sizeof(buf_v1) );
-		memcpy(buf_v0, buf, pos - buf);
-		memcpy(buf_v1, pos+1, strlen(buf) - (pos-buf-1));
+    char *pos = strchr(buf, 0xa);
+    char buf_v0[10];
+    char buf_v1[10];
+    memset(buf_v0, '\0', sizeof(buf_v0));
+    memset(buf_v1, '\0', sizeof(buf_v1));
+    memcpy(buf_v0, buf, pos - buf);
+    memcpy(buf_v1, pos + 1, strlen(buf) - (pos - buf - 1));
 
-		*v0 = atoi(buf_v0);
-		*v1 = atoi(buf_v1);
-		return 0;
+    *v0 = atoi(buf_v0);
+    *v1 = atoi(buf_v1);
+    return 0;
 }
 
 extern pthread_mutex_t lvgl_mutex;
 
-void *thread_version(void *ptr)
-{
-	int count = 0;
-	int sec = 0;
-	int sec_last = 0;
-	int v0 = 0;
-	int v1 = 0;
-	bool is_step1 = false;
-	bool is_step2 = false;
+void *thread_version(void *ptr) {
+    int count = 0;
+    int sec = 0;
+    int sec_last = 0;
+    int v0 = 0;
+    int v1 = 0;
+    bool is_step1 = false;
+    bool is_step2 = false;
 
-	int percentage = 0;
-	for(;;)
-	{
-		if(is_need_update_progress)
-		{
-			//pthread_mutex_lock(&lvgl_mutex);
-			get_progress_info(&v0, &v1);
-			if(v1 == 0)
-			{
-				percentage = 0;
-			}
-			else if(v1 == 1)
-			{
-				if(is_step1 == false)
-					percentage = 1;
+    int percentage = 0;
+    for (;;) {
+        if (is_need_update_progress) {
+            // pthread_mutex_lock(&lvgl_mutex);
+            get_progress_info(&v0, &v1);
+            if (v1 == 0) {
+                percentage = 0;
+            } else if (v1 == 1) {
+                if (is_step1 == false)
+                    percentage = 1;
 
-				is_step1 = true;
+                is_step1 = true;
 
-				if(sec_last != sec)
-					percentage++;
+                if (sec_last != sec)
+                    percentage++;
 
-				if(percentage > 45)
-					percentage = 45;
-			}
-			else if(v1 == 45)
-			{
-				if(is_step2 == false)
-					percentage = 45;
+                if (percentage > 45)
+                    percentage = 45;
+            } else if (v1 == 45) {
+                if (is_step2 == false)
+                    percentage = 45;
 
-				is_step2 = true;
-				if(sec_last != sec)
-					percentage++;
+                is_step2 = true;
+                if (sec_last != sec)
+                    percentage++;
 
-				if(percentage > 99)
-					percentage = 99;
-			}
-			else if(v1 == 100)
-			{
-				is_step1 = false;
-				is_step2 = false;
+                if (percentage > 99)
+                    percentage = 99;
+            } else if (v1 == 100) {
+                is_step1 = false;
+                is_step2 = false;
 
-				percentage = 100;
-			}
+                percentage = 100;
+            }
 
+            sec_last = sec;
+            process_bar_update(v0, percentage);
+            lv_timer_handler();
+            //	pthread_mutex_unlock(&lvgl_mutex);
+        }
 
-			sec_last = sec;
-			process_bar_update(v0, percentage);
-			lv_timer_handler();
-		//	pthread_mutex_unlock(&lvgl_mutex);
-		}
+        if (count >= 10) {
+            count = 0;
+            sec++;
+        }
 
-		if(count >= 10)
-		{
-			count = 0;
-			sec++;
-		}
+        /// Progess bar
+        progress_bar_update();
 
-		///Progess bar
-		progress_bar_update();
-
-		count++;
-		usleep(100000);
-	}
-	return NULL;
+        count++;
+        usleep(100000);
+    }
+    return NULL;
 }

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -486,9 +486,9 @@ page_pack_t pp_version = {
         .max = 5,
     },
 
-    .create = &page_version_create,
-    .enter = &page_version_enter,
+    .create = page_version_create,
+    .enter = page_version_enter,
     .exit = NULL,
-    .on_roller = &page_version_on_roller,
-    .on_click = &page_version_on_click,
+    .on_roller = page_version_on_roller,
+    .on_click = page_version_on_click,
 };

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -241,7 +241,7 @@ uint8_t command_monitor(char *cmd) {
     return ret;
 }
 
-void version_update(int sel) {
+static void page_version_on_click(uint8_t key, int sel) {
     version_update_title();
     if (sel == 0) {
         FILE *fp;
@@ -471,3 +471,23 @@ void *thread_version(void *ptr) {
     }
     return NULL;
 }
+
+static void page_version_enter() {
+    version_update_title();
+}
+
+static void page_version_on_roller(uint8_t key) {
+    version_update_title();
+}
+
+page_pack_t pp_version = {
+    .p_arr = {
+        .cur = 0,
+        .max = 5,
+    },
+
+    .enter = &page_version_enter,
+    .exit = NULL,
+    .on_roller = &page_version_on_roller,
+    .on_click = &page_version_on_click,
+};

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -165,7 +165,7 @@ err_open:
 	return -1;
 }
 
-lv_obj_t *page_version_create(lv_obj_t *parent, struct panel_arr *arr)
+lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr)
 {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
 	lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -158,7 +158,7 @@ err_open:
     return -1;
 }
 
-lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr) {
+static lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_size(page, 1053, 900);
@@ -486,6 +486,7 @@ page_pack_t pp_version = {
         .max = 5,
     },
 
+    .create = &page_version_create,
     .enter = &page_version_enter,
     .exit = NULL,
     .on_roller = &page_version_on_roller,

--- a/src/ui/page_version.h
+++ b/src/ui/page_version.h
@@ -16,15 +16,12 @@ typedef struct {
 
 extern page_pack_t pp_version;
 
-int generate_current_version(sys_version_t *sys_ver);
-
-lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr);
 void version_update(int sel);
-void process_bar_update(const int value0,
-                        const int value1);
-
+void process_bar_update(const int value0, const int value1);
 void bar_update(int sel, int value);
 void version_update_title();
+
+int generate_current_version(sys_version_t *sys_ver);
 
 void *thread_version(void *ptr);
 uint8_t command_monitor(char *cmd);

--- a/src/ui/page_version.h
+++ b/src/ui/page_version.h
@@ -1,16 +1,20 @@
 #ifndef _PAGE_VERSION_H
 #define _PAGE_VERSION_H
 
-#include "page_common.h"
 #include <lvgl/lvgl.h>
 
+#include "ui/ui_main_menu.h"
+
 #define CURRENT_VER_MAX (64)
+
 typedef struct {
     uint8_t rx;
     uint8_t va;
     uint8_t app;
     char current[CURRENT_VER_MAX];
 } sys_version_t;
+
+extern page_pack_t pp_version;
 
 int generate_current_version(sys_version_t *sys_ver);
 

--- a/src/ui/page_version.h
+++ b/src/ui/page_version.h
@@ -15,7 +15,7 @@ typedef struct {
 
 int generate_current_version(sys_version_t *sys_ver);
 
-lv_obj_t *page_version_create(lv_obj_t *parent, struct panel_arr *arr);
+lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr);
 void version_update(int sel);
 void process_bar_update(const int value0,
 		const int value1);

--- a/src/ui/page_version.h
+++ b/src/ui/page_version.h
@@ -1,16 +1,15 @@
 #ifndef _PAGE_VERSION_H
 #define _PAGE_VERSION_H
 
-
-#include "lvgl/lvgl.h"
 #include "page_common.h"
+#include <lvgl/lvgl.h>
 
 #define CURRENT_VER_MAX (64)
 typedef struct {
-	uint8_t rx;
-	uint8_t va;
-	uint8_t app;
-	char current[CURRENT_VER_MAX];
+    uint8_t rx;
+    uint8_t va;
+    uint8_t app;
+    char current[CURRENT_VER_MAX];
 } sys_version_t;
 
 int generate_current_version(sys_version_t *sys_ver);
@@ -18,12 +17,11 @@ int generate_current_version(sys_version_t *sys_ver);
 lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr);
 void version_update(int sel);
 void process_bar_update(const int value0,
-		const int value1);
-
+                        const int value1);
 
 void bar_update(int sel, int value);
 void version_update_title();
 
 void *thread_version(void *ptr);
-uint8_t command_monitor(char* cmd);
+uint8_t command_monitor(char *cmd);
 #endif

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -25,180 +25,82 @@
 #include "ui/ui_porting.h"
 #include "ui/ui_style.h"
 
-lv_obj_t *menu;
-lv_obj_t *root_page;
-progress_bar_t progress_bar;
-
-page_pack_t pp_scannow;
-page_pack_t pp_source = {
-    .p_arr = {
-        .cur = 0,
-        .max = 4,
-    }};
-page_pack_t pp_imagesettings = {
-    .p_arr = {
-        .cur = 0,
-        .max = 6,
-    }};
-page_pack_t pp_power = {
-    .p_arr = {
-        .cur = 0,
-        .max = 4,
-    }};
-page_pack_t pp_fans = {
-    .p_arr = {
-        .cur = 0,
-        .max = 4,
-    }};
-page_pack_t pp_record = {
-    .p_arr = {
-        .cur = 0,
-        .max = 7,
-    }};
-page_pack_t pp_autoscan = {
-    .p_arr = {
-        .cur = 0,
-        .max = 4,
-    }};
-page_pack_t pp_connections = {
-    .p_arr = {
-        .cur = 0,
-        .max = 8,
-    }};
-page_pack_t pp_headtracker = {
-    .p_arr = {
-        .cur = 0,
-        .max = 3,
-    }};
-page_pack_t pp_playback;
-
-page_pack_t pp_version = {
-    .p_arr = {
-        .cur = 0,
-        .max = 5,
-    }};
-
 LV_IMG_DECLARE(img_arrow);
 
-page_pack_t *find_pp(lv_obj_t *page) {
-    if (pp_scannow.page == page)
-        return &pp_scannow;
+progress_bar_t progress_bar;
 
-    if (pp_source.page == page)
-        return &pp_source;
+static lv_obj_t *menu;
+static lv_obj_t *root_page;
 
-    if (pp_imagesettings.page == page)
-        return &pp_imagesettings;
+static page_pack_t *page_packs[PAGE_MAX] = {
+    [PAGE_AUTO_SCAN] = &pp_autoscan,
+    [PAGE_CONNECTIONS] = &pp_connections,
+    [PAGE_FANS] = &pp_fans,
+    [PAGE_HEADTRACKER] = &pp_headtracker,
+    [PAGE_IMAGE_SETTINGS] = &pp_imagesettings,
+    [PAGE_PLAYBACK] = &pp_playback,
+    [PAGE_POWER] = &pp_power,
+    [PAGE_RECORD] = &pp_record,
+    [PAGE_SCAN_NOW] = &pp_scannow,
+    [PAGE_SOURCE] = &pp_source,
+    [PAGE_VERSION] = &pp_version,
+};
 
-    if (pp_power.page == page)
-        return &pp_power;
-
-    if (pp_fans.page == page)
-        return &pp_fans;
-
-    if (pp_record.page == page)
-        return &pp_record;
-
-    if (pp_autoscan.page == page)
-        return &pp_autoscan;
-
-    if (pp_connections.page == page)
-        return &pp_connections;
-
-    if (pp_headtracker.page == page)
-        return &pp_headtracker;
-
-    if (pp_playback.page == page)
-        return &pp_playback;
-
-    if (pp_version.page == page)
-        return &pp_version;
-
+static page_pack_t *find_pp(lv_obj_t *page) {
+    for (uint32_t i = 0; i < PAGE_MAX; i++) {
+        if (page_packs[i]->page == page) {
+            return page_packs[i];
+        }
+    }
     return NULL;
 }
 
 static void clear_all_icon(void) {
-    lv_img_set_src(pp_scannow.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_source.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_imagesettings.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_power.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_fans.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_record.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_autoscan.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_connections.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_headtracker.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_playback.icon, LV_SYMBOL_DUMMY);
-    lv_img_set_src(pp_version.icon, LV_SYMBOL_DUMMY);
+    for (uint32_t i = 0; i < PAGE_MAX; i++) {
+        lv_img_set_src(page_packs[i]->icon, LV_SYMBOL_DUMMY);
+    }
 }
 
 static void menu_event_handler(lv_event_t *e) {
-
     clear_all_icon();
 
     page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-    if (!pp)
-        return;
-
-    lv_img_set_src(pp->icon, &img_arrow);
+    if (pp) {
+        lv_img_set_src(pp->icon, &img_arrow);
+    }
 }
 
-static int auto_scaned_cnt = 0;
 void submenu_enter(void) {
     page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-    if (!pp)
+    if (!pp) {
         return;
-
-    if (pp == &pp_scannow) {
-        auto_scaned_cnt = scan();
-        LOGI("scan return :%d", auto_scaned_cnt);
-
-        if (auto_scaned_cnt == 1) {
-            if (!g_autoscan_exit)
-                g_autoscan_exit = true;
-
-            g_menu_op = OPLEVEL_VIDEO;
-            switch_to_video(false);
-        }
-
-        if (auto_scaned_cnt == -1)
-            submenu_exit();
-
-        return;
-    } else if (pp == &pp_playback) {
-        if (!init_pb())
-            submenu_exit(); // won't enter sub menu if no video file is found
-        return;
-    } else if (pp == &pp_source) {
-        in_sourcepage = true;
-    } else if (pp == &pp_version) {
-        version_update_title();
-    } else if (pp == &pp_imagesettings) {
-        page_ims_click();
     }
 
-    pp->p_arr.cur = 0;
-    set_select_item(&pp->p_arr, pp->p_arr.cur);
+    if (pp->enter) {
+        // if your page as a enter event handler, call it
+        pp->enter();
+    }
+
+    if (pp->p_arr.max) {
+        // if we have selectable entries, select the first one
+        pp->p_arr.cur = 0;
+        set_select_item(&pp->p_arr, pp->p_arr.cur);
+    }
 }
 
 void submenu_nav(uint8_t key) {
     page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-    if (!pp)
+    if (!pp) {
         return;
+    }
 
-    if (pp == &pp_scannow)
-        user_select(key);
-    else if (pp == &pp_playback)
-        pb_key(key);
-    else {
-        if (pp == &pp_version)
-            version_update_title();
+    if (pp->on_roller) {
+        // if your page as a roller event handler, call it
+        pp->on_roller(key);
+    }
 
-        if (pp == &pp_record)
-            formatsd_negtive();
-
-        if (pp == &pp_connections)
-            page_connections_reset();
-
+    if (pp->p_arr.max) {
+        // if we have selectable entries, move selection
         if (key == DIAL_KEY_UP) {
             if (pp->p_arr.cur < pp->p_arr.max - 1)
                 pp->p_arr.cur++;
@@ -219,67 +121,37 @@ void submenu_exit() {
     g_menu_op = OPLEVEL_MAINMENU;
 
     page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-    if (!pp)
+    if (!pp) {
         return;
-    pp->p_arr.cur = 0;
-
-    if (pp == &pp_playback)
-        pb_key(DIAL_KEY_PRESS);
-    else if (pp == &pp_scannow)
-        HDZero_Close();
-    else if (pp == &pp_source) {
-        pp_source_exit();
-        in_sourcepage = false;
-    } else if (pp == &pp_record) {
-        formatsd_negtive();
     }
 
-    // No need to remove the selected bar on ScanNow and Playback page
-    if ((pp != &pp_scannow) && (pp != &pp_playback))
+    if (pp->exit) {
+        // if your page as a exit event handler, call it
+        pp->exit();
+    }
+
+    if (pp->p_arr.max) {
+        // if we have selectable icons, reset the selector
+        pp->p_arr.cur = 0;
         set_select_item(&pp->p_arr, -1);
+    }
 }
 
 void submenu_fun(void) {
     page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-    if (!pp)
+    if (!pp) {
         return;
+    }
 
-    if (pp == &pp_scannow) {
-        g_menu_op = OPLEVEL_VIDEO;
-        switch_to_video(false);
-    } else if (pp == &pp_playback) {
-        pb_key(DIAL_KEY_CLICK);
-    } else {
-        if ((pp == &pp_fans)) {
-            fans_mode_toggle(pp->p_arr.cur);
-        }
-        if ((pp == &pp_source)) {
-            source_mode_set(pp->p_arr.cur);
-        }
-        if ((pp == &pp_autoscan)) {
-            autoscan_toggle(pp->p_arr.cur);
-        }
-        if ((pp == &pp_power)) {
-            power_set_toggle(pp->p_arr.cur);
-        }
-        if ((pp == &pp_connections)) {
-            connect_function(pp->p_arr.cur);
-        }
-        if ((pp == &pp_record)) {
-            record_set_toggle(pp->p_arr.cur);
-        }
+    if (pp->on_click) {
+        // if your page as a click event handler, call it
+        pp->on_click(DIAL_KEY_CLICK, pp->p_arr.cur);
+    }
 
-        if (pp == &pp_headtracker) {
-            headtracker_set_toggle(pp->p_arr.cur);
-        }
-
-        if ((pp == &pp_version)) {
-            version_update(pp->p_arr.cur);
-        }
-
+    if (pp->p_arr.max) {
+        // if we have selectable icons, check if we hit the back button
         if (pp->p_arr.cur == pp->p_arr.max - 1) {
             submenu_exit();
-        } else {
         }
     }
 }
@@ -290,11 +162,11 @@ void menu_nav(uint8_t key) {
     if (key == DIAL_KEY_DOWN) {
         selected--;
         if (selected < 0)
-            selected += MAIN_MENU_ITEMS;
+            selected += PAGE_MAX;
     } else if (key == DIAL_KEY_UP) {
         selected++;
-        if (selected >= MAIN_MENU_ITEMS)
-            selected -= MAIN_MENU_ITEMS;
+        if (selected >= PAGE_MAX)
+            selected -= PAGE_MAX;
     }
     lv_event_send(lv_obj_get_child(lv_obj_get_child(lv_menu_get_cur_sidebar_page(menu), 0), selected), LV_EVENT_CLICKED, NULL);
 }
@@ -393,22 +265,21 @@ static void ui_create_rootpage(lv_obj_t *parent) {
 }
 
 static void menu_reinit(void) {
-    LOGI("reinit");
-    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-    if (!pp)
-        return;
+    LOGI("menu_reinit");
 
-    // LOGI("set select item");
+    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
+    if (!pp) {
+        return;
+    }
 
     if ((pp == &pp_scannow)) {
         scan_reinit();
-    } else if ((pp == &pp_source)) {
-        set_select_item(&pp->p_arr, -1);
-    } else if ((pp == &pp_playback)) {
+    }
 
-    } else {
-        pp->p_arr.cur = -1;
-        set_select_item(&pp->p_arr, pp->p_arr.cur);
+    if (pp->p_arr.max) {
+        // if we have selectable icons, reset the selector
+        pp->p_arr.cur = 0;
+        set_select_item(&pp->p_arr, -1);
     }
 }
 
@@ -426,7 +297,6 @@ void main_menu_show(bool is_show) {
 }
 
 void main_menu_toggle(void) {
-
     if (lv_obj_has_flag(menu, LV_OBJ_FLAG_HIDDEN)) {
         lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
         menu_reinit();
@@ -505,18 +375,5 @@ void progress_bar_update() {
             progress_bar.val += 4;
         lv_bar_set_value(progress_bar.bar, progress_bar.val, LV_ANIM_OFF);
         lv_timer_handler();
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-//
-void autoscan_exit(void) {
-    if (!g_autoscan_exit) {
-        LOGI("autoscan_exit, lelve=1");
-        g_autoscan_exit = true;
-        if (auto_scaned_cnt > 1)
-            g_menu_op = OPLEVEL_SUBMENU;
-        else
-            g_menu_op = OPLEVEL_MAINMENU;
     }
 }

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -2,20 +2,19 @@
 
 #include <stdio.h>
 
-#include <lvgl/lvgl.h>
 #include <log/log.h>
+#include <lvgl/lvgl.h>
 
-#include "../driver/hardware.h"
-#include "../driver/mcp3021.h"
-#include "../driver/oled.h"
 #include "common.hh"
+#include "driver/hardware.h"
+#include "driver/mcp3021.h"
+#include "driver/oled.h"
 #include "ui/page_autoscan.h"
 #include "ui/page_common.h"
 #include "ui/page_connections.h"
 #include "ui/page_fans.h"
 #include "ui/page_headtracker.h"
 #include "ui/page_imagesettings.h"
-#include "ui/page_playback.h"
 #include "ui/page_playback.h"
 #include "ui/page_power.h"
 #include "ui/page_record.h"
@@ -26,553 +25,498 @@
 #include "ui/ui_porting.h"
 #include "ui/ui_style.h"
 
-lv_obj_t * menu;
-lv_obj_t * root_page;
+lv_obj_t *menu;
+lv_obj_t *root_page;
 progress_bar_t progress_bar;
 
 page_pack_t pp_scannow;
 page_pack_t pp_source = {
-	.p_arr = {
-		.cur = 0,
-		.max = 4,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    }};
 page_pack_t pp_imagesettings = {
-	.p_arr = {
-		.cur = 0,
-		.max = 6,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 6,
+    }};
 page_pack_t pp_power = {
-	.p_arr = {
-		.cur = 0,
-		.max = 4,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    }};
 page_pack_t pp_fans = {
-	.p_arr = {
-		.cur = 0,
-		.max = 4,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    }};
 page_pack_t pp_record = {
-	.p_arr = {
-		.cur = 0,
-		.max = 7,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 7,
+    }};
 page_pack_t pp_autoscan = {
-	.p_arr = {
-		.cur = 0,
-		.max = 4,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 4,
+    }};
 page_pack_t pp_connections = {
-	.p_arr = {
-		.cur = 0,
-		.max = 8,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 8,
+    }};
 page_pack_t pp_headtracker = {
-	.p_arr = {
-		.cur = 0,
-		.max = 3,
-	}
-};
+    .p_arr = {
+        .cur = 0,
+        .max = 3,
+    }};
 page_pack_t pp_playback;
 
 page_pack_t pp_version = {
-	.p_arr = {
-		.cur = 0,
-		.max = 5,
-	}
-};
-
+    .p_arr = {
+        .cur = 0,
+        .max = 5,
+    }};
 
 LV_IMG_DECLARE(img_arrow);
 
-page_pack_t * find_pp(lv_obj_t *page)
-{
-	if(pp_scannow.page == page)
-		return &pp_scannow;
+page_pack_t *find_pp(lv_obj_t *page) {
+    if (pp_scannow.page == page)
+        return &pp_scannow;
 
-	if(pp_source.page == page)
-		return &pp_source;
+    if (pp_source.page == page)
+        return &pp_source;
 
-	if(pp_imagesettings.page == page)
-		return &pp_imagesettings;
+    if (pp_imagesettings.page == page)
+        return &pp_imagesettings;
 
-	if(pp_power.page == page)
-		return &pp_power;
+    if (pp_power.page == page)
+        return &pp_power;
 
-	if(pp_fans.page == page)
-		return &pp_fans;
+    if (pp_fans.page == page)
+        return &pp_fans;
 
-	if(pp_record.page == page)
-		return &pp_record;
+    if (pp_record.page == page)
+        return &pp_record;
 
-	if(pp_autoscan.page == page)
-		return &pp_autoscan;
+    if (pp_autoscan.page == page)
+        return &pp_autoscan;
 
-	if(pp_connections.page == page)
-		return &pp_connections;
+    if (pp_connections.page == page)
+        return &pp_connections;
 
-	if(pp_headtracker.page == page)
-		return &pp_headtracker;
+    if (pp_headtracker.page == page)
+        return &pp_headtracker;
 
-	if(pp_playback.page == page)
-		return &pp_playback;
+    if (pp_playback.page == page)
+        return &pp_playback;
 
-	if(pp_version.page == page)
-		return &pp_version;
+    if (pp_version.page == page)
+        return &pp_version;
 
-	return NULL;
+    return NULL;
 }
 
-static void clear_all_icon(void)
-{
-	lv_img_set_src(pp_scannow.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_source.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_imagesettings.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_power.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_fans.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_record.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_autoscan.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_connections.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_headtracker.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_playback.icon, LV_SYMBOL_DUMMY);
-	lv_img_set_src(pp_version.icon, LV_SYMBOL_DUMMY);
+static void clear_all_icon(void) {
+    lv_img_set_src(pp_scannow.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_source.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_imagesettings.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_power.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_fans.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_record.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_autoscan.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_connections.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_headtracker.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_playback.icon, LV_SYMBOL_DUMMY);
+    lv_img_set_src(pp_version.icon, LV_SYMBOL_DUMMY);
 }
-static void menu_event_handler(lv_event_t * e)
-{
 
-	clear_all_icon();
+static void menu_event_handler(lv_event_t *e) {
 
-	page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-	if(!pp)
-		return;
+    clear_all_icon();
 
-	lv_img_set_src(pp->icon, &img_arrow);
+    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
+    if (!pp)
+        return;
 
+    lv_img_set_src(pp->icon, &img_arrow);
 }
 
 static int auto_scaned_cnt = 0;
-void submenu_enter(void)
-{
-	page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-	if(!pp) return;
+void submenu_enter(void) {
+    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
+    if (!pp)
+        return;
 
-	if(pp == &pp_scannow) {
-		auto_scaned_cnt = scan();
-		LOGI("scan return :%d", auto_scaned_cnt);
+    if (pp == &pp_scannow) {
+        auto_scaned_cnt = scan();
+        LOGI("scan return :%d", auto_scaned_cnt);
 
-		if(auto_scaned_cnt == 1) {
-			if(!g_autoscan_exit)
-				g_autoscan_exit = true;
+        if (auto_scaned_cnt == 1) {
+            if (!g_autoscan_exit)
+                g_autoscan_exit = true;
 
-			g_menu_op = OPLEVEL_VIDEO;
-			switch_to_video(false);
-		}
+            g_menu_op = OPLEVEL_VIDEO;
+            switch_to_video(false);
+        }
 
-		if(auto_scaned_cnt == -1)
-			submenu_exit();
+        if (auto_scaned_cnt == -1)
+            submenu_exit();
 
-		return;
-	}
-	else if(pp == &pp_playback) {
-		if(!init_pb())
-			submenu_exit(); //won't enter sub menu if no video file is found
-		return;
-	}
-	else if(pp == &pp_source) {
-		in_sourcepage = true;
-	}
-	else if(pp == &pp_version) {
-		version_update_title();
-	}
-	else if(pp==&pp_imagesettings) {
-		page_ims_click();
-	}
+        return;
+    } else if (pp == &pp_playback) {
+        if (!init_pb())
+            submenu_exit(); // won't enter sub menu if no video file is found
+        return;
+    } else if (pp == &pp_source) {
+        in_sourcepage = true;
+    } else if (pp == &pp_version) {
+        version_update_title();
+    } else if (pp == &pp_imagesettings) {
+        page_ims_click();
+    }
 
-	pp->p_arr.cur = 0;
-	set_select_item(&pp->p_arr, pp->p_arr.cur);
+    pp->p_arr.cur = 0;
+    set_select_item(&pp->p_arr, pp->p_arr.cur);
 }
 
-void submenu_nav(uint8_t key)
-{
-	page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-	if(!pp) return;
+void submenu_nav(uint8_t key) {
+    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
+    if (!pp)
+        return;
 
-	if(pp == &pp_scannow) user_select(key);
-	else if(pp == &pp_playback) pb_key(key);
-	else {
-		if(pp == &pp_version)
-			version_update_title();
+    if (pp == &pp_scannow)
+        user_select(key);
+    else if (pp == &pp_playback)
+        pb_key(key);
+    else {
+        if (pp == &pp_version)
+            version_update_title();
 
-		if(pp == &pp_record)
-			formatsd_negtive();
+        if (pp == &pp_record)
+            formatsd_negtive();
 
-		if(pp == &pp_connections)
-			page_connections_reset();
+        if (pp == &pp_connections)
+            page_connections_reset();
 
-		if(key == DIAL_KEY_UP) {
-			if(pp->p_arr.cur < pp->p_arr.max - 1)
-				pp->p_arr.cur++;
-			else
-				pp->p_arr.cur = 0;
-		}
-		else if(key == DIAL_KEY_DOWN) {
-			if(pp->p_arr.cur > 0)
-				pp->p_arr.cur--;
-			else
-				pp->p_arr.cur = pp->p_arr.max -1;
-		}
-		set_select_item(&pp->p_arr, pp->p_arr.cur);
-	}
+        if (key == DIAL_KEY_UP) {
+            if (pp->p_arr.cur < pp->p_arr.max - 1)
+                pp->p_arr.cur++;
+            else
+                pp->p_arr.cur = 0;
+        } else if (key == DIAL_KEY_DOWN) {
+            if (pp->p_arr.cur > 0)
+                pp->p_arr.cur--;
+            else
+                pp->p_arr.cur = pp->p_arr.max - 1;
+        }
+        set_select_item(&pp->p_arr, pp->p_arr.cur);
+    }
 }
 
-void submenu_exit()
-{
-	LOGI("submenu_exit");
-	g_menu_op = OPLEVEL_MAINMENU;
+void submenu_exit() {
+    LOGI("submenu_exit");
+    g_menu_op = OPLEVEL_MAINMENU;
 
-	page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-	if(!pp) return;
-	pp->p_arr.cur = 0;
+    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
+    if (!pp)
+        return;
+    pp->p_arr.cur = 0;
 
-	if(pp == &pp_playback)
-		pb_key(DIAL_KEY_PRESS);
-	else if(pp == &pp_scannow)
-		HDZero_Close();
-	else if(pp == &pp_source) {
-		pp_source_exit();
-		in_sourcepage = false;
-	}
-	else if(pp == &pp_record) {
-		formatsd_negtive();
-	}
+    if (pp == &pp_playback)
+        pb_key(DIAL_KEY_PRESS);
+    else if (pp == &pp_scannow)
+        HDZero_Close();
+    else if (pp == &pp_source) {
+        pp_source_exit();
+        in_sourcepage = false;
+    } else if (pp == &pp_record) {
+        formatsd_negtive();
+    }
 
-	//No need to remove the selected bar on ScanNow and Playback page
-	if((pp != &pp_scannow) && (pp != &pp_playback))
-		set_select_item(&pp->p_arr, -1);
+    // No need to remove the selected bar on ScanNow and Playback page
+    if ((pp != &pp_scannow) && (pp != &pp_playback))
+        set_select_item(&pp->p_arr, -1);
 }
 
-void submenu_fun(void)
-{
-	page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-	if(!pp) return;
+void submenu_fun(void) {
+    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
+    if (!pp)
+        return;
 
-	if(pp == &pp_scannow) {
-		g_menu_op = OPLEVEL_VIDEO;
-		switch_to_video(false);
-	}
-	else if(pp == &pp_playback) {
-		pb_key(DIAL_KEY_CLICK);
-	}
-	else
-	{
-		if((pp == &pp_fans) )
-		{
-			fans_mode_toggle(pp->p_arr.cur);
-		}
-		if((pp == &pp_source) )
-		{
-			source_mode_set(pp->p_arr.cur);
-		}
-		if((pp == &pp_autoscan) )
-		{
-			autoscan_toggle(pp->p_arr.cur);
-		}
-		if((pp == &pp_power) )
-		{
-			power_set_toggle(pp->p_arr.cur);
-		}
-		if((pp == &pp_connections) )
-		{
-			connect_function(pp->p_arr.cur);
-		}
-		if((pp == &pp_record) )
-		{
-			record_set_toggle(pp->p_arr.cur);
-		}
+    if (pp == &pp_scannow) {
+        g_menu_op = OPLEVEL_VIDEO;
+        switch_to_video(false);
+    } else if (pp == &pp_playback) {
+        pb_key(DIAL_KEY_CLICK);
+    } else {
+        if ((pp == &pp_fans)) {
+            fans_mode_toggle(pp->p_arr.cur);
+        }
+        if ((pp == &pp_source)) {
+            source_mode_set(pp->p_arr.cur);
+        }
+        if ((pp == &pp_autoscan)) {
+            autoscan_toggle(pp->p_arr.cur);
+        }
+        if ((pp == &pp_power)) {
+            power_set_toggle(pp->p_arr.cur);
+        }
+        if ((pp == &pp_connections)) {
+            connect_function(pp->p_arr.cur);
+        }
+        if ((pp == &pp_record)) {
+            record_set_toggle(pp->p_arr.cur);
+        }
 
-		if(pp == &pp_headtracker)
-		{
-			headtracker_set_toggle(pp->p_arr.cur);
-		}
+        if (pp == &pp_headtracker) {
+            headtracker_set_toggle(pp->p_arr.cur);
+        }
 
-		if((pp == &pp_version) )
-		{
-			version_update(pp->p_arr.cur);
-		}
+        if ((pp == &pp_version)) {
+            version_update(pp->p_arr.cur);
+        }
 
-
-		if(pp->p_arr.cur ==  pp->p_arr.max - 1)
-		{
-				submenu_exit();
-		}
-		else
-		{
-
-		}
-
-	}
+        if (pp->p_arr.cur == pp->p_arr.max - 1) {
+            submenu_exit();
+        } else {
+        }
+    }
 }
 
-void menu_nav(uint8_t key)
-{
-	static int8_t selected = 0;
-	LOGI("menu_nav: key = %d,sel = %d", key, selected);
-	if(key == DIAL_KEY_DOWN) {
-		selected--;
-		if(selected <0)
-			selected += MAIN_MENU_ITEMS;
-	}
-	else if(key == DIAL_KEY_UP) {
-		selected++;
-		if(selected >= MAIN_MENU_ITEMS)
-			selected -= MAIN_MENU_ITEMS;
-	}
-	lv_event_send(lv_obj_get_child(lv_obj_get_child(lv_menu_get_cur_sidebar_page(menu), 0), selected), LV_EVENT_CLICKED, NULL);
+void menu_nav(uint8_t key) {
+    static int8_t selected = 0;
+    LOGI("menu_nav: key = %d,sel = %d", key, selected);
+    if (key == DIAL_KEY_DOWN) {
+        selected--;
+        if (selected < 0)
+            selected += MAIN_MENU_ITEMS;
+    } else if (key == DIAL_KEY_UP) {
+        selected++;
+        if (selected >= MAIN_MENU_ITEMS)
+            selected -= MAIN_MENU_ITEMS;
+    }
+    lv_event_send(lv_obj_get_child(lv_obj_get_child(lv_menu_get_cur_sidebar_page(menu), 0), selected), LV_EVENT_CLICKED, NULL);
 }
 
-static void ui_create_rootpage(lv_obj_t * parent)
-{
-    lv_obj_t * cont;
-    lv_obj_t * section;
+static void ui_create_rootpage(lv_obj_t *parent) {
+    lv_obj_t *cont;
+    lv_obj_t *section;
 
     /*Create a root page*/
     root_page = lv_menu_page_create(parent, "aaa");
     section = lv_menu_section_create(root_page);
-	lv_obj_clear_flag(section, LV_OBJ_FLAG_SCROLLABLE);
-	lv_obj_add_event_cb(parent, menu_event_handler, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_obj_clear_flag(section, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_event_cb(parent, menu_event_handler, LV_EVENT_VALUE_CHANGED, NULL);
 
-	struct menu_obj_s s;
+    struct menu_obj_s s;
 
     create_text(&s, section, true, "Scan Now", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_scannow.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_scannow.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_scannow.page);
 
     create_text(&s, section, true, "Source", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_source.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_source.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_source.page);
 
     create_text(&s, section, true, "Image Settings", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_imagesettings.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_imagesettings.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_imagesettings.page);
 
     create_text(&s, section, true, "Power", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_power.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_power.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_power.page);
 
     create_text(&s, section, true, "Fans", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_fans.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_fans.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_fans.page);
 
     create_text(&s, section, true, "Record Options", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_record.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_record.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_record.page);
 
     create_text(&s, section, true, "Auto Scan", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_autoscan.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_autoscan.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_autoscan.page);
 
     create_text(&s, section, true, "Connections", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_connections.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_connections.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_connections.page);
 
     create_text(&s, section, true, "Head Tracker", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_headtracker.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_headtracker.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_headtracker.page);
 
     create_text(&s, section, true, "Playback", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_playback.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_playback.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_playback.page);
 
     create_text(&s, section, true, "Firmware", LV_MENU_ITEM_BUILDER_VARIANT_1);
-	pp_version.icon = s.icon;
-	cont = s.cont;
-	lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    pp_version.icon = s.icon;
+    cont = s.cont;
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
     lv_menu_set_load_page_event(parent, cont, pp_version.page);
 
-	lv_obj_add_style(section, &style_rootmenu, LV_PART_MAIN);
-	lv_obj_set_size(section, 250, 975);
-	lv_obj_set_pos(section, 0,0);
+    lv_obj_add_style(section, &style_rootmenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 250, 975);
+    lv_obj_set_pos(section, 0, 0);
 
-	lv_obj_set_size(root_page, 250, 975);
-	lv_obj_set_pos(root_page, 0,0);
-	lv_obj_set_style_border_width(root_page, 0, 0);
-	lv_obj_set_style_radius(root_page, 0, 0);
+    lv_obj_set_size(root_page, 250, 975);
+    lv_obj_set_pos(root_page, 0, 0);
+    lv_obj_set_style_border_width(root_page, 0, 0);
+    lv_obj_set_style_radius(root_page, 0, 0);
 
     lv_menu_set_sidebar_page(parent, root_page);
     lv_event_send(lv_obj_get_child(lv_obj_get_child(lv_menu_get_cur_sidebar_page(parent), 0), 0), LV_EVENT_CLICKED, NULL);
-	lv_obj_add_flag(lv_menu_get_sidebar_header(parent), LV_OBJ_FLAG_HIDDEN);
-	lv_obj_clear_flag(lv_menu_get_cur_sidebar_page(parent), LV_OBJ_FLAG_SCROLLABLE);
-
+    lv_obj_add_flag(lv_menu_get_sidebar_header(parent), LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lv_menu_get_cur_sidebar_page(parent), LV_OBJ_FLAG_SCROLLABLE);
 }
 
-static void menu_reinit(void)
-{
-	LOGI("reinit");
-	page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
-	if(!pp)
-		return;
+static void menu_reinit(void) {
+    LOGI("reinit");
+    page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
+    if (!pp)
+        return;
 
-	//LOGI("set select item");
+    // LOGI("set select item");
 
-	if((pp == &pp_scannow) )
-	{
-		scan_reinit();
-	}
-	else if((pp == &pp_source) )
-	{
-		set_select_item(&pp->p_arr, -1);
-	}
-	else if((pp == &pp_playback) )
-	{
+    if ((pp == &pp_scannow)) {
+        scan_reinit();
+    } else if ((pp == &pp_source)) {
+        set_select_item(&pp->p_arr, -1);
+    } else if ((pp == &pp_playback)) {
 
-	}
-	else
-	{
-		pp->p_arr.cur = -1;
-		set_select_item(&pp->p_arr, pp->p_arr.cur);
-	}
+    } else {
+        pp->p_arr.cur = -1;
+        set_select_item(&pp->p_arr, pp->p_arr.cur);
+    }
 }
 
-bool main_menu_isshow(void)
-{
-	return !lv_obj_has_flag(menu , LV_OBJ_FLAG_HIDDEN);
+bool main_menu_isshow(void) {
+    return !lv_obj_has_flag(menu, LV_OBJ_FLAG_HIDDEN);
 }
 
-void main_menu_show(bool is_show)
-{
-	if(is_show){
-		menu_reinit();
-		lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
-	}
-	else{
-		lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
-	}
+void main_menu_show(bool is_show) {
+    if (is_show) {
+        menu_reinit();
+        lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
+    }
 }
 
-void main_menu_toggle(void)
-{
+void main_menu_toggle(void) {
 
-	if(lv_obj_has_flag(menu , LV_OBJ_FLAG_HIDDEN)){
-		lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
-		menu_reinit();
-	}
-	else{
-		lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
-	}
+    if (lv_obj_has_flag(menu, LV_OBJ_FLAG_HIDDEN)) {
+        lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
+        menu_reinit();
+    } else {
+        lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
+    }
 }
 
-void main_menu_init(void)
-{
+void main_menu_init(void) {
     menu = lv_menu_create(lv_scr_act());
-	//lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
-	lv_obj_clear_flag(menu, LV_OBJ_FLAG_SCROLLABLE);
+    // lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(menu, LV_OBJ_FLAG_SCROLLABLE);
 
-	lv_obj_set_style_bg_color(menu, lv_color_make(32, 32, 32), 0);
-	lv_obj_set_style_border_width(menu, 3, 0);
-	lv_obj_set_style_border_color(menu, lv_color_make(255, 0, 0), 0);
-	lv_obj_set_style_border_side(menu, LV_BORDER_SIDE_LEFT|LV_BORDER_SIDE_RIGHT, 0);
-    lv_obj_set_size(menu, lv_disp_get_hor_res(NULL)-500, lv_disp_get_ver_res(NULL)-96);
-	lv_obj_set_pos(menu, 250,96);
+    lv_obj_set_style_bg_color(menu, lv_color_make(32, 32, 32), 0);
+    lv_obj_set_style_border_width(menu, 3, 0);
+    lv_obj_set_style_border_color(menu, lv_color_make(255, 0, 0), 0);
+    lv_obj_set_style_border_side(menu, LV_BORDER_SIDE_LEFT | LV_BORDER_SIDE_RIGHT, 0);
+    lv_obj_set_size(menu, lv_disp_get_hor_res(NULL) - 500, lv_disp_get_ver_res(NULL) - 96);
+    lv_obj_set_pos(menu, 250, 96);
 
-	pp_scannow.page = page_scannow_create(menu);
+    pp_scannow.page = page_scannow_create(menu);
 
-	if(g_test_en)
-		pp_source.p_arr.max = 6;
-	else
-		pp_source.p_arr.max = 5;
-	pp_source.page = page_source_create(menu, &pp_source.p_arr);
+    if (g_test_en)
+        pp_source.p_arr.max = 6;
+    else
+        pp_source.p_arr.max = 5;
+    pp_source.page = page_source_create(menu, &pp_source.p_arr);
 
-	pp_imagesettings.page = page_imagesettings_create(menu, &pp_imagesettings.p_arr);
-	pp_power.page = page_power_create(menu, &pp_power.p_arr);
-	pp_fans.page = page_fans_create(menu, &pp_fans.p_arr);
-	pp_record.page = page_record_create(menu, &pp_record.p_arr);
-	pp_autoscan.page = page_autoscan_create(menu, &pp_autoscan.p_arr);
-	pp_connections.page = page_connections_create(menu, &pp_connections.p_arr);
-	pp_headtracker.page = page_headtracker_create(menu, &pp_headtracker.p_arr);
-	pp_playback.page = page_playback_create(menu);
-	pp_version.page = page_version_create(menu, &pp_version.p_arr);
+    pp_imagesettings.page = page_imagesettings_create(menu, &pp_imagesettings.p_arr);
+    pp_power.page = page_power_create(menu, &pp_power.p_arr);
+    pp_fans.page = page_fans_create(menu, &pp_fans.p_arr);
+    pp_record.page = page_record_create(menu, &pp_record.p_arr);
+    pp_autoscan.page = page_autoscan_create(menu, &pp_autoscan.p_arr);
+    pp_connections.page = page_connections_create(menu, &pp_connections.p_arr);
+    pp_headtracker.page = page_headtracker_create(menu, &pp_headtracker.p_arr);
+    pp_playback.page = page_playback_create(menu);
+    pp_version.page = page_version_create(menu, &pp_version.p_arr);
 
-	ui_create_rootpage(menu);
+    ui_create_rootpage(menu);
 
-	progress_bar.bar = lv_bar_create(lv_scr_act());
+    progress_bar.bar = lv_bar_create(lv_scr_act());
     lv_obj_set_size(progress_bar.bar, 320, 20);
-	lv_obj_align(progress_bar.bar, LV_ALIGN_CENTER, 0, 0);
-	lv_obj_add_flag(progress_bar.bar, LV_OBJ_FLAG_HIDDEN);
-	progress_bar.start = 0;
-	progress_bar.val = 0;
+    lv_obj_align(progress_bar.bar, LV_ALIGN_CENTER, 0, 0);
+    lv_obj_add_flag(progress_bar.bar, LV_OBJ_FLAG_HIDDEN);
+    progress_bar.start = 0;
+    progress_bar.val = 0;
 }
 
-void progress_bar_update()
-{
-	static uint8_t state = 0; //0=idle, 1= in process
+void progress_bar_update() {
+    static uint8_t state = 0; // 0=idle, 1= in process
 
-	switch(state) {
-		case 0:
-			if(progress_bar.start) { //to start the progress bar
-				state = 1;
-				lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
-				lv_obj_clear_flag(progress_bar.bar, LV_OBJ_FLAG_HIDDEN);
-				progress_bar.val = 0;
-				//LOGI("Progress bar start");
-			}
-			break;
+    switch (state) {
+    case 0:
+        if (progress_bar.start) { // to start the progress bar
+            state = 1;
+            lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(progress_bar.bar, LV_OBJ_FLAG_HIDDEN);
+            progress_bar.val = 0;
+            // LOGI("Progress bar start");
+        }
+        break;
 
-		case 1:
-			if(progress_bar.start == 0) { //to end end progress bar
-				state = 0;
-				lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
-				lv_obj_add_flag(progress_bar.bar, LV_OBJ_FLAG_HIDDEN);
-				progress_bar.val = 0;
-				//LOGI("Progress bar end");
-			}
-			break;
-	}
+    case 1:
+        if (progress_bar.start == 0) { // to end end progress bar
+            state = 0;
+            lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(progress_bar.bar, LV_OBJ_FLAG_HIDDEN);
+            progress_bar.val = 0;
+            // LOGI("Progress bar end");
+        }
+        break;
+    }
 
-	if(state == 1) {
-		if(progress_bar.val <100)
-			progress_bar.val+=4;
-		lv_bar_set_value(progress_bar.bar, progress_bar.val, LV_ANIM_OFF);
-		lv_timer_handler();
-	}
+    if (state == 1) {
+        if (progress_bar.val < 100)
+            progress_bar.val += 4;
+        lv_bar_set_value(progress_bar.bar, progress_bar.val, LV_ANIM_OFF);
+        lv_timer_handler();
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void autoscan_exit(void)
-{
-	if(!g_autoscan_exit)
-	{
-		LOGI("autoscan_exit, lelve=1");
-		g_autoscan_exit = true;
-		if(auto_scaned_cnt >1)
-			g_menu_op = OPLEVEL_SUBMENU;
-		else
-			g_menu_op = OPLEVEL_MAINMENU;
-	}
+void autoscan_exit(void) {
+    if (!g_autoscan_exit) {
+        LOGI("autoscan_exit, lelve=1");
+        g_autoscan_exit = true;
+        if (auto_scaned_cnt > 1)
+            g_menu_op = OPLEVEL_SUBMENU;
+        else
+            g_menu_op = OPLEVEL_MAINMENU;
+    }
 }

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -88,7 +88,7 @@ void submenu_enter(void) {
     }
 }
 
-void submenu_nav(uint8_t key) {
+void submenu_roller(uint8_t key) {
     page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
     if (!pp) {
         return;
@@ -137,7 +137,7 @@ void submenu_exit() {
     }
 }
 
-void submenu_fun(void) {
+void submenu_click(void) {
     page_pack_t *pp = find_pp(lv_menu_get_cur_main_page(menu));
     if (!pp) {
         return;
@@ -169,99 +169,6 @@ void menu_nav(uint8_t key) {
             selected -= PAGE_MAX;
     }
     lv_event_send(lv_obj_get_child(lv_obj_get_child(lv_menu_get_cur_sidebar_page(menu), 0), selected), LV_EVENT_CLICKED, NULL);
-}
-
-static void ui_create_rootpage(lv_obj_t *parent) {
-    lv_obj_t *cont;
-    lv_obj_t *section;
-
-    /*Create a root page*/
-    root_page = lv_menu_page_create(parent, "aaa");
-    section = lv_menu_section_create(root_page);
-    lv_obj_clear_flag(section, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_add_event_cb(parent, menu_event_handler, LV_EVENT_VALUE_CHANGED, NULL);
-
-    struct menu_obj_s s;
-
-    create_text(&s, section, true, "Scan Now", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_scannow.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_scannow.page);
-
-    create_text(&s, section, true, "Source", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_source.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_source.page);
-
-    create_text(&s, section, true, "Image Settings", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_imagesettings.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_imagesettings.page);
-
-    create_text(&s, section, true, "Power", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_power.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_power.page);
-
-    create_text(&s, section, true, "Fans", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_fans.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_fans.page);
-
-    create_text(&s, section, true, "Record Options", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_record.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_record.page);
-
-    create_text(&s, section, true, "Auto Scan", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_autoscan.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_autoscan.page);
-
-    create_text(&s, section, true, "Connections", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_connections.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_connections.page);
-
-    create_text(&s, section, true, "Head Tracker", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_headtracker.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_headtracker.page);
-
-    create_text(&s, section, true, "Playback", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_playback.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_playback.page);
-
-    create_text(&s, section, true, "Firmware", LV_MENU_ITEM_BUILDER_VARIANT_1);
-    pp_version.icon = s.icon;
-    cont = s.cont;
-    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
-    lv_menu_set_load_page_event(parent, cont, pp_version.page);
-
-    lv_obj_add_style(section, &style_rootmenu, LV_PART_MAIN);
-    lv_obj_set_size(section, 250, 975);
-    lv_obj_set_pos(section, 0, 0);
-
-    lv_obj_set_size(root_page, 250, 975);
-    lv_obj_set_pos(root_page, 0, 0);
-    lv_obj_set_style_border_width(root_page, 0, 0);
-    lv_obj_set_style_radius(root_page, 0, 0);
-
-    lv_menu_set_sidebar_page(parent, root_page);
-    lv_event_send(lv_obj_get_child(lv_obj_get_child(lv_menu_get_cur_sidebar_page(parent), 0), 0), LV_EVENT_CLICKED, NULL);
-    lv_obj_add_flag(lv_menu_get_sidebar_header(parent), LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(lv_menu_get_cur_sidebar_page(parent), LV_OBJ_FLAG_SCROLLABLE);
 }
 
 static void menu_reinit(void) {
@@ -296,13 +203,23 @@ void main_menu_show(bool is_show) {
     }
 }
 
-void main_menu_toggle(void) {
-    if (lv_obj_has_flag(menu, LV_OBJ_FLAG_HIDDEN)) {
-        lv_obj_clear_flag(menu, LV_OBJ_FLAG_HIDDEN);
-        menu_reinit();
-    } else {
-        lv_obj_add_flag(menu, LV_OBJ_FLAG_HIDDEN);
-    }
+static void main_menu_create_entry(lv_obj_t *menu, lv_obj_t *section, const char *text, page_pack_t *pp) {
+    LOGD("creating main menu entry %s", text);
+
+    pp->page = pp->create(menu, &pp->p_arr);
+
+    lv_obj_t *cont = lv_menu_cont_create(section);
+
+    lv_obj_t *label = lv_label_create(cont);
+    lv_label_set_text(label, text);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_26, 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+
+    pp->icon = lv_img_create(cont);
+    lv_img_set_src(pp->icon, &img_arrow);
+
+    lv_obj_set_style_text_font(cont, &lv_font_montserrat_26, 0);
+    lv_menu_set_load_page_event(menu, cont, pp->page);
 }
 
 void main_menu_init(void) {
@@ -317,25 +234,37 @@ void main_menu_init(void) {
     lv_obj_set_size(menu, lv_disp_get_hor_res(NULL) - 500, lv_disp_get_ver_res(NULL) - 96);
     lv_obj_set_pos(menu, 250, 96);
 
-    pp_scannow.page = page_scannow_create(menu);
+    root_page = lv_menu_page_create(menu, "aaa");
 
-    if (g_test_en)
-        pp_source.p_arr.max = 6;
-    else
-        pp_source.p_arr.max = 5;
-    pp_source.page = page_source_create(menu, &pp_source.p_arr);
+    lv_obj_t *section = lv_menu_section_create(root_page);
+    lv_obj_clear_flag(section, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_event_cb(menu, menu_event_handler, LV_EVENT_VALUE_CHANGED, NULL);
 
-    pp_imagesettings.page = page_imagesettings_create(menu, &pp_imagesettings.p_arr);
-    pp_power.page = page_power_create(menu, &pp_power.p_arr);
-    pp_fans.page = page_fans_create(menu, &pp_fans.p_arr);
-    pp_record.page = page_record_create(menu, &pp_record.p_arr);
-    pp_autoscan.page = page_autoscan_create(menu, &pp_autoscan.p_arr);
-    pp_connections.page = page_connections_create(menu, &pp_connections.p_arr);
-    pp_headtracker.page = page_headtracker_create(menu, &pp_headtracker.p_arr);
-    pp_playback.page = page_playback_create(menu);
-    pp_version.page = page_version_create(menu, &pp_version.p_arr);
+    main_menu_create_entry(menu, section, "Scan Now", &pp_scannow);
+    main_menu_create_entry(menu, section, "Source", &pp_source);
+    main_menu_create_entry(menu, section, "Image Settings", &pp_imagesettings);
+    main_menu_create_entry(menu, section, "Power", &pp_power);
+    main_menu_create_entry(menu, section, "Fans", &pp_fans);
+    main_menu_create_entry(menu, section, "Record Options", &pp_record);
+    main_menu_create_entry(menu, section, "Auto Scan", &pp_autoscan);
+    main_menu_create_entry(menu, section, "Connections", &pp_connections);
+    main_menu_create_entry(menu, section, "Head Tracker", &pp_headtracker);
+    main_menu_create_entry(menu, section, "Playback", &pp_playback);
+    main_menu_create_entry(menu, section, "Firmware", &pp_version);
 
-    ui_create_rootpage(menu);
+    lv_obj_add_style(section, &style_rootmenu, LV_PART_MAIN);
+    lv_obj_set_size(section, 250, 975);
+    lv_obj_set_pos(section, 0, 0);
+
+    lv_obj_set_size(root_page, 250, 975);
+    lv_obj_set_pos(root_page, 0, 0);
+    lv_obj_set_style_border_width(root_page, 0, 0);
+    lv_obj_set_style_radius(root_page, 0, 0);
+
+    lv_menu_set_sidebar_page(menu, root_page);
+    lv_event_send(lv_obj_get_child(lv_obj_get_child(lv_menu_get_cur_sidebar_page(menu), 0), 0), LV_EVENT_CLICKED, NULL);
+    lv_obj_add_flag(lv_menu_get_sidebar_header(menu), LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lv_menu_get_cur_sidebar_page(menu), LV_OBJ_FLAG_SCROLLABLE);
 
     progress_bar.bar = lv_bar_create(lv_scr_act());
     lv_obj_set_size(progress_bar.bar, 320, 20);

--- a/src/ui/ui_main_menu.h
+++ b/src/ui/ui_main_menu.h
@@ -1,26 +1,27 @@
 #ifndef __MAIN_MENU_H__
 #define __MAIN_MENU_H__
 
-#define MAIN_MENU_ITEMS	    11
-
 #include <stdbool.h>
 #include <stdint.h>
-#include "lvgl/lvgl.h"
+
+#include <lvgl/lvgl.h>
+
 #include "ui/page_common.h"
 
-typedef struct {
-	lv_obj_t *page;
-	lv_obj_t *icon;
-
-	struct panel_arr p_arr;
-}page_pack_t;
-
+#define MAIN_MENU_ITEMS 11
 
 typedef struct {
-	lv_obj_t *bar;
-	int       start;
-	int	      val;
-}progress_bar_t;
+    lv_obj_t *page;
+    lv_obj_t *icon;
+
+    struct panel_arr p_arr;
+} page_pack_t;
+
+typedef struct {
+    lv_obj_t *bar;
+    int start;
+    int val;
+} progress_bar_t;
 
 extern progress_bar_t progress_bar;
 

--- a/src/ui/ui_main_menu.h
+++ b/src/ui/ui_main_menu.h
@@ -8,13 +8,32 @@
 
 #include "ui/page_common.h"
 
-#define MAIN_MENU_ITEMS 11
+typedef enum {
+    PAGE_AUTO_SCAN,
+    PAGE_CONNECTIONS,
+    PAGE_FANS,
+    PAGE_HEADTRACKER,
+    PAGE_IMAGE_SETTINGS,
+    PAGE_PLAYBACK,
+    PAGE_POWER,
+    PAGE_RECORD,
+    PAGE_SCAN_NOW,
+    PAGE_SOURCE,
+    PAGE_VERSION,
+
+    PAGE_MAX,
+} pages_t;
 
 typedef struct {
+    panel_arr_t p_arr;
+
     lv_obj_t *page;
     lv_obj_t *icon;
 
-    panel_arr_t p_arr;
+    void (*enter)();
+    void (*exit)();
+    void (*on_roller)(uint8_t key);
+    void (*on_click)(uint8_t key, int sel);
 } page_pack_t;
 
 typedef struct {
@@ -37,7 +56,5 @@ void submenu_exit();
 void submenu_enter();
 void submenu_fun(void);
 void progress_bar_update();
-
-void autoscan_exit(void);
 
 #endif

--- a/src/ui/ui_main_menu.h
+++ b/src/ui/ui_main_menu.h
@@ -30,6 +30,7 @@ typedef struct {
     lv_obj_t *page;
     lv_obj_t *icon;
 
+    lv_obj_t *(*create)(lv_obj_t *parent, panel_arr_t *arr);
     void (*enter)();
     void (*exit)();
     void (*on_roller)(uint8_t key);
@@ -51,10 +52,10 @@ bool main_menu_isshow(void);
 
 void menu_nav(uint8_t key);
 
-void submenu_nav(uint8_t key);
-void submenu_exit();
 void submenu_enter();
-void submenu_fun(void);
+void submenu_exit();
+void submenu_roller(uint8_t key);
+void submenu_click(void);
 void progress_bar_update();
 
 #endif

--- a/src/ui/ui_main_menu.h
+++ b/src/ui/ui_main_menu.h
@@ -14,7 +14,7 @@ typedef struct {
     lv_obj_t *page;
     lv_obj_t *icon;
 
-    struct panel_arr p_arr;
+    panel_arr_t p_arr;
 } page_pack_t;
 
 typedef struct {


### PR DESCRIPTION
this pr reworks the page pack interface to allow specifying handler functions for different page interactions,
this moves the complexity out of the main menu file and into the page files where the rest of logic usually resides.
this allows for generic handling of all pages in main_menu, greatly simplifying the process of adding new pages.

additionally:
- formats all page files 
- tidies some type definitions

for review i recommend skipping the first commit, it does not change any logic, but only formats the file according to the clang-format file

