### PR TITLE
refactor, add settings for osd element positioning

### DIFF
--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -44,106 +44,106 @@ embedded_mode=0
 
 #### OSD elements ####
 # top fan speed
-element_show_topfan_speed=1
-element_pos_4_3_x_topfan_speed=160
-element_pos_4_3_y_topfan_speed=0
-element_pos_16_9_x_topfan_speed=0
-element_pos_16_9_y_topfan_speed=0
+element_topfan_speed_show=1
+element_topfan_speed_pos_4_3_x=160
+element_topfan_speed_pos_4_3_y=0
+element_topfan_speed_pos_16_9_x=0
+element_topfan_speed_pos_16_9_y=0
 
 # latency lock
-element_show_latency_lock=1
-element_pos_4_3_x_latency_lock=200
-element_pos_4_3_y_latency_lock=0
-element_pos_16_9_x_latency_lock=40
-element_pos_16_9_y_latency_lock=0
+element_latency_lock_show=1
+element_latency_lock_pos_4_3_x=200
+element_latency_lock_pos_4_3_y=0
+element_latency_lock_pos_16_9_x=40
+element_latency_lock_pos_16_9_y=0
 
 # vtx temp
-element_show_vtx_temp=1
-element_pos_4_3_x_vtx_temp=240
-element_pos_4_3_y_vtx_temp=0
-element_pos_16_9_x_vtx_temp=80
-element_pos_16_9_y_vtx_temp=0
+element_vtx_temp_show=1
+element_vtx_temp_pos_4_3_x=240
+element_vtx_temp_pos_4_3_y=0
+element_vtx_temp_pos_16_9_x=80
+element_vtx_temp_pos_16_9_y=0
 
 # vrx temp
-element_show_vrx_temp=1
-element_pos_4_3_x_vrx_temp=280
-element_pos_4_3_y_vrx_temp=0
-element_pos_16_9_x_vrx_temp=120
-element_pos_16_9_y_vrx_temp=0
+element_vrx_temp_show=1
+element_vrx_temp_pos_4_3_x=280
+element_vrx_temp_pos_4_3_y=0
+element_vrx_temp_pos_16_9_x=120
+element_vrx_temp_pos_16_9_y=0
 
 # battery low
-element_show_battery_low=1
-element_pos_4_3_x_battery_low=320
-element_pos_4_3_y_battery_low=0
-element_pos_16_9_x_battery_low=160
-element_pos_16_9_y_battery_low=0
+element_battery_low_show=1
+element_battery_low_pos_4_3_x=320
+element_battery_low_pos_4_3_y=0
+element_battery_low_pos_16_9_x=160
+element_battery_low_pos_16_9_y=0
 
 # channel
-element_show_channel=1
-element_pos_4_3_x_channel=540
-element_pos_4_3_y_channel=0
-element_pos_16_9_x_channel=540
-element_pos_16_9_y_channel=0
+element_channel_show=1
+element_channel_pos_4_3_x=540
+element_channel_pos_4_3_y=0
+element_channel_pos_16_9_x=540
+element_channel_pos_16_9_y=0
 
 # sd rec
-element_show_sd_rec=1
-element_pos_4_3_x_sd_rec=840
-element_pos_4_3_y_sd_rec=0
-element_pos_16_9_x_sd_rec=1000
-element_pos_16_9_y_sd_rec=0
+element_sd_rec_show=1
+element_sd_rec_pos_4_3_x=840
+element_sd_rec_pos_4_3_y=0
+element_sd_rec_pos_16_9_x=1000
+element_sd_rec_pos_16_9_y=0
 
 # vlq
-element_show_vlq=1
-element_pos_4_3_x_vlq=880
-element_pos_4_3_y_vlq=0
-element_pos_16_9_x_vlq=1040
-element_pos_16_9_y_vlq=0
+element_vlq_show=1
+element_vlq_pos_4_3_x=880
+element_vlq_pos_4_3_y=0
+element_vlq_pos_16_9_x=1040
+element_vlq_pos_16_9_y=0
 
 # antenna 0
-element_show_ant0=1
-element_pos_4_3_x_ant0=960
-element_pos_4_3_y_ant0=0
-element_pos_16_9_x_ant0=1120
-element_pos_16_9_y_ant0=0
+element_ant0_show=1
+element_ant0_pos_4_3_x=960
+element_ant0_pos_4_3_y=0
+element_ant0_pos_16_9_x=1120
+element_ant0_pos_16_9_y=0
 
 # antenna 1
-element_show_ant1=1
-element_pos_4_3_x_ant1=920
-element_pos_4_3_y_ant1=0
-element_pos_16_9_x_ant1=1080
-element_pos_16_9_y_ant1=0
+element_ant1_show=1
+element_ant1_pos_4_3_x=920
+element_ant1_pos_4_3_y=0
+element_ant1_pos_16_9_x=1080
+element_ant1_pos_16_9_y=0
 
 # antenna 2
-element_show_ant2=1
-element_pos_4_3_x_ant2=1040
-element_pos_4_3_y_ant2=0
-element_pos_16_9_x_ant2=1200
-element_pos_16_9_y_ant2=0
+element_ant2_show=1
+element_ant2_pos_4_3_x=1040
+element_ant2_pos_4_3_y=0
+element_ant2_pos_16_9_x=1200
+element_ant2_pos_16_9_y=0
 
 # antenna 3
-element_show_ant3=1
-element_pos_4_3_x_ant3=1000
-element_pos_4_3_y_ant3=0
-element_pos_16_9_x_ant3=1160
-element_pos_16_9_y_ant3=0
+element_ant3_show=1
+element_ant3_pos_4_3_x=1000
+element_ant3_pos_4_3_y=0
+element_ant3_pos_16_9_x=1160
+element_ant3_pos_16_9_y=0
 
 # goggle temp top
-element_show_goggle_temp_top=1
-element_pos_4_3_x_goggle_temp_top=170
-element_pos_4_3_y_goggle_temp_top=50
-element_pos_16_9_x_goggle_temp_top=170
-element_pos_16_9_y_goggle_temp_top=50
+element_goggle_temp_top_show=1
+element_goggle_temp_top_pos_4_3_x=170
+element_goggle_temp_top_pos_4_3_y=50
+element_goggle_temp_top_pos_16_9_x=170
+element_goggle_temp_top_pos_16_9_y=50
 
 # goggle temp left
-element_show_goggle_temp_left=1
-element_pos_4_3_x_goggle_temp_left=270
-element_pos_4_3_y_goggle_temp_left=50
-element_pos_16_9_x_goggle_temp_left=270
-element_pos_16_9_y_goggle_temp_left=50
+element_goggle_temp_left_show=1
+element_goggle_temp_left_pos_4_3_x=270
+element_goggle_temp_left_pos_4_3_y=50
+element_goggle_temp_left_pos_16_9_x=270
+element_goggle_temp_left_pos_16_9_y=50
 
 # goggle temp right
-element_show_goggle_temp_right=1
-element_pos_4_3_x_goggle_temp_right=370
-element_pos_4_3_y_goggle_temp_right=50
-element_pos_16_9_x_goggle_temp_right=370
-element_pos_16_9_y_goggle_temp_right=50
+element_goggle_temp_right_show=1
+element_goggle_temp_right_pos_4_3_x=370
+element_goggle_temp_right_pos_4_3_y=50
+element_goggle_temp_right_pos_16_9_x=370
+element_goggle_temp_right_pos_16_9_y=50

--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -41,3 +41,109 @@ enable=0
 
 [osd]
 embedded_mode=0
+
+#### OSD elements ####
+# top fan speed
+element_show_topfan_speed=1
+element_pos_4_3_x_topfan_speed=160
+element_pos_4_3_y_topfan_speed=0
+element_pos_16_9_x_topfan_speed=0
+element_pos_16_9_y_topfan_speed=0
+
+# latency lock
+element_show_latency_lock=1
+element_pos_4_3_x_latency_lock=200
+element_pos_4_3_y_latency_lock=0
+element_pos_16_9_x_latency_lock=40
+element_pos_16_9_y_latency_lock=0
+
+# vtx temp
+element_show_vtx_temp=1
+element_pos_4_3_x_vtx_temp=240
+element_pos_4_3_y_vtx_temp=0
+element_pos_16_9_x_vtx_temp=80
+element_pos_16_9_y_vtx_temp=0
+
+# vrx temp
+element_show_vrx_temp=1
+element_pos_4_3_x_vrx_temp=280
+element_pos_4_3_y_vrx_temp=0
+element_pos_16_9_x_vrx_temp=120
+element_pos_16_9_y_vrx_temp=0
+
+# battery low
+element_show_battery_low=1
+element_pos_4_3_x_battery_low=320
+element_pos_4_3_y_battery_low=0
+element_pos_16_9_x_battery_low=160
+element_pos_16_9_y_battery_low=0
+
+# channel
+element_show_channel=1
+element_pos_4_3_x_channel=540
+element_pos_4_3_y_channel=0
+element_pos_16_9_x_channel=540
+element_pos_16_9_y_channel=0
+
+# sd rec
+element_show_sd_rec=1
+element_pos_4_3_x_sd_rec=840
+element_pos_4_3_y_sd_rec=0
+element_pos_16_9_x_sd_rec=1000
+element_pos_16_9_y_sd_rec=0
+
+# vlq
+element_show_vlq=1
+element_pos_4_3_x_vlq=880
+element_pos_4_3_y_vlq=0
+element_pos_16_9_x_vlq=1040
+element_pos_16_9_y_vlq=0
+
+# antenna 0
+element_show_ant0=1
+element_pos_4_3_x_ant0=960
+element_pos_4_3_y_ant0=0
+element_pos_16_9_x_ant0=1120
+element_pos_16_9_y_ant0=0
+
+# antenna 1
+element_show_ant1=1
+element_pos_4_3_x_ant1=920
+element_pos_4_3_y_ant1=0
+element_pos_16_9_x_ant1=1080
+element_pos_16_9_y_ant1=0
+
+# antenna 2
+element_show_ant2=1
+element_pos_4_3_x_ant2=1040
+element_pos_4_3_y_ant2=0
+element_pos_16_9_x_ant2=1200
+element_pos_16_9_y_ant2=0
+
+# antenna 3
+element_show_ant3=1
+element_pos_4_3_x_ant3=1000
+element_pos_4_3_y_ant3=0
+element_pos_16_9_x_ant3=1160
+element_pos_16_9_y_ant3=0
+
+# goggle temp top
+element_show_goggle_temp_top=1
+element_pos_4_3_x_goggle_temp_top=170
+element_pos_4_3_y_goggle_temp_top=50
+element_pos_16_9_x_goggle_temp_top=170
+element_pos_16_9_y_goggle_temp_top=50
+
+# goggle temp left
+element_show_goggle_temp_left=1
+element_pos_4_3_x_goggle_temp_left=270
+element_pos_4_3_y_goggle_temp_left=50
+element_pos_16_9_x_goggle_temp_left=270
+element_pos_16_9_y_goggle_temp_left=50
+
+# goggle temp right
+element_show_goggle_temp_right=1
+element_pos_4_3_x_goggle_temp_right=370
+element_pos_4_3_y_goggle_temp_right=50
+element_pos_16_9_x_goggle_temp_right=370
+element_pos_16_9_y_goggle_temp_right=50

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -42,19 +42,19 @@
 static void load_osd_element_ini_settings(setting_osd_goggle_element_t *element, char *config_name, const setting_osd_goggle_element_t *defaults) {
     char buf[128];
 
-    sprintf(buf, "element_show_%s", config_name);
+    sprintf(buf, "element_%s_show", config_name);
     element->show = ini_getl("osd", buf, defaults->show, SETTING_INI);
 
-    sprintf(buf, "element_pos_4_3_x_%s", config_name);
+    sprintf(buf, "element_%s_pos_4_3_x", config_name);
     element->position.mode_4_3.x = ini_getl("osd", buf, defaults->position.mode_4_3.x, SETTING_INI);
 
-    sprintf(buf, "element_pos_4_3_y_%s", config_name);
+    sprintf(buf, "element_%s_pos_4_3_y", config_name);
     element->position.mode_4_3.y = ini_getl("osd", buf, defaults->position.mode_4_3.y, SETTING_INI);
 
-    sprintf(buf, "element_pos_16_9_x_%s", config_name);
+    sprintf(buf, "element_%s_pos_16_9_x", config_name);
     element->position.mode_16_9.x = ini_getl("osd", buf, defaults->position.mode_16_9.x, SETTING_INI);
 
-    sprintf(buf, "element_pos_16_9_y_%s", config_name);
+    sprintf(buf, "element_%s_pos_16_9_y", config_name);
     element->position.mode_16_9.y = ini_getl("osd", buf, defaults->position.mode_16_9.y, SETTING_INI);
 }
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -39,6 +39,25 @@
 #include "ui/ui_statusbar.h"
 #include "util/file.h"
 
+static void load_osd_element_ini_settings(setting_osd_goggle_element_t *element, char *config_name, const setting_osd_goggle_element_t *defaults) {
+    char buf[128];
+
+    sprintf(buf, "element_show_%s", config_name);
+    element->show = ini_getl("osd", buf, defaults->show, SETTING_INI);
+
+    sprintf(buf, "element_pos_4_3_x_%s", config_name);
+    element->position.mode_4_3.x = ini_getl("osd", buf, defaults->position.mode_4_3.x, SETTING_INI);
+
+    sprintf(buf, "element_pos_4_3_y_%s", config_name);
+    element->position.mode_4_3.y = ini_getl("osd", buf, defaults->position.mode_4_3.y, SETTING_INI);
+
+    sprintf(buf, "element_pos_16_9_x_%s", config_name);
+    element->position.mode_16_9.x = ini_getl("osd", buf, defaults->position.mode_16_9.x, SETTING_INI);
+
+    sprintf(buf, "element_pos_16_9_y_%s", config_name);
+    element->position.mode_16_9.y = ini_getl("osd", buf, defaults->position.mode_16_9.y, SETTING_INI);
+}
+
 static void load_ini_setting(void) {
     char str[128];
 
@@ -52,14 +71,14 @@ static void load_ini_setting(void) {
         system("rm /mnt/UDISK/setting.ini");
     }
 
-    g_setting.scan.channel = ini_getl("scan", "channel", 1, SETTING_INI);
+    g_setting.scan.channel = ini_getl("scan", "channel", g_setting_defaults.scan.channel, SETTING_INI);
 
     // fans
     ini_gets("fans", "auto", "enable", str, sizeof(str), SETTING_INI);
     g_setting.fans.auto_mode = strcmp(str, "enable") == 0;
-    g_setting.fans.top_speed = ini_getl("fans", "top_speed", 4, SETTING_INI);
-    g_setting.fans.left_speed = ini_getl("fans", "left_speed", 5, SETTING_INI);
-    g_setting.fans.right_speed = ini_getl("fans", "right_speed", 5, SETTING_INI);
+    g_setting.fans.top_speed = ini_getl("fans", "top_speed", g_setting_defaults.fans.top_speed, SETTING_INI);
+    g_setting.fans.left_speed = ini_getl("fans", "left_speed", g_setting_defaults.fans.left_speed, SETTING_INI);
+    g_setting.fans.right_speed = ini_getl("fans", "right_speed", g_setting_defaults.fans.right_speed, SETTING_INI);
 
     // autoscan
     ini_gets("autoscan", "status", "scan", str, sizeof(str), SETTING_INI);
@@ -70,18 +89,35 @@ static void load_ini_setting(void) {
     } else {
         g_setting.autoscan.status = 2;
     }
-    g_setting.autoscan.source = ini_getl("autoscan", "source", SETTING_SOURCE_LAST, SETTING_INI);
-    g_setting.autoscan.last_source = ini_getl("autoscan", "last_source", SETTING_SOURCE_HDZERO, SETTING_INI);
+    g_setting.autoscan.source = ini_getl("autoscan", "source", g_setting_defaults.autoscan.source, SETTING_INI);
+    g_setting.autoscan.last_source = ini_getl("autoscan", "last_source", g_setting_defaults.autoscan.last_source, SETTING_INI);
 
-    // embedded osd mode 4x3 default
-    g_setting.osd.embedded_mode = ini_getl("osd", "embedded_mode", EMBEDDED_4x3, SETTING_INI);
+    // osd
+    g_setting.osd.embedded_mode = ini_getl("osd", "embedded_mode", g_setting_defaults.osd.embedded_mode, SETTING_INI);
+    load_osd_element_ini_settings(&g_setting.osd.elements.topfan_speed, "topfan_speed", &g_setting_defaults.osd.elements.topfan_speed);
+    load_osd_element_ini_settings(&g_setting.osd.elements.latency_lock, "latency_lock", &g_setting_defaults.osd.elements.latency_lock);
+    load_osd_element_ini_settings(&g_setting.osd.elements.vtx_temp, "vtx_temp", &g_setting_defaults.osd.elements.vtx_temp);
+    load_osd_element_ini_settings(&g_setting.osd.elements.vrx_temp, "vrx_temp", &g_setting_defaults.osd.elements.vrx_temp);
+    load_osd_element_ini_settings(&g_setting.osd.elements.battery_low, "battery_low", &g_setting_defaults.osd.elements.battery_low);
+    load_osd_element_ini_settings(&g_setting.osd.elements.channel, "channel", &g_setting_defaults.osd.elements.channel);
+    load_osd_element_ini_settings(&g_setting.osd.elements.sd_rec, "sd_rec", &g_setting_defaults.osd.elements.sd_rec);
+    load_osd_element_ini_settings(&g_setting.osd.elements.vlq, "vlq", &g_setting_defaults.osd.elements.vlq);
+    load_osd_element_ini_settings(&g_setting.osd.elements.ant0, "ant0", &g_setting_defaults.osd.elements.ant0);
+    load_osd_element_ini_settings(&g_setting.osd.elements.ant1, "ant1", &g_setting_defaults.osd.elements.ant1);
+    load_osd_element_ini_settings(&g_setting.osd.elements.ant2, "ant2", &g_setting_defaults.osd.elements.ant2);
+    load_osd_element_ini_settings(&g_setting.osd.elements.ant3, "ant3", &g_setting_defaults.osd.elements.ant3);
+    load_osd_element_ini_settings(&g_setting.osd.elements.goggle_temp_top, "goggle_temp_top", &g_setting_defaults.osd.elements.goggle_temp_top);
+    load_osd_element_ini_settings(&g_setting.osd.elements.goggle_temp_left, "goggle_temp_left", &g_setting_defaults.osd.elements.goggle_temp_left);
+    load_osd_element_ini_settings(&g_setting.osd.elements.goggle_temp_right, "goggle_temp_right", &g_setting_defaults.osd.elements.goggle_temp_right);
 
     // power
-    g_setting.power.voltage = ini_getl("power", "voltage", 35, SETTING_INI);
-    g_setting.power.warning_type = ini_getl("power", "warning_type", 0, SETTING_INI);
-    g_setting.power.cell_count_mode = ini_getl("power", "cell_count_mode", 0, SETTING_INI);
-    g_setting.power.cell_count = ini_getl("power", "cell_count", 2, SETTING_INI);
-    g_setting.power.osd_display_mode = ini_getl("power", "osd_display_mode", 0, SETTING_INI);
+    g_setting.power.voltage = ini_getl("power", "voltage", g_setting_defaults.power.voltage, SETTING_INI);
+    g_setting.power.warning_type = ini_getl("power", "warning_type", g_setting_defaults.power.warning_type, SETTING_INI);
+    g_setting.power.cell_count_mode = ini_getl("power", "cell_count_mode", g_setting_defaults.power.cell_count_mode, SETTING_INI);
+    g_setting.power.cell_count = ini_getl("power", "cell_count", g_setting_defaults.power.cell_count, SETTING_INI);
+    g_setting.power.osd_display_mode = ini_getl("power", "osd_display_mode", g_setting_defaults.power.osd_display_mode, SETTING_INI);
+
+    // record
     ini_gets("record", "mode_manual", "disable", str, sizeof(str), SETTING_INI);
     g_setting.record.mode_manual = strcmp(str, "enable") == 0;
     ini_gets("record", "format_ts", "enable", str, sizeof(str), SETTING_INI);
@@ -91,26 +127,26 @@ static void load_ini_setting(void) {
     ini_gets("record", "audio", "enable", str, sizeof(str), SETTING_INI);
     g_setting.record.audio = strcmp(str, "enable") == 0;
 
-    g_setting.record.audio_source = ini_getl("record", "audio_source", 0, SETTING_INI);
+    g_setting.record.audio_source = ini_getl("record", "audio_source", g_setting_defaults.record.audio_source, SETTING_INI);
 
     // image
-    g_setting.image.oled = ini_getl("image", "oled", 7, SETTING_INI);
-    g_setting.image.brightness = ini_getl("image", "brightness", 0, SETTING_INI);
-    g_setting.image.saturation = ini_getl("image", "saturation", 0, SETTING_INI);
-    g_setting.image.contrast = ini_getl("image", "contrast", 0, SETTING_INI);
-    g_setting.image.auto_off = ini_getl("image", "auto_off", 2, SETTING_INI);
+    g_setting.image.oled = ini_getl("image", "oled", g_setting_defaults.image.oled, SETTING_INI);
+    g_setting.image.brightness = ini_getl("image", "brightness", g_setting_defaults.image.brightness, SETTING_INI);
+    g_setting.image.saturation = ini_getl("image", "saturation", g_setting_defaults.image.saturation, SETTING_INI);
+    g_setting.image.contrast = ini_getl("image", "contrast", g_setting_defaults.image.contrast, SETTING_INI);
+    g_setting.image.auto_off = ini_getl("image", "auto_off", g_setting_defaults.image.auto_off, SETTING_INI);
 
     // head tracker
-    g_setting.ht.enable = ini_getl("ht", "enable", 0, SETTING_INI);
-    g_setting.ht.max_angle = ini_getl("ht", "max_angle", 120, SETTING_INI);
-    g_setting.ht.acc_x = ini_getl("ht", "acc_x", 0, SETTING_INI);
-    g_setting.ht.acc_y = ini_getl("ht", "acc_y", 0, SETTING_INI);
-    g_setting.ht.acc_z = ini_getl("ht", "acc_z", 0, SETTING_INI);
-    g_setting.ht.gyr_x = ini_getl("ht", "gyr_x", 0, SETTING_INI);
-    g_setting.ht.gyr_y = ini_getl("ht", "gyr_y", 0, SETTING_INI);
-    g_setting.ht.gyr_z = ini_getl("ht", "gyr_z", 0, SETTING_INI);
+    g_setting.ht.enable = ini_getl("ht", "enable", g_setting_defaults.ht.enable, SETTING_INI);
+    g_setting.ht.max_angle = ini_getl("ht", "max_angle", g_setting_defaults.ht.max_angle, SETTING_INI);
+    g_setting.ht.acc_x = ini_getl("ht", "acc_x", g_setting_defaults.ht.acc_x, SETTING_INI);
+    g_setting.ht.acc_y = ini_getl("ht", "acc_y", g_setting_defaults.ht.acc_y, SETTING_INI);
+    g_setting.ht.acc_z = ini_getl("ht", "acc_z", g_setting_defaults.ht.acc_z, SETTING_INI);
+    g_setting.ht.gyr_x = ini_getl("ht", "gyr_x", g_setting_defaults.ht.gyr_x, SETTING_INI);
+    g_setting.ht.gyr_y = ini_getl("ht", "gyr_y", g_setting_defaults.ht.gyr_y, SETTING_INI);
+    g_setting.ht.gyr_z = ini_getl("ht", "gyr_z", g_setting_defaults.ht.gyr_z, SETTING_INI);
 
-    g_setting.elrs.enable = ini_getl("elrs", "enable", 0, SETTING_INI);
+    g_setting.elrs.enable = ini_getl("elrs", "enable", g_setting_defaults.elrs.enable, SETTING_INI);
 
     // Check
     g_test_en = false;

--- a/src/core/osd.h
+++ b/src/core/osd.h
@@ -17,19 +17,21 @@
 #define LINE_LENGTH_1 1460                       // bmp have boundry
 
 typedef struct {
-    lv_obj_t *topfan_speed; // 0
-    lv_obj_t *vtx_temp;     // 1
-    lv_obj_t *battery;      // 2
-    lv_obj_t *vrx_temp;     // 3
-    lv_obj_t *latency_lock; // 4
-    lv_obj_t *ch;           // middle
-    lv_obj_t *sd_rec;       // 5
-    lv_obj_t *vlq;          // 6
-    lv_obj_t *ant0;         // 7
-    lv_obj_t *ant1;         // 8
-    lv_obj_t *ant2;         // 9
-    lv_obj_t *ant3;         // 10
-    lv_obj_t *osd_tempe[3]; // top,left,bot
+    lv_obj_t *topfan_speed;
+    lv_obj_t *latency_lock;
+    lv_obj_t *vtx_temp;
+    lv_obj_t *vrx_temp;
+    lv_obj_t *battery_low;
+    lv_obj_t *channel;
+    lv_obj_t *sd_rec;
+    lv_obj_t *vlq;
+    lv_obj_t *ant0;
+    lv_obj_t *ant1;
+    lv_obj_t *ant2;
+    lv_obj_t *ant3;
+    lv_obj_t *goggle_temp_top;
+    lv_obj_t *goggle_temp_left;
+    lv_obj_t *goggle_temp_right;
 } osd_hdzero_t;
 
 typedef struct

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -19,6 +19,72 @@ bool g_showRXOSD = true;
 bool g_latency_locked = false;
 bool g_test_en = false;
 source_info_t g_source_info;
+const setting_t g_setting_defaults = {
+    // ### scan ###
+    {
+        // channel
+        1},
+
+    // ### fans ###
+    {
+        // top_speed, auto_mode, left_speed, right_speed
+        4, true, 5, 5},
+
+    // ### autoscan ###
+    {
+        // status, last_source, source
+        SETTING_AUTOSCAN_SCAN, SETTING_SOURCE_LAST, SETTING_SOURCE_HDZERO},
+
+    // ### power ###
+    {
+        // voltage, display_voltage, warning_type, cell_count_mode, cell_count, osd_display_mode
+        35, true, 2, SETTING_POWER_CELL_COUNT_MODE_AUTO, 2, SETTING_POWER_OSD_DISPLAY_MODE_TOTAL},
+
+    // ### record ###
+    {
+        // mode_manual, format_ts, osd, audio, audio_source
+        false, true, true, true, 0},
+
+    // ### image ###
+    {
+        // oled, brightness, saturation, contrast, auto_off
+        7, 0, 0, 0, 2},
+
+    // ### head tracker ###
+    {
+        // enable, max_angle, acc_x, acc_y, acc_z, gyr_x, gyr_y, gyr_z
+        false, 120, 0, 0, 0, 0, 0, 0},
+
+    // ### ELRS ###
+    {
+        // enable
+        false},
+
+    // ### OSD ###
+    {
+        // embedded_mode
+        EMBEDDED_4x3,
+        //      elements
+        // show       position
+        //       mode_4_3   mode_16_9
+        //        x    y    x   y
+        {{true, {{160, 0}, {0, 0}}},     // topfan_speed
+         {true, {{200, 0}, {40, 0}}},    // latency_lock
+         {true, {{240, 0}, {80, 0}}},    // vtx_temp
+         {true, {{280, 0}, {120, 0}}},   // vrx_temp
+         {true, {{320, 0}, {160, 0}}},   // battery_low
+         {true, {{540, 0}, {540, 0}}},   // channel
+         {true, {{840, 0}, {1000, 0}}},  // sd_rec
+         {true, {{880, 0}, {1040, 0}}},  // vlq
+         {true, {{960, 0}, {1120, 0}}},  // ant0
+         {true, {{920, 0}, {1080, 0}}},  // ant1
+         {true, {{1040, 0}, {1200, 0}}}, // ant2
+         {true, {{1000, 0}, {1160, 0}}}, // ant3
+         {true, {{170, 50}, {170, 50}}}, // goggle_temp_top
+         {true, {{270, 50}, {270, 50}}}, // goggle_temp_left
+         {true, {{370, 50}, {370, 50}}}} // goggle_temp_right
+    }};
+
 /////////////////////////////////////////////////////////////////////////////
 
 LV_IMG_DECLARE(img_arrow);

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -141,7 +141,41 @@ typedef enum {
 } embedded_mode_t;
 
 typedef struct {
+    int x;
+    int y;
+} setting_osd_goggle_element_position_t;
+
+typedef struct {
+    setting_osd_goggle_element_position_t mode_4_3;
+    setting_osd_goggle_element_position_t mode_16_9;
+} setting_osd_goggle_element_positions_t;
+
+typedef struct {
+    bool show;
+    setting_osd_goggle_element_positions_t position;
+} setting_osd_goggle_element_t;
+
+typedef struct {
+    setting_osd_goggle_element_t topfan_speed;
+    setting_osd_goggle_element_t latency_lock;
+    setting_osd_goggle_element_t vtx_temp;
+    setting_osd_goggle_element_t vrx_temp;
+    setting_osd_goggle_element_t battery_low;
+    setting_osd_goggle_element_t channel;
+    setting_osd_goggle_element_t sd_rec;
+    setting_osd_goggle_element_t vlq;
+    setting_osd_goggle_element_t ant0;
+    setting_osd_goggle_element_t ant1;
+    setting_osd_goggle_element_t ant2;
+    setting_osd_goggle_element_t ant3;
+    setting_osd_goggle_element_t goggle_temp_top;
+    setting_osd_goggle_element_t goggle_temp_left;
+    setting_osd_goggle_element_t goggle_temp_right;
+} setting_osd_goggle_elements_t;
+
+typedef struct {
     embedded_mode_t embedded_mode;
+    setting_osd_goggle_elements_t elements;
 } setting_osd_t;
 
 typedef struct {
@@ -214,6 +248,7 @@ enum {
 typedef uint8_t lv_menu_builder_variant_t;
 
 extern setting_t g_setting;
+extern const setting_t g_setting_defaults;
 extern op_level_t g_menu_op;
 extern bool g_sdcard_enable;
 extern bool g_sdcard_det_req;


### PR DESCRIPTION
Refactored OSD code to allow for individual element positioning and visibility settings (with settings saving x,y for both 4x3 and 16x9 modes) in preparation for a dedicated OSD settings page.
No (intentional) UI changes, besides changing the order of some OSD elements.
Added "g_setting_defaults" const setting_t struct instance to hold defaults for all settings values in one place.

Gonna need help testing this one, if the approach looks good.