### PR TITLE
Fail build if firmware exceeds set size

### DIFF
--- a/mkapp/mkapp_ota.sh
+++ b/mkapp/mkapp_ota.sh
@@ -30,10 +30,15 @@ mkdir -p $IMG_DIR
 ${BIN_DIR}/mkfs.jffs2 \
     --little-endian \
     --eraseblock=0x10000 \
-    --pad=${APP_SIZE} \
     --root=${APP_DIR} \
     --output=${APP_IMAGE}
 make_img_md5 ${APP_IMAGE}
+
+FILESIZE=$(stat -c%s "${APP_IMAGE}")
+if (( ${FILESIZE} > ${APP_SIZE})); then
+    echo -e "\e[31;1mERROR: Firmware size is too large for partition!\e[0m"
+    exit 1
+fi
 
 cd $IMG_DIR
 tar cvf $IMG_DIR/hdzgoggle_app_ota-${APP_VERSION}.tar *


### PR DESCRIPTION
Rather that using the `--pad` parameter to the `mkfs.jffs2` command, which cause the build to take 4 minutes in a devcontainer on MacOS, likely because of the way the directory is volume mounted.

If the filesystem is greater than the the configured `APP_SIZE` in the script, then a message is printed and script exits with exit code 1, causing the build to fail.