### PR TITLE
Add option to display average cell voltage in osd

### DIFF
--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -17,6 +17,7 @@ voltage=35
 warning_type=2
 cell_count_mode=0
 cell_count = 2
+osd_display_mode = 0
 
 [record]
 mode_manual=disable

--- a/src/core/battery.c
+++ b/src/core/battery.c
@@ -30,3 +30,10 @@ bool battery_is_low() {
     int cell_volt = g_battery.voltage / g_battery.type;
     return cell_volt <= g_setting.power.voltage * 100;
 }
+
+int battery_get_millivolts(bool per_cell) {
+    if (per_cell)
+        return g_battery.voltage / g_battery.type;
+    
+    return g_battery.voltage;
+}

--- a/src/core/battery.h
+++ b/src/core/battery.h
@@ -17,3 +17,4 @@ void battery_init();
 void battery_update();
 
 bool battery_is_low();
+int battery_get_millivolts(bool per_cell);

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -80,6 +80,7 @@ static void load_ini_setting(void) {
     g_setting.power.warning_type = ini_getl("power", "warning_type", 0, SETTING_INI);
     g_setting.power.cell_count_mode = ini_getl("power", "cell_count_mode", 0, SETTING_INI);
     g_setting.power.cell_count = ini_getl("power", "cell_count", 2, SETTING_INI);
+    g_setting.power.osd_display_mode = ini_getl("power", "osd_display_mode", 0, SETTING_INI);
     ini_gets("record", "mode_manual", "disable", str, sizeof(str), SETTING_INI);
     g_setting.record.mode_manual = strcmp(str, "enable") == 0;
     ini_gets("record", "format_ts", "enable", str, sizeof(str), SETTING_INI);

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -90,12 +90,18 @@ typedef enum {
     SETTING_POWER_CELL_COUNT_MODE_MANUAL = 1
 } setting_power_cell_count_mode_t;
 
+typedef enum {
+    SETTING_POWER_OSD_DISPLAY_MODE_TOTAL = 0,
+    SETTING_POWER_OSD_DISPLAY_MODE_CELL = 1
+} setting_power_osd_display_mode_t;
+
 typedef struct {
     int voltage;
     bool display_voltage;
     int warning_type; // 0=beep,1=visual,2=both
     setting_power_cell_count_mode_t cell_count_mode;
     int cell_count;
+    setting_power_osd_display_mode_t osd_display_mode;
 } setting_power_t;
 
 typedef struct {

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -13,6 +13,7 @@
 static slider_group_t slider_group_cell_voltage;
 static btn_group_t btn_group_cell_count_mode;
 static slider_group_t slider_group_cell_count;
+static btn_group_t btn_group_osd_display_mode;
 static btn_group_t btn_group_warn_type;
 
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 120, 160, LV_GRID_TEMPLATE_LAST};
@@ -60,6 +61,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_btn_group_item(&btn_group_cell_count_mode, cont, 2, "Cell Count Mode", "Auto", "Manual", "", "", ROW_CELL_COUNT_MODE);
     create_slider_item(&slider_group_cell_count, cont, "Cell Count", CELL_MAX_COUNT, g_setting.power.cell_count, ROW_CELL_COUNT);
     create_slider_item(&slider_group_cell_voltage, cont, "Cell Voltage", CELL_VOLTAGE_MAX, g_setting.power.voltage, ROW_CELL_VOLTAGE);
+    create_btn_group_item(&btn_group_osd_display_mode, cont, 2, "OSD Display Mode", "Total", "Cell Avg.", "", "", ROW_OSD_DISPLAY_MODE);
     create_btn_group_item(&btn_group_warn_type, cont, 3, "Warning Type", "Beep", "Visual", "Both", "", ROW_WARN_TYPE);
     create_label_item(cont, "< Back", 1, ROW_BACK, 1);
 
@@ -77,6 +79,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_set_sel(&btn_group_cell_count_mode, g_setting.power.cell_count_mode);
     lv_slider_set_value(slider_group_cell_count.slider, g_setting.power.cell_count, LV_ANIM_OFF);
     lv_slider_set_value(slider_group_cell_voltage.slider, g_setting.power.voltage, LV_ANIM_OFF);
+    btn_group_set_sel(&btn_group_osd_display_mode, g_setting.power.osd_display_mode);
     btn_group_set_sel(&btn_group_warn_type, g_setting.power.warning_type);
     page_power_update_cell_count();
 
@@ -186,6 +189,12 @@ static void page_power_on_click(uint8_t key, int sel) {
         }
         break;
 
+    case ROW_OSD_DISPLAY_MODE:
+        btn_group_toggle_sel(&btn_group_osd_display_mode);
+        g_setting.power.osd_display_mode = btn_group_get_sel(&btn_group_osd_display_mode);
+        ini_putl("power", "osd_display_mode", g_setting.power.osd_display_mode, SETTING_INI);
+        break;
+
     case ROW_WARN_TYPE:
         btn_group_toggle_sel(&btn_group_warn_type);
         g_setting.power.warning_type = btn_group_get_sel(&btn_group_warn_type);
@@ -200,7 +209,7 @@ static void page_power_on_click(uint8_t key, int sel) {
 page_pack_t pp_power = {
     .p_arr = {
         .cur = 0,
-        .max = 6,
+        .max = 7,
     },
 
     .create = page_power_create,

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -61,7 +61,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_btn_group_item(&btn_group_cell_count_mode, cont, 2, "Cell Count Mode", "Auto", "Manual", "", "", ROW_CELL_COUNT_MODE);
     create_slider_item(&slider_group_cell_count, cont, "Cell Count", CELL_MAX_COUNT, g_setting.power.cell_count, ROW_CELL_COUNT);
     create_slider_item(&slider_group_cell_voltage, cont, "Cell Voltage", CELL_VOLTAGE_MAX, g_setting.power.voltage, ROW_CELL_VOLTAGE);
-    create_btn_group_item(&btn_group_osd_display_mode, cont, 2, "OSD Display Mode", "Total", "Cell Avg.", "", "", ROW_OSD_DISPLAY_MODE);
+    create_btn_group_item(&btn_group_osd_display_mode, cont, 2, "Display Mode", "Total", "Cell Avg.", "", "", ROW_OSD_DISPLAY_MODE);
     create_btn_group_item(&btn_group_warn_type, cont, 3, "Warning Type", "Beep", "Visual", "Both", "", ROW_WARN_TYPE);
     create_label_item(cont, "< Back", 1, ROW_BACK, 1);
 

--- a/src/ui/page_power.h
+++ b/src/ui/page_power.h
@@ -8,8 +8,9 @@
 #define ROW_CELL_COUNT_MODE 1
 #define ROW_CELL_COUNT 2
 #define ROW_CELL_VOLTAGE 3
-#define ROW_WARN_TYPE 4
-#define ROW_BACK 5
+#define ROW_OSD_DISPLAY_MODE 4
+#define ROW_WARN_TYPE 5
+#define ROW_BACK 6
 
 #include <stdbool.h>
 

--- a/src/ui/ui_statusbar.c
+++ b/src/ui/ui_statusbar.c
@@ -151,27 +151,28 @@ void statubar_update(void) {
     memset(buf, 0, sizeof(buf));
 
     // display battery voltage
-    int bat_mv = 0;
-    switch (g_setting.power.osd_display_mode)
-    {
-        default:
-        case SETTING_POWER_OSD_DISPLAY_MODE_TOTAL:
-            bat_mv = battery_get_millivolts(false);
-            sprintf(buf, "%dS %d.%dV", 
-                    g_battery.type,
-                    bat_mv / 1000,
-                    bat_mv % 1000 / 100);
-            
-            break;
-            
-        case SETTING_POWER_OSD_DISPLAY_MODE_CELL:
-            bat_mv = battery_get_millivolts(true);
-            sprintf(buf, "%dS %d.%dV/C", 
-                    g_battery.type,
-                    bat_mv / 1000, 
-                    bat_mv % 1000 / 100);
+    switch (g_setting.power.osd_display_mode) {
 
-            break;
+    default:
+    case SETTING_POWER_OSD_DISPLAY_MODE_TOTAL: {
+        const int bat_mv = battery_get_millivolts(false);
+        sprintf(buf, "%dS %d.%dV",
+                g_battery.type,
+                bat_mv / 1000,
+                bat_mv % 1000 / 100);
+
+        break;
+    }
+
+    case SETTING_POWER_OSD_DISPLAY_MODE_CELL: {
+        const int bat_mv = battery_get_millivolts(true);
+        sprintf(buf, "%dS %d.%dV/C",
+                g_battery.type,
+                bat_mv / 1000,
+                bat_mv % 1000 / 100);
+
+        break;
+    }
     }
 
     lv_label_set_text(label4, buf);

--- a/src/ui/ui_statusbar.c
+++ b/src/ui/ui_statusbar.c
@@ -149,9 +149,30 @@ int statusbar_init(void) {
 void statubar_update(void) {
     char buf[128];
     memset(buf, 0, sizeof(buf));
-    sprintf(buf, "%dS %d.%dV", g_battery.type,
-            g_battery.voltage / 1000,
-            g_battery.voltage % 1000 / 100);
+
+    // display battery voltage
+    int bat_mv = 0;
+    switch (g_setting.power.osd_display_mode)
+    {
+        default:
+        case SETTING_POWER_OSD_DISPLAY_MODE_TOTAL:
+            bat_mv = battery_get_millivolts(false);
+            sprintf(buf, "%dS %d.%dV", 
+                    g_battery.type,
+                    bat_mv / 1000,
+                    bat_mv % 1000 / 100);
+            
+            break;
+            
+        case SETTING_POWER_OSD_DISPLAY_MODE_CELL:
+            bat_mv = battery_get_millivolts(true);
+            sprintf(buf, "%dS %d.%dV/C", 
+                    g_battery.type,
+                    bat_mv / 1000, 
+                    bat_mv % 1000 / 100);
+
+            break;
+    }
 
     lv_label_set_text(label4, buf);
 


### PR DESCRIPTION
Added a toggle to the power settings page to choose whether the osd shows the total battery voltage or the average voltage per cell.
I wanted to make it obvious which mode is active, so "/C" is added to the old format when cell average mode is active, if someone has a better idea let me know.
e.g.:
"Total" mode:       4S 15.6V
"Cell Avg." mode: 4S 3.9V/C

Would appreciate if someone could test the pr on their goggles, don't have mine yet.

Resolves #68 