### PR TITLE
Stop DVR when changing channel via backpack

### DIFF
--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -228,6 +228,7 @@ void msp_process_packet()
 							beep();
 							pthread_mutex_lock(&lvgl_mutex);
 							HDZero_open();
+							osd_dvr_cmd(DVR_STOP);
 							switch_to_video(true);
 							g_menu_op = OPLEVEL_VIDEO;
 							pthread_mutex_unlock(&lvgl_mutex);


### PR DESCRIPTION
As reported by cjohnstone87 on discord, if you are recording a channel and you change channel via the backpack, the recording contains garbage after the channel change. When changing channel via the OSD it stops the recording before changing channel.

This PR changes the backpack behaviour to be the same as the OSD.