### PR TITLE
add delay to sensor module loads

### DIFF
--- a/mkapp/app/script/rc.sh
+++ b/mkapp/app/script/rc.sh
@@ -36,8 +36,11 @@ write_flashes
 config_uart_vdpo
 
 #load driver 
-insmod /mnt/app//ko/mcp3021.ko
-insmod /mnt/app//ko/nct75.ko
+insmod /mnt/app/ko/mcp3021.ko
+usleep 2000
+insmod /mnt/app/ko/nct75.ko
+usleep 2000
+
 #set Microphone Bias Control Register
 aww 0x050967c0 0x110e6100
 


### PR DESCRIPTION
the goggle application relies on the mcp3021 being registered _first_ so it gets assigned `device0` in the dev fs.
insmod is async, so when both load commands are sent back to back there is a good chance nct75 is assigned `device0`.
this PR adds a flat delay, mitigating the biggest risk. a better solution would be to have the application search the `name` files in the dev-fs.