### PR TITLE
Add ELRS OSD and buzzer support

### DIFF
--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -47,7 +47,7 @@ uint16_t elrs_osd[HD_VMAX][HD_HMAX];
 static uint16_t elrs_osd_overlay[HD_VMAX][HD_HMAX];
 
 void msp_process_packet();
-static void handleOSD(uint8_t *payload, uint8_t size);
+static void handle_osd(uint8_t *payload, uint8_t size);
 
 static const uint16_t freq_table[] = {
     5658, 5695, 5732, 5769, 5806, 5843, 5880, 5917, // R1-8
@@ -292,7 +292,7 @@ void msp_process_packet() {
             beep_dur((packet.payload[0] | packet.payload[1]<<8) * 1000);
             break;
         case MSP_SET_OSD_ELEM:
-            handleOSD(packet.payload, packet.payload_size);
+            handle_osd(packet.payload, packet.payload_size);
             break;
         case MSP_SET_HT_ENABLE:
             if (packet.payload_size > 0) {
@@ -378,7 +378,7 @@ void elrs_clear_osd() {
     }
 }
 
-static void handleOSD(uint8_t payload[], uint8_t size) {
+static void handle_osd(uint8_t payload[], uint8_t size) {
     switch (payload[0]) {
     case 0x00: // hearbeat
         break;

--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -370,7 +370,7 @@ bool elrs_headtracking_enabled() {
     return headtracking_enabled;
 }
 
-static void clear_osd() {
+void elrs_clear_osd() {
     memset(elrs_osd_overlay, 0x20, sizeof(elrs_osd_overlay));
 }
 
@@ -379,12 +379,12 @@ static void handleOSD(uint8_t payload[], uint8_t size) {
     case 0x00: // hearbeat
         break;
     case 0x01: // release port
-        clear_osd();
+        elrs_clear_osd();
         memcpy(elrs_osd, elrs_osd_overlay, sizeof(elrs_osd));
         osd_signal_update();
         break;
     case 0x02: // clear screen
-        clear_osd();
+        elrs_clear_osd();
         break;
     case 0x03: // write string
     {

--- a/src/core/elrs.h
+++ b/src/core/elrs.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "core/msp_displayport.h"
+
 typedef enum {
     MSP_IDLE,
     MSP_HEADER_START,
@@ -58,6 +60,8 @@ typedef struct {
     uint16_t payload_offset;
     bool read_error;
 } mspPacket_t;
+
+extern uint16_t elrs_osd[HD_VMAX][HD_HMAX];
 
 void elrs_init();
 bool elrs_headtracking_enabled();

--- a/src/core/elrs.h
+++ b/src/core/elrs.h
@@ -61,6 +61,7 @@ typedef struct {
 
 void elrs_init();
 bool elrs_headtracking_enabled();
+void elrs_clear_osd();
 
 void msp_send_packet(uint16_t function, mspPacketType_e type, uint16_t payload_size, uint8_t *payload);
 bool msp_read_resposne(uint16_t function, uint16_t *payload_size, uint8_t *payload);

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -42,8 +42,6 @@ static uint16_t osd_buf_shadow[HD_VMAX][HD_HMAX];
 extern lv_style_t style_osd;
 extern pthread_mutex_t lvgl_mutex;
 
-extern uint8_t elrs_osd[HD_VMAX][HD_HMAX];
-
 ///////////////////////////////////////////////////////////////////
 //-1=error;
 // 0=idle,1=recording,2=stopped,3=No SD card,4=recorf file path error,

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -447,6 +447,7 @@ void osd_hdzero_update(void) {
 
 int osd_clear(void) {
     clear_screen();
+    elrs_clear_osd();
     osd_signal_update();
     return 0;
 }

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -18,6 +18,7 @@
 
 #include "core/battery.h"
 #include "core/common.hh"
+#include "core/elrs.h"
 #include "core/msp_displayport.h"
 #include "driver/dm5680.h"
 #include "driver/fans.h"
@@ -40,6 +41,8 @@ static uint16_t osd_buf_shadow[HD_VMAX][HD_HMAX];
 
 extern lv_style_t style_osd;
 extern pthread_mutex_t lvgl_mutex;
+
+extern uint8_t elrs_osd[HD_VMAX][HD_HMAX];
 
 ///////////////////////////////////////////////////////////////////
 //-1=error;
@@ -678,8 +681,10 @@ void *thread_osd(void *ptr) {
 
         for (int i = 0; i < HD_VMAX; i++) {
             for (int j = 0; j < HD_HMAX; j++) {
-                if (osd_buf[i][j] != osd_buf_shadow[i][j]) {
-                    osd_buf_shadow[i][j] = osd_buf[i][j];
+                uint16_t ch = osd_buf[i][j];
+                if (ch == 0x20) ch = elrs_osd[i][j];
+                if (ch != osd_buf_shadow[i][j]) {
+                    osd_buf_shadow[i][j] = ch;
                     draw_osd_on_screen(i, j);
                 }
             }


### PR DESCRIPTION
Adds support for receiving MSP commands to add the the OSD overlay. And also implements the buzzer command over MSP as well. 

The current VTx OSD takes precedence, so if the ELRS elements are put in places that are used then the existing ones are displayed.

This is in preparation for other backpack features that are in the works.

To test you should flash https://github.com/ExpressLRS/Backpack/pull/84 to the backpack. Also flash an ESP32 with the DEBUG_TX_Backpack and you can use the `osd_test.py` script in the Backpack repo for sending text to the goggle OSD.