### PR TITLE
Wireless Head Tracking

### DIFF
--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -39,6 +39,7 @@ static sem_t response_semaphore;
 static mspPacket_t response_packet;
 static int record_state;
 static uint32_t record_time = 0;
+static bool headtracking_enabled = false;
 
 void msp_process_packet();
 
@@ -288,6 +289,10 @@ void msp_process_packet() {
         case MSP_SET_OSD_ELEM:
             // TODO
             break;
+        case MSP_SET_HT_ENABLE:
+            if (packet.payload_size > 0)
+                headtracking_enabled = packet.payload[0];
+            break;
         }
     } else if (packet.type == MSP_PACKET_RESPONSE) {
         memcpy(&response_packet, &packet, sizeof(response_packet));
@@ -351,4 +356,8 @@ void msp_ht_update(uint16_t pan, uint16_t tilt, uint16_t roll)
 		uint8_t payload[6] = {pan & 0xFF, pan >> 8, tilt & 0xFF, tilt >> 8, roll & 0xFF, roll >> 8};
 		msp_send_packet(MSP_SET_PTR, MSP_PACKET_COMMAND, sizeof(payload), payload);
 	}
+}
+
+bool elrs_headtracking_enabled() {
+	return headtracking_enabled;
 }

--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -19,6 +19,7 @@
 
 #include "core/battery.h"
 #include "core/common.hh"
+#include "core/ht.h"
 #include "core/osd.h"
 #include "driver/dm5680.h"
 #include "driver/gpio.h"
@@ -290,8 +291,12 @@ void msp_process_packet() {
             // TODO
             break;
         case MSP_SET_HT_ENABLE:
-            if (packet.payload_size > 0)
+            if (packet.payload_size > 0) {
                 headtracking_enabled = packet.payload[0];
+                if (headtracking_enabled) {
+                    ht_set_center_position();
+                }
+            }
             break;
         }
     } else if (packet.type == MSP_PACKET_RESPONSE) {
@@ -350,14 +355,13 @@ void msp_send_packet(uint16_t function, mspPacketType_e type, uint16_t payload_s
     uart_write(fd_esp32, buffer, payload_size + 9);
 }
 
-void msp_ht_update(uint16_t pan, uint16_t tilt, uint16_t roll)
-{
-	if (g_setting.elrs.enable) {
-		uint8_t payload[6] = {pan & 0xFF, pan >> 8, tilt & 0xFF, tilt >> 8, roll & 0xFF, roll >> 8};
-		msp_send_packet(MSP_SET_PTR, MSP_PACKET_COMMAND, sizeof(payload), payload);
-	}
+void msp_ht_update(uint16_t pan, uint16_t tilt, uint16_t roll) {
+    if (g_setting.elrs.enable) {
+        uint8_t payload[6] = {pan & 0xFF, pan >> 8, tilt & 0xFF, tilt >> 8, roll & 0xFF, roll >> 8};
+        msp_send_packet(MSP_SET_PTR, MSP_PACKET_COMMAND, sizeof(payload), payload);
+    }
 }
 
 bool elrs_headtracking_enabled() {
-	return headtracking_enabled;
+    return headtracking_enabled;
 }

--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -344,3 +344,11 @@ void msp_send_packet(uint16_t function, mspPacketType_e type, uint16_t payload_s
     buffer[payload_size + 8] = crc;
     uart_write(fd_esp32, buffer, payload_size + 9);
 }
+
+void msp_ht_update(uint16_t pan, uint16_t tilt, uint16_t roll)
+{
+	if (g_setting.elrs.enable) {
+		uint8_t payload[6] = {pan & 0xFF, pan >> 8, tilt & 0xFF, tilt >> 8, roll & 0xFF, roll >> 8};
+		msp_send_packet(MSP_SET_PTR, MSP_PACKET_COMMAND, sizeof(payload), payload);
+	}
+}

--- a/src/core/elrs.h
+++ b/src/core/elrs.h
@@ -40,6 +40,7 @@ typedef struct __attribute__((packed)) {
 #define MSP_GET_BAT_VOLTS  0x0309
 #define MSP_GET_VERSION    0x030A
 #define MSP_SET_BUZZER     0x030B
+#define MSP_SET_HT_ENABLE  0x030D
 #define MSP_SET_OSD_ELEM   0x00B6
 #define MSP_SET_MODE       0x0380 // goggles to backpack
 #define MSP_GET_BP_VERSION 0x0381 // goggles to backpack
@@ -59,6 +60,7 @@ typedef struct {
 } mspPacket_t;
 
 void elrs_init();
+bool elrs_headtracking_enabled();
 
 void msp_send_packet(uint16_t function, mspPacketType_e type, uint16_t payload_size, uint8_t *payload);
 bool msp_read_resposne(uint16_t function, uint16_t *payload_size, uint8_t *payload);

--- a/src/core/elrs.h
+++ b/src/core/elrs.h
@@ -44,6 +44,7 @@ typedef struct __attribute__((packed)) {
 #define MSP_SET_MODE       0x0380 // goggles to backpack
 #define MSP_GET_BP_VERSION 0x0381 // goggles to backpack
 #define MSP_GET_BP_STATUS  0x0382 // goggles to backpack
+#define MSP_SET_PTR        0x0383 // goggles to backpack
 
 #define MSP_PORT_INBUF_SIZE 64
 
@@ -62,5 +63,6 @@ void elrs_init();
 void msp_send_packet(uint16_t function, mspPacketType_e type, uint16_t payload_size, uint8_t *payload);
 bool msp_read_resposne(uint16_t function, uint16_t *payload_size, uint8_t *payload);
 bool msp_await_resposne(uint16_t function, uint16_t payload_size, uint8_t *payload, uint32_t timeout_ms);
+void msp_ht_update(uint16_t pan, uint16_t tilt, uint16_t roll);
 
 #endif //__ELRS_H__

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -10,6 +10,7 @@
 
 #include "MadgwickAHRS.h"
 #include "common.hh"
+#include "elrs.h"
 #include "ht.h"
 #include "osd.h"
 
@@ -282,7 +283,7 @@ void ht_calibrate() {
 
 static void calculate_orientation() {
     float gyrAngle[3], accAngle[3];
-    int tmp;
+    float tmp;
 
     if (!calibrating && !ht_data.enable)
         return;
@@ -322,6 +323,12 @@ static void calculate_orientation() {
     ht_data.htChannels[2] = constrain(tmp, ppmMinPulse, ppmMaxPulse) + ppmCenter;
 
     Set_HT_dat(ht_data.htChannels[0], ht_data.htChannels[1], ht_data.htChannels[2]);
+
+    uint16_t ptrCRSF[3];
+    ptrCRSF[0] = fmap(ht_data.htChannels[0], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
+    ptrCRSF[1] = fmap(ht_data.htChannels[1], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
+    ptrCRSF[2] = fmap(ht_data.htChannels[2], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
+    msp_ht_update(ptrCRSF[0], ptrCRSF[1], ptrCRSF[2]);
 }
 
 void ht_set_center_position() {

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -324,11 +324,13 @@ static void calculate_orientation() {
 
     Set_HT_dat(ht_data.htChannels[0], ht_data.htChannels[1], ht_data.htChannels[2]);
 
-    uint16_t ptrCRSF[3];
-    ptrCRSF[0] = fmap(ht_data.htChannels[0], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
-    ptrCRSF[1] = fmap(ht_data.htChannels[1], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
-    ptrCRSF[2] = fmap(ht_data.htChannels[2], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
-    msp_ht_update(ptrCRSF[0], ptrCRSF[1], ptrCRSF[2]);
+    if (elrs_headtracking_enabled()) {
+        uint16_t ptrCRSF[3];
+        ptrCRSF[0] = fmap(ht_data.htChannels[0], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
+        ptrCRSF[1] = fmap(ht_data.htChannels[1], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
+        ptrCRSF[2] = fmap(ht_data.htChannels[2], ppmMinPulse + ppmCenter, ppmMaxPulse + ppmCenter, 191.0, 1792.0) + 0.5;
+        msp_ht_update(ptrCRSF[0], ptrCRSF[1], ptrCRSF[2]);
+    }
 }
 
 void ht_set_center_position() {

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -1,7 +1,11 @@
 #ifndef __UTIL_MATH_H__
 #define __UTIL_MATH_H__
 
-#define constrain(value, min, max)  (value < min ? min : (value > max ? max : value))
+#define constrain(value, min, max) \
+    (value < min ? min : (value > max ? max : value))
+
+#define fmap(value, in_min, in_max, out_min, out_max) \
+    (((value) - (in_min)) * ((out_max) - (out_min)) / ((in_max) - (in_min)) + (out_min))
 
 float normalize(float value, float start, float end);
 void rotate(float pn[3], const float rot[3]);


### PR DESCRIPTION
This PR builds on top the head tracking and ELRS backpack work done previously.

To test this PR you currently need to flash the  HDzero goggles with this PR, the HDzero goggle and TX module backpack need to be flashed with the backpack wireless head tracking PR (https://github.com/ExpressLRS/Backpack/pull/83) and the TX module also needs to be flashed with the wireless head tracking PR (https://github.com/ExpressLRS/ExpressLRS/pull/2060).

Once that is done, there will be an option in the ExpressLRS Lua "Backpack" menu that allows you to configure which channels Pan/Tilt/Roll are mapped to when being sent to the ELRS receiver.

EDIT: After some feedback, I've added an "enable" channel option in the ELRS Lua script, which allows the user to disable/enable the head tracker via a switch. Each time the head tracker is enabled it also re-centres the head tracker. When the head tracker is disabled (via the switch) the gimbal channels are move back to centre.
