### PR TITLE
Fixes OLED wake from motion detect

### DIFF
--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -28,7 +28,7 @@ static const uint8_t frame_period = 10;
 static const uint8_t sync_len = 200;
 
 static bool has_motion_data = false;
-static int is_moving;
+static bool is_moving = true;
 
 
 static volatile bool calibrating = false;
@@ -44,7 +44,7 @@ static void calculate_orientation();
 
 ///////////////////////////////////////////////////////////////////////////////
 // no motion to disable OLED display
-static void detect_motion(int is_moving) {
+static void detect_motion(bool is_moving) {
     static uint8_t state = 0; // 0: detecting motion, 1=oled pre off mode, 2= oled off mode
     static int cnt = 0;
 

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -27,6 +27,10 @@ static ht_data_t ht_data;
 static const uint8_t frame_period = 10;
 static const uint8_t sync_len = 200;
 
+static bool has_motion_data = false;
+static int is_moving;
+
+
 static volatile bool calibrating = false;
 static int calibration_count = 0;
 
@@ -113,12 +117,18 @@ static void detect_motion(int is_moving) {
     }
 }
 
+void ht_detect_motion() {
+    if (has_motion_data) {
+        detect_motion(is_moving);
+        has_motion_data = false;
+    }
+}
+
 static void get_imu_data(int bCalcDiff) {
     static int dec_cnt;
     static struct bmi2_sens_axes_data gyr_last;
     int16_t dx, dy, dz;
     uint32_t diff;
-    int is_moving;
 
     get_bmi270(&ht_data.sensor_data);
 
@@ -140,7 +150,7 @@ static void get_imu_data(int bCalcDiff) {
         // if(is_moving)
         //     LOGI("IMU: %d",diff);
 
-        detect_motion(is_moving);
+        has_motion_data = true;
     }
 }
 

--- a/src/core/ht.h
+++ b/src/core/ht.h
@@ -49,6 +49,7 @@ typedef struct {
 void ht_init();
 void ht_enable();
 void ht_disable();
+void ht_detect_motion();
 void ht_calibrate();
 void ht_set_maxangle(int angle);
 void ht_set_center_position();

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -246,6 +246,7 @@ int main(int argc, char *argv[]) {
         statubar_update();
         osd_hdzero_update();
         ims_update();
+        ht_detect_motion();
         lv_timer_handler();
         source_status_timer();
         pthread_mutex_unlock(&lvgl_mutex);


### PR DESCRIPTION
There was an intermittent problem when the OLED off/on is called from the timer thread where the OLED on would not always work causing the screens to stay off.

This PR changes that behaviour by just setting a flag in the timer thread, and the `detect_motion` call is now done from the main thread which perform the OLED changes if there was motion or not.

Prior to this fix I could easily get the OLED wake to fail within a couple of tries, but after this I have performed the sleep/wake well over 10 times without a problem.