### PR TITLE
fix vlq indicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,14 @@ project(HDZGOGGLE VERSION 1.1)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+set(CMAKE_C_FLAGS "-mfpu=neon -mfloat-abi=hard -Wno-unused-function -Wno-unused-variable -ffunction-sections -fdata-sections -Wl,-gc-sections -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64")
+set(CMAKE_CXX_FLAGS "-mfpu=neon -mfloat-abi=hard -Wno-unused-function -Wno-unused-variable -ffunction-sections -fdata-sections -Wl,-gc-sections -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64")
+
 set(CMAKE_C_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
+
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 set(OS_APP_PATH ${PROJECT_SOURCE_DIR}/mkapp/app/app)
 

--- a/lib/lvgl/lvgl/lv_conf.h
+++ b/lib/lvgl/lvgl/lv_conf.h
@@ -87,9 +87,9 @@
  *It removes the need to manually update the tick with `lv_tick_inc()`)*/
 #define LV_TICK_CUSTOM 1
 #if LV_TICK_CUSTOM
-    extern uint32_t wk_tick_get(void);
+    extern uint32_t time_ms();
     #define LV_TICK_CUSTOM_INCLUDE <stdint.h>         /*Header for the system time function*/
-    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (wk_tick_get())    /*Expression evaluating to current system time in ms*/
+    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (time_ms())    /*Expression evaluating to current system time in ms*/
 #endif   /*LV_TICK_CUSTOM*/
 
 /*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.

--- a/src/core/msp_displayport.c
+++ b/src/core/msp_displayport.c
@@ -1,18 +1,11 @@
-//#include "common.h"
-//#include "uart.h"
-//#include "global.h"
-//#include "print.h"
-//#include "cmd_struct.h"
+#include "msp_displayport.h"
+
 #include <string.h>
 #include <stdio.h>
-#include "msp_displayport.h"
+
 #include "osd.h"
-//#include "i2c_device.h"
-//#include "isr.h"
-//#include "hardware.h"
+#include "util/time.h"
 
-
-int seconds = 0;
 
 uint8_t crc8tab[256] = {
     0x00, 0xD5, 0x7F, 0xAA, 0xFE, 0x2B, 0x81, 0x54, 0x29, 0xFC, 0x56, 0x83, 0xD7, 0x02, 0xA8, 0x7D,
@@ -102,7 +95,7 @@ void recive_one_frame(uint8_t* uart_buf,uint8_t uart_buf_len)
         //rx = RS_rx1();
         rx = uart_buf[uart_buf_ptr];
 
-        last_rcv_seconds1 = seconds;
+        last_rcv_seconds1 = time_s();
         #if(0)
         _outchar(rx);
         #endif
@@ -203,7 +196,7 @@ void recive_one_frame(uint8_t* uart_buf,uint8_t uart_buf_len)
             case RX_CRC1:
                 if(rx == crc1){
                     parser_rx(function, index, rx_buf);
-                    last_rcv_seconds0 = seconds;
+                    last_rcv_seconds0 = time_s();
                 }
                 rx_state = RX_HEADER0;
                 break;
@@ -299,8 +292,9 @@ void lqDetect(uint8_t rData)
 void lqStatistics()
 {
     static uint16_t last_sec = 0;
+    const uint32_t now = time_s();
     
-    if(seconds != last_sec){
+    if(now != last_sec){
         if(lq_rcv_cnt>=8)
             link_quality = 8;
         else if(lq_rcv_cnt == 7){
@@ -320,7 +314,7 @@ void lqStatistics()
         else
             link_quality = lq_rcv_cnt;
         
-        last_sec = seconds;
+        last_sec = now;
         lq_rcv_cnt = 0;
         lq_err_cnt = 0;
     }

--- a/src/core/msp_displayport.h
+++ b/src/core/msp_displayport.h
@@ -71,7 +71,6 @@ extern uint8_t          vtxVersion;
 extern uint8_t          vtxType;
 extern uint8_t          vtxFcLock;
 extern uint8_t          cam_4_3;
-extern int              seconds;
 
 extern uint8_t fc_init_done;
 extern uint16_t osd_buf[HD_VMAX][HD_HMAX];

--- a/src/ui/ui_porting.c
+++ b/src/ui/ui_porting.c
@@ -1,8 +1,6 @@
 #include "ui/ui_porting.h"
 
 #include <stdio.h>
-#include <sys/time.h>
-#include <time.h>
 
 #include <log/log.h>
 
@@ -75,19 +73,4 @@ int lvgl_switch_to_1080p(void) {
 
     h_resolution = 1920;
     return 0;
-}
-
-uint32_t wk_tick_get(void) {
-    static uint64_t start_ms = 0;
-    if (start_ms == 0) {
-        struct timeval tv_start;
-        gettimeofday(&tv_start, NULL);
-        start_ms = (tv_start.tv_sec * 1000000 + tv_start.tv_usec) / 1000;
-    }
-
-    struct timeval tv_now;
-    gettimeofday(&tv_now, NULL);
-
-    const uint64_t now_ms = (tv_now.tv_sec * 1000000 + tv_now.tv_usec) / 1000;
-    return now_ms - start_ms;
 }

--- a/src/util/time.c
+++ b/src/util/time.c
@@ -1,0 +1,32 @@
+#include "time.h"
+
+#include <sys/time.h>
+#include <time.h>
+
+uint32_t time_ms() {
+    struct timeval tv_now;
+    gettimeofday(&tv_now, NULL);
+
+    const uint64_t now_ms = (tv_now.tv_sec * 1000000 + tv_now.tv_usec) / 1000;
+
+    static uint64_t start_ms = 0;
+    if (start_ms == 0) {
+        start_ms = now_ms;
+    }
+
+    return now_ms - start_ms;
+}
+
+uint32_t time_s() {
+    struct timeval tv_now;
+    gettimeofday(&tv_now, NULL);
+
+    const uint64_t now_s = tv_now.tv_sec;
+
+    static uint64_t start_s = 0;
+    if (start_s == 0) {
+        start_s = now_s;
+    }
+
+    return now_s - start_s;
+}

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdint.h>
+
+uint32_t time_ms();
+uint32_t time_s();


### PR DESCRIPTION
- adds optimization flags to ensure msp displayport processing can keep up
- fixes bug introduced in #94 where lqi second counter wouldn't get updated.