### PR TITLE
Common CFLAGS are now stored in toolchain.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,16 +16,7 @@ set(STANDARD_LIBRARIES
 	rt
 	stdc++
 )
-set(COMMON_COMPILE_OPTIONS
-	-O3
-	-mfpu=neon
-	-mfloat-abi=hard
-	-Wno-unused-function
-	-Wno-unused-variable
-	-ffunction-sections
-	-fdata-sections 
-	-Wl,-gc-sections
-)
+
 add_definitions(
 	-DAWCHIP=AW_V5 
 	-D_GNU_SOURCE 
@@ -57,7 +48,6 @@ add_executable(${PROJECT_NAME}
 	${SRC_FILES_WINDOW}
 	${SRC_FILES_PLAYER}
 )
-target_compile_options(${PROJECT_NAME} PRIVATE ${COMMON_COMPILE_OPTIONS})
 target_include_directories(${PROJECT_NAME} PRIVATE 
 	src/
 	src/core

--- a/lib/esp-loader/CMakeLists.txt
+++ b/lib/esp-loader/CMakeLists.txt
@@ -2,6 +2,5 @@ file(GLOB SRC_FILES "src/*.c")
 
 add_library(esp-loader OBJECT ${SRC_FILES})
 target_compile_definitions(esp-loader PUBLIC -DMD5_ENABLED=1)
-target_compile_options(esp-loader PRIVATE ${COMMON_COMPILE_OPTIONS})
 target_include_directories(esp-loader PUBLIC include)
 target_include_directories(esp-loader PRIVATE private_include)

--- a/lib/log/CMakeLists.txt
+++ b/lib/log/CMakeLists.txt
@@ -1,5 +1,4 @@
 file(GLOB SRC_FILES "src/*.c")
 
 add_library(log OBJECT ${SRC_FILES})
-target_compile_options(log PRIVATE ${COMMON_COMPILE_OPTIONS})
 target_include_directories(log PUBLIC include)

--- a/lib/lvgl/CMakeLists.txt
+++ b/lib/lvgl/CMakeLists.txt
@@ -1,6 +1,5 @@
 file(GLOB_RECURSE SRC_FILES_LVGL "lvgl/*.c")
 
 add_library(lvgl OBJECT ${SRC_FILES_LVGL})
-target_compile_options(lvgl PRIVATE ${COMMON_COMPILE_OPTIONS})
 target_include_directories(lvgl PUBLIC .)
 target_include_directories(lvgl PRIVATE src)

--- a/lib/minIni/CMakeLists.txt
+++ b/lib/minIni/CMakeLists.txt
@@ -2,4 +2,3 @@ file(GLOB SRC_FILES "src/*.c" "src/*.h")
 
 add_library(minIni OBJECT ${SRC_FILES})
 target_include_directories(minIni PUBLIC src)
-target_compile_options(minIni PRIVATE ${COMMON_COMPILE_OPTIONS})

--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -1,12 +1,13 @@
+cmake_minimum_required(VERSION 3.13.0)
+
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
- 
+
 set(TOOLS ${PROJECT_SOURCE_DIR}/toolchain)
 set(CMAKE_C_COMPILER "${TOOLS}/bin/arm-openwrt-linux-muslgnueabi-gcc")
 set(CMAKE_CXX_COMPILER "${TOOLS}/bin/arm-openwrt-linux-muslgnueabi-g++")
 set(CMAKE_AR "${TOOLS}/bin/arm-openwrt-linux-muslgnueabi-ar")
 set(CMAKE_LD "${TOOLS}/bin/arm-openwrt-linux-muslgnueabi-ld")
 
-cmake_minimum_required(VERSION 3.13.0)
- 
-add_compile_options(-Wall)
+set(CMAKE_C_FLAGS "-Wall -O3 -mfpu=neon -mfloat-abi=hard -Wno-unused-function -Wno-unused-variable -ffunction-sections -fdata-sections -Wl,-gc-sections")
+


### PR DESCRIPTION
Allows 3rd party libraries build with common settings.