### PR TITLE
fix app size

### DIFF
--- a/mkapp/mkapp_ota.sh
+++ b/mkapp/mkapp_ota.sh
@@ -20,18 +20,19 @@ BIN_DIR=$ROOT_DIR/bin
 IMG_DIR=$ROOT_DIR/ota_app
 APP_DIR=$ROOT_DIR/app
 
-APP_SIZE=12582912
+APP_SIZE=8388608
 APP_IMAGE=${IMG_DIR}/app.fex
 APP_VERSION=$(get_app_version "$ROOT_DIR/app/version")
 
 rm -rf $IMG_DIR
 mkdir -p $IMG_DIR
 
-${BIN_DIR}/mkfs.jffs2 -l -e 0x10000 \
-	-p ${APP_SIZE} \
-	-d ${APP_DIR} \
-	-o ${APP_IMAGE}
-
+${BIN_DIR}/mkfs.jffs2 \
+    --little-endian \
+    --eraseblock=0x10000 \
+    --pad=${APP_SIZE} \
+    --root=${APP_DIR} \
+    --output=${APP_IMAGE}
 make_img_md5 ${APP_IMAGE}
 
 cd $IMG_DIR


### PR DESCRIPTION
for some reason the short versions of the parameters to the mkfs.jffs2 command do not work reliably
adjusts the app size to 8MB, which should give us plenty of headroom, as the compressed version of the app currently is 2.2MB.