### PR TITLE
Fix OSD not being cleared properly

### DIFF
--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -444,6 +444,7 @@ void osd_hdzero_update(void) {
 
 int osd_clear(void) {
     clear_screen();
+    osd_signal_update();
     return 0;
 }
 


### PR DESCRIPTION
As mentioned on discord, after flying HD, then switching to analog the OSD is not cleared.
Also, mentioned on discord when switching HD channels the OSD is not cleared.

The problem is that the OSD buffer is cleared by calling `osd_clear`, but then OSD thread was not signalled to copy the buffer to the shadow buffer (used for actual display). This fix adds a call to `osd_signal_update` in the `osd_clear` function so the OSD thread copies the data to the shadow buffer.