### PR TITLE
Implement Head Tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ file(GLOB SRC_FILES_UI   "src/ui/*.c" "src/ui/*.h")
 file(GLOB SRC_FILES_BMI   "src/bmi270/*.c" "src/bmi270/*.h")
 file(GLOB SRC_FILES_WINDOW "src/window/*.c" "src/window/*.h")
 file(GLOB SRC_FILES_PLAYER "src/player/*.c" "src/player/*.h")
+file(GLOB SRC_FILES_UTIL "src/util/*.c" "src/util/*.h")
 
 add_executable(${PROJECT_NAME}
 	${SRC_FILES_CORE}
@@ -47,6 +48,7 @@ add_executable(${PROJECT_NAME}
 	${SRC_FILES_BMI}
 	${SRC_FILES_WINDOW}
 	${SRC_FILES_PLAYER}
+	${SRC_FILES_UTIL}
 )
 target_include_directories(${PROJECT_NAME} PRIVATE 
 	src/

--- a/src/core/MadgwickAHRS.c
+++ b/src/core/MadgwickAHRS.c
@@ -21,7 +21,7 @@
 //---------------------------------------------------------------------------------------------------
 // Definitions
 
-#define sampleFreq	512.0f		// sample frequency in Hz
+#define sampleFreq	100.0f		// sample frequency in Hz
 #define betaDef		0.1f		// 2 * proportional gain
 
 //---------------------------------------------------------------------------------------------------
@@ -39,10 +39,11 @@ static char anglesComputed = 0;
 
 float invSqrt(float x) {
 	float halfx = 0.5f * x;
-	float y = x;
-	long i = *(long*)&y;
-	i = 0x5f3759df - (i >> 1);
-	y = *(float*)&i;
+	union { float f; long l; } i;
+	i.f = x;
+	i.l = 0x5f3759df - (i.l >> 1);
+	float y = i.f;
+	y = y * (1.5f - (halfx * y * y));
 	y = y * (1.5f - (halfx * y * y));
 	return y;
 }

--- a/src/core/defines.h
+++ b/src/core/defines.h
@@ -8,7 +8,8 @@ typedef enum{
     OPLEVEL_VIDEO = 10,
     OPLEVEL_IMS = 11,
     PAGE_FAN_SLIDE = 100,
-    PAGE_POWER_SLIDE = 102
+    PAGE_ANGLE_SLIDE = 101,
+    PAGE_POWER_SLIDE = 102,
 } op_level_t ;
 
 typedef enum{

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -160,10 +160,6 @@ void init_ht()
     ht_data.rollInverse = -1; 
     ht_data.panInverse = -1; 
 
-    ht_data.tiltFactor = 500.0/180.0;
-    ht_data.rollFactor = 500.0/180.0;
-    ht_data.panFactor = 500.0/180.0;
-    
     ht_data.tiltMaxPulse = 500;
     ht_data.tiltMinPulse = -500; 
     ht_data.tiltCenter = 1500; 
@@ -179,6 +175,7 @@ void init_ht()
     ht_data.htChannels[2] = 0;
     
     ht_data.enable = 0;
+    set_maxangle_ht(g_setting.ht.max_angle);
     ht_data.acc_offset[0] = g_setting.ht.acc_x;
     ht_data.acc_offset[1] = g_setting.ht.acc_y;
     ht_data.acc_offset[2] = g_setting.ht.acc_z;
@@ -208,6 +205,13 @@ void init_ht()
     if (res != 0){
         LOGE("Error timer_settime: %s\n", strerror(errno));
     }
+}
+
+void set_maxangle_ht(int angle)
+{
+    ht_data.tiltFactor = 1000.0 / angle;
+    ht_data.rollFactor = 1000.0 / angle;
+    ht_data.panFactor = 1000.0 / angle;
 }
 
 // Rotate, in Order X -> Y -> Z

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -213,31 +213,31 @@ void set_maxangle_ht(int angle)
 // Rotate, in Order X -> Y -> Z
 static void rotate(float pn[3], const float rot[3])
 {
-  float out[3];
+    float out[3];
 
-  // X-axis Rotation
-  if (rot[0] != 0) {
-    out[0] = pn[0] * 1 + pn[1] * 0 + pn[2] * 0;
-    out[1] = pn[0] * 0 + pn[1] * cos(rot[0]) - pn[2] * sin(rot[0]);
-    out[2] = pn[0] * 0 + pn[1] * sin(rot[0]) + pn[2] * cos(rot[0]);
-    memcpy(pn, out, sizeof(out[0]) * 3);
-  }
+    // X-axis Rotation
+    if (rot[0] != 0) {
+        out[0] = pn[0] * 1 + pn[1] * 0 + pn[2] * 0;
+        out[1] = pn[0] * 0 + pn[1] * cos(rot[0]) - pn[2] * sin(rot[0]);
+        out[2] = pn[0] * 0 + pn[1] * sin(rot[0]) + pn[2] * cos(rot[0]);
+        memcpy(pn, out, sizeof(out[0]) * 3);
+    }
 
-  // Y-axis Rotation
-  if (rot[1] != 0) {
-    out[0] = pn[0] * cos(rot[1]) - pn[1] * 0 + pn[2] * sin(rot[1]);
-    out[1] = pn[0] * 0 + pn[1] * 1 + pn[2] * 0;
-    out[2] = -pn[0] * sin(rot[1]) + pn[1] * 0 + pn[2] * cos(rot[1]);
-    memcpy(pn, out, sizeof(out[0]) * 3);
-  }
+    // Y-axis Rotation
+    if (rot[1] != 0) {
+        out[0] = pn[0] * cos(rot[1]) - pn[1] * 0 + pn[2] * sin(rot[1]);
+        out[1] = pn[0] * 0 + pn[1] * 1 + pn[2] * 0;
+        out[2] = -pn[0] * sin(rot[1]) + pn[1] * 0 + pn[2] * cos(rot[1]);
+        memcpy(pn, out, sizeof(out[0]) * 3);
+    }
 
-  // Z-axis Rotation
-  if (rot[2] != 0) {
-    out[0] = pn[0] * cos(rot[2]) - pn[1] * sin(rot[2]) + pn[2] * 0;
-    out[1] = pn[0] * sin(rot[2]) + pn[1] * cos(rot[2]) + pn[2] * 0;
-    out[2] = pn[0] * 0 + pn[1] * 0 + pn[2] * 1;
-    memcpy(pn, out, sizeof(out[0]) * 3);
-  }
+    // Z-axis Rotation
+    if (rot[2] != 0) {
+        out[0] = pn[0] * cos(rot[2]) - pn[1] * sin(rot[2]) + pn[2] * 0;
+        out[1] = pn[0] * sin(rot[2]) + pn[1] * cos(rot[2]) + pn[2] * 0;
+        out[2] = pn[0] * 0 + pn[1] * 0 + pn[2] * 1;
+        memcpy(pn, out, sizeof(out[0]) * 3);
+    }
 }
 
 static void calc_gyr(float* gyrAngle) //in degree
@@ -271,11 +271,11 @@ static int constrain(int value, int min, int max)
 // by assuming the range wraps around when going below min or above max
 static float normalize(float value, float start, float end)
 {
-  float width = end - start;          //
-  float offsetValue = value - start;  // value relative to 0
+    float width = end - start;          //
+    float offsetValue = value - start;  // value relative to 0
 
-  return (offsetValue - (floor(offsetValue / width) * width)) + start;
-  // + start to reset back to start of original range
+    return (offsetValue - (floor(offsetValue / width) * width)) + start;
+    // + start to reset back to start of original range
 }
 
 void calibrate_ht()
@@ -336,9 +336,9 @@ int calc_ht()
                           accAngle[0],              accAngle[1],              accAngle[2]);
 
     // Adjust PTR relatice to user specified home position
-	ht_data.panAngle = getYaw() - ht_data.panAngleHome;
-	ht_data.tiltAngle = getPitch() - ht_data.tiltAngleHome;
-	ht_data.rollAngle = getRoll() - ht_data.rollAngleHome;
+    ht_data.panAngle = getYaw() - ht_data.panAngleHome;
+    ht_data.tiltAngle = getPitch() - ht_data.tiltAngleHome;
+    ht_data.rollAngle = getRoll() - ht_data.rollAngleHome;
 
     tmp = normalize(ht_data.panAngle, -180.0, 180.0) * ht_data.panInverse * ht_data.panFactor + 0.5;
     ht_data.htChannels[0] = constrain(tmp, ppmMinPulse, ppmMaxPulse) + ppmCenter;
@@ -350,7 +350,7 @@ int calc_ht()
     ht_data.htChannels[2] = constrain(tmp, ppmMinPulse, ppmMaxPulse) + ppmCenter;
 
     Set_HT_dat(ht_data.htChannels[0], ht_data.htChannels[1], ht_data.htChannels[2]);
-	return 1;
+    return 1;
 }
 
 void set_center_position_ht()

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -30,7 +30,7 @@ static uint8_t sync_len = 200;
 static volatile bool calibrating = false;
 static int calibration_count = 0;
 
-static const float imu_orientation[3] = {0.0 * DEG_TO_RAD, -90.0 * DEG_TO_RAD, (-90.0+22.0) * DEG_TO_RAD};
+static const float imu_orientation[3] = {0.0 * DEG_TO_RAD, -90.0 * DEG_TO_RAD, (-90.0+23.0) * DEG_TO_RAD};
 
 static const int ppmMaxPulse = 500;
 static const int ppmMinPulse = -500; 

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -1,6 +1,4 @@
 #include <stdio.h>
-#include <math.h>
-#include <memory.h>
 #include <unistd.h>
 #include <time.h>
 #include <signal.h>
@@ -20,6 +18,7 @@
 #include "driver/dm6302.h"
 #include "driver/oled.h"
 #include "ui/page_common.h"
+#include "util/math.h"
 
 //#define FAST_SIM
 ///////////////////////////////////////////////////////////////////////////////
@@ -210,36 +209,6 @@ void set_maxangle_ht(int angle)
     ht_data.panFactor = 1000.0 / angle;
 }
 
-// Rotate, in Order X -> Y -> Z
-static void rotate(float pn[3], const float rot[3])
-{
-    float out[3];
-
-    // X-axis Rotation
-    if (rot[0] != 0) {
-        out[0] = pn[0] * 1 + pn[1] * 0 + pn[2] * 0;
-        out[1] = pn[0] * 0 + pn[1] * cos(rot[0]) - pn[2] * sin(rot[0]);
-        out[2] = pn[0] * 0 + pn[1] * sin(rot[0]) + pn[2] * cos(rot[0]);
-        memcpy(pn, out, sizeof(out[0]) * 3);
-    }
-
-    // Y-axis Rotation
-    if (rot[1] != 0) {
-        out[0] = pn[0] * cos(rot[1]) - pn[1] * 0 + pn[2] * sin(rot[1]);
-        out[1] = pn[0] * 0 + pn[1] * 1 + pn[2] * 0;
-        out[2] = -pn[0] * sin(rot[1]) + pn[1] * 0 + pn[2] * cos(rot[1]);
-        memcpy(pn, out, sizeof(out[0]) * 3);
-    }
-
-    // Z-axis Rotation
-    if (rot[2] != 0) {
-        out[0] = pn[0] * cos(rot[2]) - pn[1] * sin(rot[2]) + pn[2] * 0;
-        out[1] = pn[0] * sin(rot[2]) + pn[1] * cos(rot[2]) + pn[2] * 0;
-        out[2] = pn[0] * 0 + pn[1] * 0 + pn[2] * 1;
-        memcpy(pn, out, sizeof(out[0]) * 3);
-    }
-}
-
 static void calc_gyr(float* gyrAngle) //in degree
 {
     // convert gyro readings to degrees/sec (with calibration offsets)
@@ -256,26 +225,6 @@ static void calc_acc(float* accAngle) //in G
     accAngle[1] = acc_to_g(ht_data.sensor_data.acc.y);
     accAngle[2] = acc_to_g(ht_data.sensor_data.acc.z);
     rotate(accAngle, imu_orientation);
-}
-
-static int constrain(int value, int min, int max)
-{
-    if (value < min)
-        return min;
-    if (value > max)
-        return max;
-    return value;
-}
-
-// Normalizes any number to an arbitrary range
-// by assuming the range wraps around when going below min or above max
-static float normalize(float value, float start, float end)
-{
-    float width = end - start;          //
-    float offsetValue = value - start;  // value relative to 0
-
-    return (offsetValue - (floor(offsetValue / width) * width)) + start;
-    // + start to reset back to start of original range
 }
 
 void calibrate_ht()

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -84,7 +84,7 @@ void detect_motion(int is_moving)
                 
                 OLED_ON(0); //Turn off OLED
 
-                if(g_hw_stat.source_mode ==1) 
+                if(g_hw_stat.source_mode == HW_SRC_MODE_HDZERO) 
                     HDZero_Close(); //Turn off RF
 
                 state = 2;
@@ -101,7 +101,7 @@ void detect_motion(int is_moving)
             if(cnt == 2) {
                 state = 0;
                 cnt = 0;
-                if(g_hw_stat.source_mode ==1) {
+                if(g_hw_stat.source_mode == HW_SRC_MODE_HDZERO) {
                     HDZero_open();
                     uint8_t ch = g_setting.scan.channel - 1;
 	                DM6302_SetChannel(ch);

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <errno.h>
 
+#include <minIni.h>
 #include <log/log.h>
 
 #include "common.hh"
@@ -177,8 +178,13 @@ void init_ht()
     ht_data.htChannels[1] = 0;
     ht_data.htChannels[2] = 0;
     
-    ht_data.is_calibrated = 0;
     ht_data.enable = 0;
+    ht_data.acc_offset[0] = g_setting.ht.acc_x;
+    ht_data.acc_offset[1] = g_setting.ht.acc_y;
+    ht_data.acc_offset[2] = g_setting.ht.acc_z;
+    ht_data.gyr_offset[0] = g_setting.ht.gyr_x;
+    ht_data.gyr_offset[1] = g_setting.ht.gyr_y;
+    ht_data.gyr_offset[2] = g_setting.ht.gyr_z;
 
     // start timer
     timer_t timerId = 0;
@@ -282,6 +288,13 @@ void calibrate_ht()
     ht_data.gyr_offset[0] >>= CALIBRATION_BCNT;
     ht_data.gyr_offset[1] >>= CALIBRATION_BCNT;
     ht_data.gyr_offset[2] >>= CALIBRATION_BCNT;
+
+    ini_putl("ht", "acc_x", ht_data.acc_offset[0], SETTING_INI);
+    ini_putl("ht", "acc_y", ht_data.acc_offset[1], SETTING_INI);
+    ini_putl("ht", "acc_z", ht_data.acc_offset[2], SETTING_INI);
+    ini_putl("ht", "gyr_x", ht_data.gyr_offset[0], SETTING_INI);
+    ini_putl("ht", "gyr_y", ht_data.gyr_offset[1], SETTING_INI);
+    ini_putl("ht", "gyr_z", ht_data.gyr_offset[2], SETTING_INI);
 
     LOGI("done!");
 }

--- a/src/core/ht.h
+++ b/src/core/ht.h
@@ -20,37 +20,34 @@ typedef struct {
     int32_t gyr_offset[3];
 
     // Final angles for headtracker
-    float tiltAngle;      
-    float tiltAngleLP;    
+    float tiltAngle;
+    float tiltAngleHome;
 
-    float rollAngle;       
-    float rollAngleLP;    
+    float rollAngle;
+    float rollAngleHome;
 
-    float panAngle;       
-    float panAngleLP;     
-
-    float tiltRollBeta;
-    float panBeta; 
+    float panAngle;
+    float panAngleHome;
 
     // Servo settings
-    uint8_t tiltInverse;  //1= inverted
-    uint8_t rollInverse;
-    uint8_t panInverse;
+    int8_t tiltInverse; // -1= inverted
+    int8_t rollInverse;
+    int8_t panInverse;
 
     float   tiltFactor; //Gain
-    float   rollFactor;       
+    float   rollFactor;
     float   panFactor;
 
     //PPM setting
-    int16_t tiltMaxPulse; 
-    int16_t tiltMinPulse; 
-    int16_t tiltCenter; 
+    int16_t tiltMaxPulse;
+    int16_t tiltMinPulse;
+    int16_t tiltCenter;
     int16_t panMaxPulse;
-    int16_t panMinPulse; 
-    int16_t panCenter; 
+    int16_t panMinPulse;
+    int16_t panCenter;
     int16_t rollMaxPulse;
-    int16_t rollMinPulse; 
-    int16_t rollCenter; 
+    int16_t rollMinPulse;
+    int16_t rollCenter;
 
     int16_t htChannels[3]; //0=Pan, 1=tilt, 2=roll
     
@@ -65,8 +62,10 @@ void init_ht();
 void enable_ht();
 void disable_ht();
 void calibrate_ht();
+void set_center_position_ht();
 int calc_ht();
 void get_imu_data(int bCalcDiff);
+int16_t* get_ht_channels();
 
 
 #endif //__HT_C__

--- a/src/core/ht.h
+++ b/src/core/ht.h
@@ -52,7 +52,6 @@ typedef struct {
     int16_t htChannels[3]; //0=Pan, 1=tilt, 2=roll
     
     // internal state
-    uint8_t is_calibrated;
     uint8_t enable;
 	
 } ht_data_t;

--- a/src/core/ht.h
+++ b/src/core/ht.h
@@ -39,16 +39,6 @@ typedef struct {
     float   panFactor;
 
     //PPM setting
-    int16_t tiltMaxPulse;
-    int16_t tiltMinPulse;
-    int16_t tiltCenter;
-    int16_t panMaxPulse;
-    int16_t panMinPulse;
-    int16_t panCenter;
-    int16_t rollMaxPulse;
-    int16_t rollMinPulse;
-    int16_t rollCenter;
-
     int16_t htChannels[3]; //0=Pan, 1=tilt, 2=roll
     
     // internal state

--- a/src/core/ht.h
+++ b/src/core/ht.h
@@ -61,6 +61,7 @@ void init_ht();
 void enable_ht();
 void disable_ht();
 void calibrate_ht();
+void set_maxangle_ht(int angle);
 void set_center_position_ht();
 int calc_ht();
 void get_imu_data(int bCalcDiff);

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -23,6 +23,7 @@
 #include "ui/page_scannow.h"
 #include "ui/page_common.h"
 #include "ui/page_fans.h"
+#include "ui/page_headtracker.h"
 #include "ui/page_power.h"
 #include "ui/page_imagesettings.h"
 #include "ui/page_playback.h"
@@ -239,6 +240,10 @@ static void btn_click(void)  //short press enter key
 	{ 
 		submenu_click();	
 	}
+	else if(g_menu_op == PAGE_ANGLE_SLIDE)
+	{ 
+		submenu_click();	
+	}
 	else if(g_menu_op == PAGE_POWER_SLIDE)
 	{ 
 		submenu_click();	
@@ -273,6 +278,10 @@ static void roller_up(void)
 	else if(g_menu_op == PAGE_FAN_SLIDE)
 	{
 		fans_speed_dec();
+	}
+	else if(g_menu_op == PAGE_ANGLE_SLIDE)
+	{
+		ht_angle_dec();
 	}
 	else if(g_menu_op == PAGE_POWER_SLIDE)
 	{
@@ -309,6 +318,10 @@ static void roller_down(void)
 	else if(g_menu_op == PAGE_FAN_SLIDE)
 	{
 		fans_speed_inc();
+	}
+	else if(g_menu_op == PAGE_ANGLE_SLIDE)
+	{
+		ht_angle_inc();
 	}
 	else if(g_menu_op == PAGE_POWER_SLIDE)
 	{

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -126,11 +126,7 @@ static void load_ini_setting(void)
 	g_setting.image.contrast = atoi(str);
   	ini_gets("image", "auto_off", "2", str, sizeof(str), SETTING_INI);
 	g_setting.image.auto_off = atoi(str);
-
 	g_setting.ht.enable = ini_getl("ht", "enable", 0, SETTING_INI);
-	if(!g_setting.ht.enable) 
-			disable_ht();
-
 	g_setting.elrs.enable = ini_getl("elrs", "enable", 0, SETTING_INI);
 
 	//Check
@@ -274,9 +270,16 @@ int main(int argc, char* argv[])
 
 	esp32_init();
 	elrs_init();
+	init_ht();
 
 	start_running(); //start to run from saved settings
 	create_threads();
+
+	if(g_setting.ht.enable)
+		enable_ht();
+	else
+		disable_ht();
+
 	g_init_done = 1;
 	for(;;)
 	{

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -127,6 +127,7 @@ static void load_ini_setting(void)
   	ini_gets("image", "auto_off", "2", str, sizeof(str), SETTING_INI);
 	g_setting.image.auto_off = atoi(str);
 	g_setting.ht.enable = ini_getl("ht", "enable", 0, SETTING_INI);
+	g_setting.ht.max_angle = ini_getl("ht", "max_angle", 120, SETTING_INI);
 	g_setting.ht.acc_x = ini_getl("ht", "acc_x", 0, SETTING_INI);
 	g_setting.ht.acc_y = ini_getl("ht", "acc_y", 0, SETTING_INI);
 	g_setting.ht.acc_z = ini_getl("ht", "acc_z", 0, SETTING_INI);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -127,6 +127,12 @@ static void load_ini_setting(void)
   	ini_gets("image", "auto_off", "2", str, sizeof(str), SETTING_INI);
 	g_setting.image.auto_off = atoi(str);
 	g_setting.ht.enable = ini_getl("ht", "enable", 0, SETTING_INI);
+	g_setting.ht.acc_x = ini_getl("ht", "acc_x", 0, SETTING_INI);
+	g_setting.ht.acc_y = ini_getl("ht", "acc_y", 0, SETTING_INI);
+	g_setting.ht.acc_z = ini_getl("ht", "acc_z", 0, SETTING_INI);
+	g_setting.ht.gyr_x = ini_getl("ht", "gyr_x", 0, SETTING_INI);
+	g_setting.ht.gyr_y = ini_getl("ht", "gyr_y", 0, SETTING_INI);
+	g_setting.ht.gyr_z = ini_getl("ht", "gyr_z", 0, SETTING_INI);
 	g_setting.elrs.enable = ini_getl("elrs", "enable", 0, SETTING_INI);
 
 	//Check

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -12,7 +12,6 @@
 
 #include "common.hh"
 #include "defines.h"
-#include "ht.h"
 #include "input_device.h"
 #include "msp_displayport.h"
 #include "osd.h"
@@ -55,22 +54,6 @@ static void detect_sdcard(void)
 		g_sdcard_det_req = 0;
 	}
 	sdcard_enable_last = g_sdcard_enable;
-}
-
-static void *thread_imu(void *ptr)
-{
-	int cnt = 0;
-	for(;;)
-	{
-		get_imu_data(true);
-		calc_ht();
-		if(cnt++ == 9) {
-			cnt = 0;
-			seconds++;
-		}
-		usleep(100000); //0.1s
-	}
-	return NULL;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -194,7 +177,6 @@ static void threads_instance(threads_obj_t *obj)
 	obj->instance[0] =  thread_peripheral;
 	obj->instance[1] =  thread_version;
 	obj->instance[2] =  thread_osd;
-	obj->instance[3] =  thread_imu;
 }
 
 int create_threads()

--- a/src/core/thread.h
+++ b/src/core/thread.h
@@ -5,7 +5,7 @@
 #include <pthread.h>
 
 #define THREAD_COUNT_MAX (10)
-#define THREAD_COUNT (4)
+#define THREAD_COUNT (3)
 
 typedef void *(*fun_thread_instance_t)(void *params);
 

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -174,6 +174,22 @@ lv_obj_t *create_label_item(lv_obj_t *parent, const char *name, int col, int row
     return label;
 }
 
+lv_obj_t *create_info_item(lv_obj_t *parent, const char *name, int col, int row, int cols) {
+    lv_obj_t *label = lv_label_create(parent);
+    lv_label_set_text(label, name);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
+    lv_obj_set_style_pad_top(label, 12, 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_set_size(label, 320 * cols, 40);
+
+    lv_label_set_recolor(label, true);
+
+    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, col, cols,
+                         LV_GRID_ALIGN_CENTER, row, 1);
+    return label;
+}
+
 void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const char *name, int range, int default_value, int row) {
     lv_obj_t *label = lv_label_create(parent);
     lv_label_set_text(label, name);

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -109,6 +109,7 @@ typedef struct {
 
 typedef struct {
     int enable;
+    int max_angle;
     int32_t acc_x;
     int32_t acc_y;
     int32_t acc_z;

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -109,6 +109,12 @@ typedef struct {
 
 typedef struct {
     int enable;
+    int32_t acc_x;
+    int32_t acc_y;
+    int32_t acc_z;
+    int32_t gyr_x;
+    int32_t gyr_y;
+    int32_t gyr_z;
 } head_tracker_t;
 
 typedef struct {

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -211,6 +211,8 @@ void create_btn_item(lv_obj_t *parent, const char *name, int col, int row);
 
 lv_obj_t *create_label_item(lv_obj_t *parent, const char *name, int col, int row, int cols);
 
+lv_obj_t *create_info_item(lv_obj_t *parent, const char *name, int col, int row, int cols);
+
 void create_btn_group_item(btn_group_t *btn_group, lv_obj_t *parent, int count, const char *name, const char *name0, const char *name1,
                            const char *name2, const char *name3, int row);
 

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -9,7 +9,7 @@
 static btn_group_t btn_group;
 
 static lv_coord_t col_dsc[] = {160, 160, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 40, 40, 40, 60, LV_GRID_TEMPLATE_LAST};
 static lv_obj_t *label_cali;
 static lv_timer_t *timer;
 static lv_obj_t *pan;
@@ -55,7 +55,7 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     btn_group_set_sel(&btn_group, !g_setting.ht.enable);
 
-    create_label_item(cont, "Pan", 1, 5, 1);
+    create_label_item(cont, "Pan", 1, 6, 1);
     pan = lv_bar_create(cont);
     lv_bar_set_range(pan, 1000, 2000);
     lv_obj_set_size(pan, 500, 25);
@@ -66,9 +66,9 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_bg_color(pan, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
     lv_obj_set_style_radius(pan, 0, LV_PART_INDICATOR);
     lv_obj_set_grid_cell(pan, LV_GRID_ALIGN_START, 2, 1,
-                         LV_GRID_ALIGN_CENTER, 5, 1);
+                         LV_GRID_ALIGN_CENTER, 6, 1);
 
-    create_label_item(cont, "Tilt", 1, 6, 1);
+    create_label_item(cont, "Tilt", 1, 7, 1);
     tilt = lv_bar_create(cont);
     lv_bar_set_range(tilt, 1000, 2000);
     lv_obj_set_size(tilt, 500, 25);
@@ -79,9 +79,9 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_bg_color(tilt, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
     lv_obj_set_style_radius(tilt, 0, LV_PART_INDICATOR);
     lv_obj_set_grid_cell(tilt, LV_GRID_ALIGN_START, 2, 1,
-                         LV_GRID_ALIGN_CENTER, 6, 1);
+                         LV_GRID_ALIGN_CENTER, 7, 1);
 
-    create_label_item(cont, "Roll", 1, 7, 1);
+    create_label_item(cont, "Roll", 1, 8, 1);
     roll = lv_bar_create(cont);
     lv_bar_set_range(roll, 1000, 2000);
     lv_obj_set_size(roll, 500, 25);
@@ -92,7 +92,7 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_bg_color(roll, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
     lv_obj_set_style_radius(roll, 0, LV_PART_INDICATOR);
     lv_obj_set_grid_cell(roll, LV_GRID_ALIGN_START, 2, 1,
-                         LV_GRID_ALIGN_CENTER, 7, 1);
+                         LV_GRID_ALIGN_CENTER, 8, 1);
     return page;
 }
 

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -8,13 +8,14 @@
 
 static btn_group_t btn_group;
 
-static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t col_dsc[] = {160, 160, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 static lv_obj_t *label_cali;
 static lv_timer_t *timer;
 static lv_obj_t *pan;
 static lv_obj_t *tilt;
 static lv_obj_t *roll;
+static slider_group_t slider_group;
 
 static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
@@ -47,7 +48,10 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     create_label_item(cont, "Set Center", 1, 2, 1);
 
-    create_label_item(cont, "< Back", 1, 3, 1);
+    create_slider_item(&slider_group, cont, "Max Angle", 360, g_setting.ht.max_angle, 3);
+    lv_slider_set_range(slider_group.slider, 0, 360);
+
+    create_label_item(cont, "< Back", 1, 4, 1);
 
     btn_group_set_sel(&btn_group, !g_setting.ht.enable);
 
@@ -109,6 +113,15 @@ static void page_headtracker_on_click(uint8_t key, int sel) {
         lv_timer_handler();
     } else if (sel == 2) {
         set_center_position_ht();
+    } else if (sel == 3) {
+        if (g_menu_op == PAGE_ANGLE_SLIDE) {
+            g_menu_op = OPLEVEL_SUBMENU;
+            lv_obj_add_style(slider_group.slider, &style_silder_main, LV_PART_MAIN);
+            ini_putl("ht", "max_angle", g_setting.ht.max_angle, SETTING_INI);
+        } else {
+            g_menu_op = PAGE_ANGLE_SLIDE;
+            lv_obj_add_style(slider_group.slider, &style_silder_select, LV_PART_MAIN);
+        }
     }
 }
 
@@ -122,6 +135,7 @@ static void page_headtracker_timer(struct _lv_timer_t *timer)
 
 static void page_headtracker_enter()
 {
+    lv_slider_set_value(slider_group.slider, g_setting.ht.max_angle, LV_ANIM_OFF);
     timer = lv_timer_create(page_headtracker_timer, 50, NULL);
     lv_timer_set_repeat_count(timer, -1);
 }
@@ -131,10 +145,46 @@ static void page_headtracker_exit()
     lv_timer_del(timer);
 }
 
+void ht_angle_inc(void) {
+    int32_t value = 0;
+    char buf[5];
+
+    value = lv_slider_get_value(slider_group.slider);
+    if (value < 360)
+        value += 1;
+
+    lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);
+
+    sprintf(buf, "%d", value);
+    lv_label_set_text(slider_group.label, buf);
+
+    set_maxangle_ht(value);
+
+    g_setting.ht.max_angle = value;
+}
+
+void ht_angle_dec(void) {
+    int32_t value = 0;
+    char buf[5];
+
+    value = lv_slider_get_value(slider_group.slider);
+    if (value > 0)
+        value -= 1;
+
+    lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);
+
+    sprintf(buf, "%d", value);
+    lv_label_set_text(slider_group.label, buf);
+
+    set_maxangle_ht(value);
+
+    g_setting.ht.max_angle = value;
+}
+
 page_pack_t pp_headtracker = {
     .p_arr = {
         .cur = 0,
-        .max = 4,
+        .max = 5,
     },
 
     .create = page_headtracker_create,

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -10,7 +10,11 @@ static btn_group_t btn_group;
 
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
-lv_obj_t *label_cali;
+static lv_obj_t *label_cali;
+static lv_timer_t *timer;
+static lv_obj_t *pan;
+static lv_obj_t *tilt;
+static lv_obj_t *roll;
 
 static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
@@ -41,10 +45,50 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     label_cali = create_label_item(cont, "Calibrate", 1, 1, 1);
 
-    create_label_item(cont, "< Back", 1, 2, 1);
+    create_label_item(cont, "Set Center", 1, 2, 1);
+
+    create_label_item(cont, "< Back", 1, 3, 1);
 
     btn_group_set_sel(&btn_group, !g_setting.ht.enable);
 
+    create_label_item(cont, "Pan", 1, 5, 1);
+    pan = lv_bar_create(cont);
+    lv_bar_set_range(pan, 1000, 2000);
+    lv_obj_set_size(pan, 500, 25);
+    lv_obj_center(pan);
+    lv_bar_set_value(pan, 0, LV_ANIM_OFF);
+    lv_obj_set_style_bg_color(pan, lv_color_make(0xff, 0xff, 0xff), LV_PART_MAIN);
+    lv_obj_set_style_radius(pan, 0, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(pan, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
+    lv_obj_set_style_radius(pan, 0, LV_PART_INDICATOR);
+    lv_obj_set_grid_cell(pan, LV_GRID_ALIGN_START, 2, 1,
+                         LV_GRID_ALIGN_CENTER, 5, 1);
+
+    create_label_item(cont, "Tilt", 1, 6, 1);
+    tilt = lv_bar_create(cont);
+    lv_bar_set_range(tilt, 1000, 2000);
+    lv_obj_set_size(tilt, 500, 25);
+    lv_obj_center(tilt);
+    lv_bar_set_value(tilt, 0, LV_ANIM_OFF);
+    lv_obj_set_style_bg_color(tilt, lv_color_make(0xff, 0xff, 0xff), LV_PART_MAIN);
+    lv_obj_set_style_radius(tilt, 0, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(tilt, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
+    lv_obj_set_style_radius(tilt, 0, LV_PART_INDICATOR);
+    lv_obj_set_grid_cell(tilt, LV_GRID_ALIGN_START, 2, 1,
+                         LV_GRID_ALIGN_CENTER, 6, 1);
+
+    create_label_item(cont, "Roll", 1, 7, 1);
+    roll = lv_bar_create(cont);
+    lv_bar_set_range(roll, 1000, 2000);
+    lv_obj_set_size(roll, 500, 25);
+    lv_obj_center(roll);
+    lv_bar_set_value(roll, 0, LV_ANIM_OFF);
+    lv_obj_set_style_bg_color(roll, lv_color_make(0xff, 0xff, 0xff), LV_PART_MAIN);
+    lv_obj_set_style_radius(roll, 0, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(roll, lv_color_make(0, 0xff, 0), LV_PART_INDICATOR);
+    lv_obj_set_style_radius(roll, 0, LV_PART_INDICATOR);
+    lv_obj_set_grid_cell(roll, LV_GRID_ALIGN_START, 2, 1,
+                         LV_GRID_ALIGN_CENTER, 7, 1);
     return page;
 }
 
@@ -63,18 +107,39 @@ static void page_headtracker_on_click(uint8_t key, int sel) {
         calibrate_ht();
         lv_label_set_text(label_cali, "Re-calibrate");
         lv_timer_handler();
+    } else if (sel == 2) {
+        set_center_position_ht();
     }
+}
+
+static void page_headtracker_timer(struct _lv_timer_t *timer)
+{
+    int16_t *channels = get_ht_channels();
+    lv_bar_set_value(pan, channels[0], LV_ANIM_OFF);
+    lv_bar_set_value(tilt, channels[1], LV_ANIM_OFF);
+    lv_bar_set_value(roll, channels[2], LV_ANIM_OFF);
+}
+
+static void page_headtracker_enter()
+{
+    timer = lv_timer_create(page_headtracker_timer, 50, NULL);
+    lv_timer_set_repeat_count(timer, -1);
+}
+
+static void page_headtracker_exit()
+{
+    lv_timer_del(timer);
 }
 
 page_pack_t pp_headtracker = {
     .p_arr = {
         .cur = 0,
-        .max = 3,
+        .max = 4,
     },
 
     .create = page_headtracker_create,
-    .enter = NULL,
-    .exit = NULL,
+    .enter = page_headtracker_enter,
+    .exit = page_headtracker_exit,
     .on_roller = NULL,
     .on_click = page_headtracker_on_click,
 };

--- a/src/ui/page_headtracker.h
+++ b/src/ui/page_headtracker.h
@@ -7,4 +7,7 @@
 
 extern page_pack_t pp_headtracker;
 
+void ht_angle_dec(void);
+void ht_angle_inc(void);
+
 #endif

--- a/src/util/math.c
+++ b/src/util/math.c
@@ -1,0 +1,45 @@
+#include <math.h>
+#include <memory.h>
+
+#include "math.h"
+
+// Normalizes any number to an arbitrary range
+// by assuming the range wraps around when going below min or above max
+float normalize(float value, float start, float end)
+{
+    float width = end - start;          //
+    float offsetValue = value - start;  // value relative to 0
+
+    return (offsetValue - (floor(offsetValue / width) * width)) + start;
+    // + start to reset back to start of original range
+}
+
+// Rotate a point (pn) in space in Order X -> Y -> Z
+void rotate(float pn[3], const float rot[3])
+{
+    float out[3];
+
+    // X-axis Rotation
+    if (rot[0] != 0) {
+        out[0] = pn[0] * 1 + pn[1] * 0 + pn[2] * 0;
+        out[1] = pn[0] * 0 + pn[1] * cos(rot[0]) - pn[2] * sin(rot[0]);
+        out[2] = pn[0] * 0 + pn[1] * sin(rot[0]) + pn[2] * cos(rot[0]);
+        memcpy(pn, out, sizeof(out[0]) * 3);
+    }
+
+    // Y-axis Rotation
+    if (rot[1] != 0) {
+        out[0] = pn[0] * cos(rot[1]) - pn[1] * 0 + pn[2] * sin(rot[1]);
+        out[1] = pn[0] * 0 + pn[1] * 1 + pn[2] * 0;
+        out[2] = -pn[0] * sin(rot[1]) + pn[1] * 0 + pn[2] * cos(rot[1]);
+        memcpy(pn, out, sizeof(out[0]) * 3);
+    }
+
+    // Z-axis Rotation
+    if (rot[2] != 0) {
+        out[0] = pn[0] * cos(rot[2]) - pn[1] * sin(rot[2]) + pn[2] * 0;
+        out[1] = pn[0] * sin(rot[2]) + pn[1] * cos(rot[2]) + pn[2] * 0;
+        out[2] = pn[0] * 0 + pn[1] * 0 + pn[2] * 1;
+        memcpy(pn, out, sizeof(out[0]) * 3);
+    }
+}

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -1,0 +1,9 @@
+#ifndef __UTIL_MATH_H__
+#define __UTIL_MATH_H__
+
+#define constrain(value, min, max)  (value < min ? min : (value > max ? max : value))
+
+float normalize(float value, float start, float end);
+void rotate(float pn[3], const float rot[3]);
+
+#endif // __UTIL_MATH_H__


### PR DESCRIPTION
Implementation of Head Tracking.

The head tracker in the HDZero goggles outputs the PPM signal on the HT port on the goggles with the following channel layout
- Pan -> Channel 0 (TR1 in EdgeTX)
- Tilt -> Channel 1 (TR2 in EdgeTX)
- Roll - Channel 2 (TR3 in EdgeTX)

## Setup
In the goggles "Head Tracking" page the "Tracking" option should be set to "On", the the goggles should be resting on a level surface and the "Calibrate" option should be selected. I find that resting them on a book on the left and right side, with the face plate above the desk gives the best results.

The "Max Angle" option is used to set the angular limits for the head tracker, i.e. how far your head moves to reach full deflection on the PPM signal. The best way to do this is to first get you head in natural resting position when flying and set the centre point using the "Set Center" option, then select the "Max Angle" option and adjust the value while moving your head left/right, up&down until you get the desired range on the PPM bars at the bottom of the screen.

## Usage
When you use the head tracking function, you need to enter the "Head Tracking" page and select the "Set Center" option. This will reset the centre/home point for the goggles, so you need to do this when facing the direction and holding you head in you natural resting position when flying.