### PR TITLE
Fix self test logging

### DIFF
--- a/lib/log/CMakeLists.txt
+++ b/lib/log/CMakeLists.txt
@@ -1,5 +1,10 @@
 file(GLOB SRC_FILES "src/*.c")
 
-add_library(log SHARED ${SRC_FILES})
+add_library(log-shared SHARED ${SRC_FILES})
+target_include_directories(log-shared PUBLIC include)
+set_target_properties(log-shared PROPERTIES OUTPUT_NAME "log")
+install(TARGETS log-shared)
+
+add_library(log OBJECT ${SRC_FILES})
 target_include_directories(log PUBLIC include)
 install(TARGETS log)

--- a/lib/log/include/log/log.h
+++ b/lib/log/include/log/log.h
@@ -1,6 +1,8 @@
 #ifndef LOG_H
 #define LOG_H
 
+#include <stdbool.h>
+
 #define LOG_LEVEL_DEBUG   -2
 #define LOG_LEVEL_VERBOSE -1
 #define LOG_LEVEL_INFO    0
@@ -15,5 +17,7 @@
 #define LOGD(...) log_printf(__FILE__, __func__, __LINE__, LOG_LEVEL_DEBUG, __VA_ARGS__)
 
 int log_printf(const char *file, const char *func, int line, const int level, const char *fmt, ...);
+
+bool log_enable_file(const char *filename);
 
 #endif

--- a/lib/log/src/log.c
+++ b/lib/log/src/log.c
@@ -6,6 +6,8 @@
 
 #define get_filename(file) (strrchr(file, '/') ? strrchr(file, '/') + 1 : file)
 
+static FILE *log_file = NULL;
+
 static const char *log_level_names[] = {
     "DEBUG",   // -2
     "VERBOSE", // -1
@@ -25,11 +27,31 @@ int log_printf(const char *file, const char *func, int line, const int level, co
     vsnprintf(buf, sizeof buf, fmt, args2);
     va_end(args2);
 
-    return printf(
+    int ret = printf(
         "[%s][%s:%s:%d] %s\r\n",
         log_level_names[level + 2],
         get_filename(file),
         func,
         line,
         buf);
+
+    if (log_file) {
+        fprintf(log_file, "[%s][%s:%s:%d] %s\r\n",
+                log_level_names[level + 2],
+                get_filename(file),
+                func,
+                line,
+                buf);
+        fflush(log_file);
+    }
+
+    return ret;
+}
+
+bool log_enable_file(const char *filename) {
+    log_file = fopen(filename, "w+");
+    if (log_file) {
+        return true;
+    }
+    return false;
 }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -7,6 +7,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <log/log.h>
 #include <lvgl/lvgl.h>
 #include <minIni.h>
 
@@ -35,6 +36,7 @@
 #include "ui/ui_main_menu.h"
 #include "ui/ui_porting.h"
 #include "ui/ui_statusbar.h"
+#include "util/file.h"
 
 static void load_ini_setting(void) {
     char str[128];
@@ -107,12 +109,8 @@ static void load_ini_setting(void) {
 
     // Check
     g_test_en = false;
-    log_file = fopen(LOG_FILE, "r");
-    if (log_file) {
-        fclose(log_file);
-        log_file = fopen(LOG_FILE, "w+");
-        if (log_file)
-            g_test_en = true;
+    if (file_exists(LOG_FILE) && log_enable_file(LOG_FILE)) {
+        g_test_en = true;
     }
 }
 

--- a/src/core/self_test.c
+++ b/src/core/self_test.c
@@ -1,90 +1,88 @@
 #include "self_test.h"
 
 #include <stdint.h>
-#include <unistd.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 #include <log/log.h>
 
-#include "../driver/dm5680.h"
 #include "../driver/TP2825.h"
-#include "../driver/i2c.h"
-#include "../driver/hardware.h"
-#include "../driver/it66121.h"
-#include "../driver/it66021.h"
+#include "../driver/dm5680.h"
 #include "../driver/dm6302.h"
-#include "ui/page_common.h"
+#include "../driver/hardware.h"
+#include "../driver/i2c.h"
+#include "../driver/it66021.h"
+#include "../driver/it66121.h"
 #include "common.hh"
-
+#include "ui/page_common.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // log
-FILE* log_file;
+FILE *log_file;
 
-#define UART_WAIT (100*1000)
+#define UART_WAIT (100 * 1000)
 
-void self_test()
-{
+void self_test() {
     int i;
-    uint32_t dat0,dat1;
-    char* msg[2] = {"[Error]", "[Pass] "}; 
-    
-    if(!g_test_en) return;
-    
+    uint32_t dat0, dat1;
+    char *msg[2] = {"[Error]", "[Pass] "};
+
+    if (!g_test_en)
+        return;
+
     LOGI("==== Self Test ======================");
-    //1. Read FPGA
-     i = I2C_Read(ADDR_FPGA,  0xFF);
-     LOGI("%sFPGA ver = %d ",msg[i!=0],i);
-    
-    //2. Check UART connection between V536 and DM5680 on left (UART2) and Right (UART1) 
+    // 1. Read FPGA
+    i = I2C_Read(ADDR_FPGA, 0xFF);
+    LOGI("%sFPGA ver = %d ", msg[i != 0], i);
+
+    // 2. Check UART connection between V536 and DM5680 on left (UART2) and Right (UART1)
     rx_status[0].rx_ver = 0;
     rx_status[1].rx_ver = 0;
     DM5680_req_ver();
     usleep(UART_WAIT);
-    LOGI("%sUART1 communicate left  DM5680 ver=%x",msg[rx_status[0].rx_ver != 0],rx_status[0].rx_ver);
-    LOGI("%sUART2 communicate right DM5680 ver=%x",msg[rx_status[1].rx_ver != 0],rx_status[1].rx_ver);
+    LOGI("%sUART1 communicate left  DM5680 ver=%x", msg[rx_status[0].rx_ver != 0], rx_status[0].rx_ver);
+    LOGI("%sUART2 communicate right DM5680 ver=%x", msg[rx_status[1].rx_ver != 0], rx_status[1].rx_ver);
 
-    //3. IT66121 (Right) HDMI_TX
+    // 3. IT66121 (Right) HDMI_TX
     DM5680_ResetHDMI_TX(0);
     DM5680_ResetHDMI_TX(1);
     usleep(UART_WAIT);
-    i = I2C_R_Read(ADDR_IT66121, 0x00); //Vender ID
-    LOGI("%sIT66121(R, HDMI_TX) Vender ID = 0x%x ",msg[(i==0x54)],i);
+    i = I2C_R_Read(ADDR_IT66121, 0x00); // Vender ID
+    LOGI("%sIT66121(R, HDMI_TX) Vender ID = 0x%x ", msg[(i == 0x54)], i);
     DM5680_ResetHDMI_TX(0);
 
-    //4. IT66021 (Left)
+    // 4. IT66021 (Left)
     DM5680_ResetHDMI_RX(0);
     DM5680_ResetHDMI_RX(1);
     usleep(UART_WAIT);
-    i = I2C_L_Read(ADDR_IT66021, 0x00); //Vender ID
-    LOGI("%sIT66021(L, HDMI_RX) Vender ID = 0x%x ",msg[i==0x54],i);
+    i = I2C_L_Read(ADDR_IT66021, 0x00); // Vender ID
+    LOGI("%sIT66021(L, HDMI_RX) Vender ID = 0x%x ", msg[i == 0x54], i);
     DM5680_ResetHDMI_RX(0);
 
-
-    //5. AL FPGA
+    // 5. AL FPGA
     i = I2C_Read(ADDR_AL, 0xFF);
-    LOGI("%sAL ver = 0x%x ",msg[1],i);
+    LOGI("%sAL ver = 0x%x ", msg[1], i);
 
-    //6. TP2825
+    // 6. TP2825
     TP2825_open();
     i = I2C_Read(ADDR_TP2825, 0x00);
-    LOGI("%sTP2825 ver = 0x%x ",msg[i==0x11],i);
+    LOGI("%sTP2825 ver = 0x%x ", msg[i == 0x11], i);
     TP2825_close();
 
-    //7. DM6302s
+    // 7. DM6302s
     DM5680_ResetRF(0);
     DM5680_ResetRF(1);
     usleep(UART_WAIT);
     DM6302_Init0(0);
-    SPI_Read (0x6, 0xFF0, &dat0, &dat1);
-    LOGI("%sDM6302 (Left)  = 0x%x ",msg[(dat0==0x18)],dat0);
-    LOGI("%sDM6302 (Right) = 0x%x ",msg[(dat1==0x18)],dat1);
+    SPI_Read(0x6, 0xFF0, &dat0, &dat1);
+    LOGI("%sDM6302 (Left)  = 0x%x ", msg[(dat0 == 0x18)], dat0);
+    LOGI("%sDM6302 (Right) = 0x%x ", msg[(dat1 == 0x18)], dat1);
     DM5680_ResetRF(0);
 
-    //8. HAN Status
-    i =  Get_HAN_status() & 1;
-    LOGI("%sHAN Status. ",msg[i]);
+    // 8. HAN Status
+    i = Get_HAN_status() & 1;
+    LOGI("%sHAN Status. ", msg[i]);
 
     LOGI("==== Log  ======================");
 }

--- a/src/core/self_test.c
+++ b/src/core/self_test.c
@@ -7,19 +7,15 @@
 
 #include <log/log.h>
 
-#include "../driver/TP2825.h"
-#include "../driver/dm5680.h"
-#include "../driver/dm6302.h"
-#include "../driver/hardware.h"
-#include "../driver/i2c.h"
-#include "../driver/it66021.h"
-#include "../driver/it66121.h"
-#include "common.hh"
+#include "core/common.hh"
+#include "driver/TP2825.h"
+#include "driver/dm5680.h"
+#include "driver/dm6302.h"
+#include "driver/hardware.h"
+#include "driver/i2c.h"
+#include "driver/it66021.h"
+#include "driver/it66121.h"
 #include "ui/page_common.h"
-
-///////////////////////////////////////////////////////////////////////////////
-// log
-FILE *log_file;
 
 #define UART_WAIT (100 * 1000)
 

--- a/src/core/self_test.h
+++ b/src/core/self_test.h
@@ -3,9 +3,7 @@
 
 #include <stdio.h>
 
-#define LOG_FILE    "/mnt/extsd/self_test.txt"
-
-extern FILE* log_file;
+#define LOG_FILE "/mnt/extsd/self_test.txt"
 
 void self_test();
 #endif


### PR DESCRIPTION
Carl made me aware that the "self test" feature stopped working. That previously hooked into their flavor of `Printf` and was lost during the log refactor.
This PR re-adds this functionality. 