### PR TITLE
Tweak TP2825 registers & detect sequence

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -227,7 +227,7 @@ static void device_init(void) {
     enable_bmi270();
     IT66021_init();
     IT66121_init();
-    TP2825_Config(0, 0);
+    TP2825_Init(0, 0);
     DM5680_req_ver();
     fans_top_setspeed(g_setting.fans.top_speed);
 }

--- a/src/driver/TP2825.c
+++ b/src/driver/TP2825.c
@@ -18,13 +18,18 @@ void TP2825_open() {
     gpio_set(GPIO_TP2825_RSTB, 1);
 }
 
-// ch_sel: 0=AV in; 1=Module bay
-void TP2825_Config(int ch_sel, int is_pal) {
+void TP2825_Init(int ch_sel, int is_pal) {
     TP2825_close();
     usleep(10000);
     TP2825_open();
     usleep(10000);
 
+    TP2825_Config(ch_sel, is_pal);
+}
+
+// ch_sel: 0=AV in; 1=Module bay
+void TP2825_Config(int ch_sel, int is_pal) {
+    I2C_Write(ADDR_TP2825, 0x06, 0xB3);
     I2C_Write(ADDR_TP2825, 0x41, ch_sel);
 
     if (is_pal) {
@@ -76,8 +81,6 @@ void TP2825_Config(int ch_sel, int is_pal) {
         I2C_Write(ADDR_TP2825, 0x32, 0x96);
         I2C_Write(ADDR_TP2825, 0x33, 0xC0);
     }
-
-    I2C_Write(ADDR_TP2825, 0x06, 0xB3);
 
     I2C_Write(ADDR_TP2825, 0x09, 0xa4);
     I2C_Write(ADDR_TP2825, 0x0A, 0x33);

--- a/src/driver/TP2825.c
+++ b/src/driver/TP2825.c
@@ -4,9 +4,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <log/log.h>
+
 #include "core/common.hh"
 #include "driver/gpio.h"
-#include "i2c.h"
+#include "driver/i2c.h"
 
 void TP2825_close() {
     gpio_set(GPIO_TP2825_RSTB, 0);
@@ -19,89 +21,98 @@ void TP2825_open() {
 // ch_sel: 0=AV in; 1=Module bay
 void TP2825_Config(int ch_sel, int is_pal) {
     TP2825_close();
-    usleep(1000);
+    usleep(10000);
     TP2825_open();
-    usleep(1000);
+    usleep(10000);
 
     I2C_Write(ADDR_TP2825, 0x41, ch_sel);
 
     if (is_pal) {
+        LOGD("init pal");
         I2C_Write(ADDR_TP2825, 0x02, 0xCE);
-        I2C_Write(ADDR_TP2825, 0x06, 0x34);
-        I2C_Write(ADDR_TP2825, 0x08, 0xD0);
-        I2C_Write(ADDR_TP2825, 0x07, 0x80);
-        I2C_Write(ADDR_TP2825, 0x0B, 0x80);
-        I2C_Write(ADDR_TP2825, 0x0C, 0x53);
         I2C_Write(ADDR_TP2825, 0x0D, 0x11);
-        // I2C_Write(ADDR_TP2825, 0x15, 0x13);
+
+        I2C_Write(ADDR_TP2825, 0x15, 0x13);
         I2C_Write(ADDR_TP2825, 0x16, 0x4A);
-        I2C_Write(ADDR_TP2825, 0x17, 0xC0);
-        I2C_Write(ADDR_TP2825, 0x18, 0x17);
-        I2C_Write(ADDR_TP2825, 0x19, 0x20);
+
         I2C_Write(ADDR_TP2825, 0x1A, 0x17);
-        I2C_Write(ADDR_TP2825, 0x20, 0xB0);
-        I2C_Write(ADDR_TP2825, 0x22, 0x39);
-        // I2C_Write(ADDR_TP2825, 0x23, 0x3c);
-        I2C_Write(ADDR_TP2825, 0x26, 0x02);
-        I2C_Write(ADDR_TP2825, 0x28, 0x41);
-        I2C_Write(ADDR_TP2825, 0x2A, 0xB0); // diable color kill
-        I2C_Write(ADDR_TP2825, 0x2B, 0x70);
+        I2C_Write(ADDR_TP2825, 0x17, 0xC0);
+        I2C_Write(ADDR_TP2825, 0x19, 0x20);
+
+        I2C_Write(ADDR_TP2825, 0x18, 0x13);
+
+        I2C_Write(ADDR_TP2825, 0x1C, 0x09);
+        I2C_Write(ADDR_TP2825, 0x1D, 0x48);
+
+        // I2C_Write(ADDR_TP2825, 0x20, 0xB0); // rational? default appears to reduce fringing on the image border
         I2C_Write(ADDR_TP2825, 0x2D, 0x60);
-        I2C_Write(ADDR_TP2825, 0x2E, 0x5E);
+
         I2C_Write(ADDR_TP2825, 0x30, 0x7A);
         I2C_Write(ADDR_TP2825, 0x31, 0x4A);
         I2C_Write(ADDR_TP2825, 0x32, 0x4D);
         I2C_Write(ADDR_TP2825, 0x33, 0xF0);
-        I2C_Write(ADDR_TP2825, 0x35, 0x65);
-        I2C_Write(ADDR_TP2825, 0x39, 0x84);
-        I2C_Write(ADDR_TP2825, 0x4C, 0x03);
-        I2C_Write(ADDR_TP2825, 0x4D, 0x03);
-        I2C_Write(ADDR_TP2825, 0x4E, 0x37);
-        I2C_Write(ADDR_TP2825, 0x1C, 0x09);
-        I2C_Write(ADDR_TP2825, 0x1D, 0x48);
     } else {
+        LOGD("init ntsc");
         I2C_Write(ADDR_TP2825, 0x02, 0xCF);
-        I2C_Write(ADDR_TP2825, 0x06, 0x34);
-        I2C_Write(ADDR_TP2825, 0x08, 0xD0);
-        I2C_Write(ADDR_TP2825, 0x07, 0x80);
-        I2C_Write(ADDR_TP2825, 0x0B, 0x80);
-        I2C_Write(ADDR_TP2825, 0x0C, 0x53);
         I2C_Write(ADDR_TP2825, 0x0D, 0x10);
-        // I2C_Write(ADDR_TP2825, 0x15, 0x13);
+
+        I2C_Write(ADDR_TP2825, 0x15, 0x13);
         I2C_Write(ADDR_TP2825, 0x16, 0x3C);
-        I2C_Write(ADDR_TP2825, 0x17, 0xC0);
-        I2C_Write(ADDR_TP2825, 0x18, 0x13);
-        I2C_Write(ADDR_TP2825, 0x19, 0xF0);
+
         I2C_Write(ADDR_TP2825, 0x1A, 0x07);
-        I2C_Write(ADDR_TP2825, 0x20, 0xA0);
-        I2C_Write(ADDR_TP2825, 0x22, 0x39);
-        // I2C_Write(ADDR_TP2825, 0x23, 0x3c);
-        I2C_Write(ADDR_TP2825, 0x26, 0x12);
-        I2C_Write(ADDR_TP2825, 0x28, 0x41);
-        I2C_Write(ADDR_TP2825, 0x2A, 0xB0); // diable color kill
-        I2C_Write(ADDR_TP2825, 0x2B, 0x70);
+        I2C_Write(ADDR_TP2825, 0x17, 0xC0);
+        I2C_Write(ADDR_TP2825, 0x19, 0xF0);
+
+        I2C_Write(ADDR_TP2825, 0x18, 0x11);
+
+        I2C_Write(ADDR_TP2825, 0x1C, 0x09);
+        I2C_Write(ADDR_TP2825, 0x1D, 0x38);
+
+        // I2C_Write(ADDR_TP2825, 0x20, 0xA0); // rational? default appears to reduce fringing on the image border
         I2C_Write(ADDR_TP2825, 0x2D, 0x68);
-        I2C_Write(ADDR_TP2825, 0x2E, 0x5E);
+
         I2C_Write(ADDR_TP2825, 0x30, 0x62);
         I2C_Write(ADDR_TP2825, 0x31, 0xBB);
         I2C_Write(ADDR_TP2825, 0x32, 0x96);
         I2C_Write(ADDR_TP2825, 0x33, 0xC0);
-        I2C_Write(ADDR_TP2825, 0x35, 0x65);
-        I2C_Write(ADDR_TP2825, 0x39, 0x84);
-        I2C_Write(ADDR_TP2825, 0x4C, 0x03);
-        I2C_Write(ADDR_TP2825, 0x4D, 0x03);
-        I2C_Write(ADDR_TP2825, 0x4E, 0x37);
-        I2C_Write(ADDR_TP2825, 0x1C, 0x09);
-        I2C_Write(ADDR_TP2825, 0x1D, 0x38);
     }
+
+    I2C_Write(ADDR_TP2825, 0x06, 0xB3);
+
+    I2C_Write(ADDR_TP2825, 0x09, 0xa4);
+    I2C_Write(ADDR_TP2825, 0x0A, 0x33);
+    I2C_Write(ADDR_TP2825, 0x0C, 0x7f);
+
+    // I2C_Write(ADDR_TP2825, 0x10, 0x0);  // brightness
+    // I2C_Write(ADDR_TP2825, 0x11, 0x3c); // contrast
+    // I2C_Write(ADDR_TP2825, 0x12, 0x40); // saturation
+    // I2C_Write(ADDR_TP2825, 0x13, 0x0);  // hue
+    // I2C_Write(ADDR_TP2825, 0x14, 0x2);  // sharpness
+
+    I2C_Write(ADDR_TP2825, 0x21, 0x6d); // improves exposure
+    I2C_Write(ADDR_TP2825, 0x22, 0x39);
+    I2C_Write(ADDR_TP2825, 0x23, 0x7c); // reset to 0x3D down the line
+    I2C_Write(ADDR_TP2825, 0x24, 0x59); // higher gain helps white flashes
+    I2C_Write(ADDR_TP2825, 0x25, 0xfa); // feels like default has no max value, we want _some_ limit
+    I2C_Write(ADDR_TP2825, 0x26, 0x42);
+    I2C_Write(ADDR_TP2825, 0x28, 0x45);
+    I2C_Write(ADDR_TP2825, 0x2A, 0xb1); // diable color kill
+    I2C_Write(ADDR_TP2825, 0x2C, 0x0a);
+
+    I2C_Write(ADDR_TP2825, 0x39, 0x04); // LPF makes image drop slower.
+
+    I2C_Write(ADDR_TP2825, 0x35, 0x65);
+    I2C_Write(ADDR_TP2825, 0x4C, 0x03);
+    I2C_Write(ADDR_TP2825, 0x4D, 0x03);
+    I2C_Write(ADDR_TP2825, 0x4E, 0x37);
 }
 
 // 0 = AV in; 1 = Module bay
 void TP2825_Switch_CH(uint8_t sel) {
     I2C_Write(ADDR_TP2825, 0x41, sel);
-    I2C_Write(ADDR_TP2825, 0x06, 0xB2);
+    I2C_Write(ADDR_TP2825, 0x06, 0xB3);
 }
 
 void TP2825_Set_Clamp(int set_default) {
-    I2C_Write(ADDR_TP2825, 0x23, set_default ? 0x3c : 0x7c);
+    I2C_Write(ADDR_TP2825, 0x23, set_default ? 0x3D : 0x7c);
 }

--- a/src/driver/TP2825.c
+++ b/src/driver/TP2825.c
@@ -16,8 +16,8 @@ void TP2825_open() {
     gpio_set(GPIO_TP2825_RSTB, 1);
 }
 
-void TP2825_Config(int ch_sel, int is_pal) // ch_sel: 0=AV in; 1=Module bay
-{
+// ch_sel: 0=AV in; 1=Module bay
+void TP2825_Config(int ch_sel, int is_pal) {
     TP2825_close();
     usleep(1000);
     TP2825_open();
@@ -96,8 +96,8 @@ void TP2825_Config(int ch_sel, int is_pal) // ch_sel: 0=AV in; 1=Module bay
     }
 }
 
-void TP2825_Switch_CH(uint8_t sel) // 0 = AV in; 1 = Module bay
-{
+// 0 = AV in; 1 = Module bay
+void TP2825_Switch_CH(uint8_t sel) {
     I2C_Write(ADDR_TP2825, 0x41, sel);
     I2C_Write(ADDR_TP2825, 0x06, 0xB2);
 }

--- a/src/driver/TP2825.h
+++ b/src/driver/TP2825.h
@@ -10,6 +10,6 @@ void TP2825_Init(int ch_sel, int is_pal);   // ch_sel: 0=AV in; 1=Module bay
 void TP2825_Config(int ch_sel, int is_pal); // ch_sel: 0=AV in; 1=Module bay
 
 void TP2825_Switch_CH(uint8_t sel); // 0 = AV in; 1 = Module bay
-void TP2825_Set_Clamp(int set_default);
+void TP2825_Set_Clamp(int set_low);
 
 #endif

--- a/src/driver/TP2825.h
+++ b/src/driver/TP2825.h
@@ -6,6 +6,7 @@
 void TP2825_close();
 void TP2825_open();
 
+void TP2825_Init(int ch_sel, int is_pal);   // ch_sel: 0=AV in; 1=Module bay
 void TP2825_Config(int ch_sel, int is_pal); // ch_sel: 0=AV in; 1=Module bay
 
 void TP2825_Switch_CH(uint8_t sel); // 0 = AV in; 1 = Module bay

--- a/src/driver/TP2825.h
+++ b/src/driver/TP2825.h
@@ -3,13 +3,17 @@
 
 #include <stdint.h>
 
+#define TP2825_CLAMP_MIN 0x3e
+#define TP2825_CLAMP_MID 0x4f
+#define TP2825_CLAMP_MAX 0x7f
+
 void TP2825_close();
 void TP2825_open();
 
-void TP2825_Init(int ch_sel, int is_pal);   // ch_sel: 0=AV in; 1=Module bay
-void TP2825_Config(int ch_sel, int is_pal); // ch_sel: 0=AV in; 1=Module bay
+void TP2825_Init(int ch_sel, int is_pal);                  // ch_sel: 0=AV in; 1=Module bay
+void TP2825_Config(int ch_sel, int is_pal, uint8_t clamp); // ch_sel: 0=AV in; 1=Module bay
 
 void TP2825_Switch_CH(uint8_t sel); // 0 = AV in; 1 = Module bay
-void TP2825_Set_Clamp(int set_low);
+void TP2825_Set_Clamp(uint8_t val);
 
 #endif

--- a/src/driver/hardware.c
+++ b/src/driver/hardware.c
@@ -8,17 +8,17 @@
 
 #include <log/log.h>
 
-#include "../core/common.hh"
-#include "../core/osd.h"
-#include "TP2825.h"
-#include "defines.h"
-#include "dm5680.h"
-#include "dm6302.h"
-#include "i2c.h"
-#include "it66021.h"
-#include "msp_displayport.h"
-#include "oled.h"
-#include "uart.h"
+#include "core/common.hh"
+#include "core/defines.h"
+#include "core/msp_displayport.h"
+#include "core/osd.h"
+#include "driver/TP2825.h"
+#include "driver/dm5680.h"
+#include "driver/dm6302.h"
+#include "driver/i2c.h"
+#include "driver/it66021.h"
+#include "driver/oled.h"
+#include "driver/uart.h"
 
 /////////////////////////////////////////////////////////////////////////
 // global

--- a/src/driver/hardware.c
+++ b/src/driver/hardware.c
@@ -214,7 +214,7 @@ void Source_AV(uint8_t sel) // 0=AV in, 1=AV module
 
     g_hw_stat.av_chid = sel;
     g_hw_stat.av_pal = 0; //(g_hw_stat.av_valid[sel] == 2) ? 1 : 0;
-    TP2825_Config(sel, g_hw_stat.av_pal);
+    TP2825_Init(sel, g_hw_stat.av_pal);
     AV_Mode_Switch_fpga(g_hw_stat.av_pal);
 
     I2C_Write(ADDR_FPGA, 0x8d, 0x14);

--- a/src/driver/hardware.c
+++ b/src/driver/hardware.c
@@ -364,9 +364,11 @@ int AV_in_detect() {
             if (counter > AV_DETECT_DROP_CNT) {
                 // signal dropped, lets search
                 state = AV_DETECT_INIT_SEARCH;
+                g_hw_stat.av_valid[g_hw_stat.av_chid] = 0;
                 counter = 0;
                 break;
             }
+            TP2825_Set_Clamp(0);
             counter++;
             break;
 
@@ -384,6 +386,10 @@ int AV_in_detect() {
             }
             if (vdet == 0x68) {
                 // some video was detected
+                if (counter == AV_DETECT_DET_CNT) {
+                    // first check after clamp has no vsync, ignore
+                    TP2825_Set_Clamp(1);
+                }
                 counter++;
                 break;
             }
@@ -394,6 +400,7 @@ int AV_in_detect() {
                 counter = 0;
                 last_vdet = 0;
             } else {
+                TP2825_Set_Clamp(0);
                 last_vdet = vdet;
             }
             break;
@@ -401,7 +408,6 @@ int AV_in_detect() {
 
         case AV_DETECT_VERIFY:
             if (counter > AV_DETECT_VERIFY_CNT) {
-                TP2825_Set_Clamp(1);
                 if (AV_Mode_Switch(g_hw_stat.av_pal)) {
                     ret = 1;
                 }


### PR DESCRIPTION
- tweak the TP2825 registers for better vsync retention and exposure
- rework the analog video detect sequence to a state machine with a delayed mode switch to allow for fast channel switching.