### PR TITLE
Add clock update function via ELRS backpack

### DIFF
--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -28,6 +28,7 @@
 #include "driver/dm5680.h"
 #include "driver/gpio.h"
 #include "driver/hardware.h"
+#include "driver/rtc.h"
 #include "driver/uart.h"
 #include "ui/page_common.h"
 #include "ui/page_scannow.h"
@@ -303,6 +304,18 @@ void msp_process_packet() {
                 if (headtracking_enabled) {
                     ht_set_center_position();
                 }
+            }
+            break;
+        case MSP_SET_RTC:
+            if (packet.payload_size > 0) {
+                struct rtc_date rd;
+                rd.year = packet.payload[0] + 1900;
+                rd.month = packet.payload[1] + 1;
+                rd.day = packet.payload[2];
+                rd.hour = packet.payload[3];
+                rd.min = packet.payload[4];
+                rd.sec = packet.payload[5];
+                rtc_set_clock(&rd);
             }
             break;
         }

--- a/src/core/elrs.h
+++ b/src/core/elrs.h
@@ -43,6 +43,7 @@ typedef struct __attribute__((packed)) {
 #define MSP_GET_VERSION    0x030A
 #define MSP_SET_BUZZER     0x030B
 #define MSP_SET_HT_ENABLE  0x030D
+#define MSP_SET_RTC        0x030E
 #define MSP_SET_OSD_ELEM   0x00B6
 #define MSP_SET_MODE       0x0380 // goggles to backpack
 #define MSP_GET_BP_VERSION 0x0381 // goggles to backpack


### PR DESCRIPTION
As outlined in ExpressLRS/Backpack#86 this PR adds the ability to update the system and RTC clock using the ELRS backpack that connects to the home WiFi network to access a NTP server. 

To test this you need to flash the onboard backpack with the Backpack PR and follow the instructions for configuring and updating the clock.