### PR TITLE
RTC Driver for setting/getting hardware clock.

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -28,6 +28,7 @@
 #include "driver/it66121.h"
 #include "driver/mcp3021.h"
 #include "driver/oled.h"
+#include "driver/rtc.h"
 #include "ui/page_power.h"
 #include "ui/page_scannow.h"
 #include "ui/page_source.h"
@@ -251,6 +252,7 @@ int main(int argc, char *argv[]) {
     uart_init();
     hw_stat_init();
     device_init();
+    rtc_init();
 
     osd_init();
     ims_init();

--- a/src/driver/rtc.c
+++ b/src/driver/rtc.c
@@ -1,0 +1,129 @@
+#include "rtc.h"
+
+#include <linux/rtc.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <log/log.h>
+
+#include "util/file.h"
+
+/**
+ *  Constants
+ */
+static const char* RTC_FILE = "/mnt/extsd/rtc.txt";
+
+/**
+ *  Conversion Utils
+ */
+void rd2rt(const struct rtc_date* rd, struct rtc_time* rt) {
+	rt->tm_year = rd->year - 1900;
+	rt->tm_mon  = rd->month - 1;
+	rt->tm_mday = rd->day;
+	rt->tm_hour = rd->hour;
+	rt->tm_min  = rd->min;
+	rt->tm_sec  = rd->sec;
+}
+void rt2rd(const struct rtc_time* rt, struct rtc_date* rd) {
+	rd->year  = rt->tm_year + 1900;
+	rd->month = rt->tm_mon + 1;
+	rd->day   = rt->tm_mday;
+	rd->hour  = rt->tm_hour;
+	rd->min   = rt->tm_min;
+	rd->sec   = rt->tm_sec;
+}
+
+/**
+ *  Initialize RTC from file if detected,
+ *  must be formatted to ISO-8601:
+ *  YYYY-MM-DDTHH:MM:SS
+ *  2023-03-10T01:05:15
+ */
+void rtc_init() {
+	if (file_exists(RTC_FILE)) {
+		FILE* fp = fopen(RTC_FILE, "r");
+		if (fp) {
+			static char buffer[32];
+			while(fgets(buffer,sizeof(buffer),fp)) {
+				struct rtc_date rd;
+				sscanf(buffer,
+				       "%04d-%02d-%02dT%02d:%02d:%02d",
+					   &rd.year,
+					   &rd.month,
+					   &rd.day,
+					   &rd.hour,
+					   &rd.min,
+					   &rd.sec);
+			    rtc_set_clock(&rd);
+			}
+			fclose(fp);
+		}
+	}
+	
+	rtc_timestamp();
+}
+
+/**
+ *  Format RTC in a standard format
+ */
+static inline
+void rtc_print(const struct rtc_date* rd) {
+	LOGI("RTC: %04d-%02d-%02dT%02d:%02d:%02d\n",
+		 rd->year,
+		 rd->month,
+		 rd->day,
+		 rd->hour,
+		 rd->min,
+		 rd->sec);
+}
+
+/**
+ *  Log RTC in a standard format
+ */
+void rtc_timestamp() {
+	struct rtc_date rd;
+	rtc_get_clock(&rd);
+	rtc_print(&rd);
+}
+
+/**
+ *  Set Hardware Clock
+ */
+void rtc_set_clock(const struct rtc_date* rd) {
+	int fd = open("/dev/rtc", O_WRONLY);
+	if (fd != -1) {
+		struct rtc_time rt;
+		rd2rt(rd,&rt);
+		if (ioctl(fd, RTC_SET_TIME, &rt) != 0) {
+			LOGI("ioctl(%d,RTC_SET_TIME,rt) failed with errno(%d)\n", errno);
+		}
+		close(fd);
+	}
+	else {
+		LOGI("Failed to open(/dev/rtc, O_WRONLY)\n");
+	}
+}	
+
+/**
+ *  Get Hardware Clock
+ */
+void rtc_get_clock(struct rtc_date* rd) {
+	int fd = open("/dev/rtc", O_RDONLY);
+	if (fd != -1) {
+		struct rtc_time rt;
+		if (ioctl(fd, RTC_RD_TIME, &rt) == 0) {
+			rt2rd(&rt, rd);
+		}
+		else {
+			LOGI("ioctl(%d,RTC_RD_TIME,rt) failed with errno(%d)\n", errno);
+		}
+		close(fd);
+	}
+	else {
+		LOGI("Failed to open(/dev/rtc, O_RDONLY)\n");
+	}
+}

--- a/src/driver/rtc.h
+++ b/src/driver/rtc.h
@@ -1,0 +1,18 @@
+#ifndef _RTC_H
+#define _RTC_H
+
+struct rtc_date {
+	int year;  // YYYY
+	int month; // 1 - 12
+	int day;   // 1 - 31
+	int hour;  // 0 - 23
+	int min;   // 0 - 59 
+	int sec;   // 0 - 59
+};
+
+void rtc_init_from_file();
+void rtc_timestamp();
+void rtc_set_clock(const struct rtc_date* rd);
+void rtc_get_clock(struct rtc_date* rd);
+
+#endif


### PR DESCRIPTION
Introducing RTC driver.  For setting up the initial date/time create a file on the root of the sd card called rtc.txt and add the following line to initialize the hardware clock:

2023-03-10T01:17:30

Once initialized the file can be deleted, otherwise the next time the goggles power up it will be 
set to the time specified in the file.  I purchased a compatible battery from Amazon:  https://a.co/d/ajZNTnZ

[rtc.txt](https://github.com/hd-zero/hdzero-goggle/files/10939234/rtc.txt)