### PR TITLE
CMakeLists.txt v3.10 does not support SDL2::SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 	softwinner
 )
 if(EMULATOR_BUILD)
-	target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2)
+	target_link_libraries(${PROJECT_NAME} PRIVATE ${SDL2_LIBRARIES})
 endif()
 
 if(NOT EMULATOR_BUILD)


### PR DESCRIPTION
Requires newer version of CMake, however we can still leverage the ${SDL2_LIBRARIES}:

```
New in version 3.19.

This module defines the following [IMPORTED](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED.html#prop_tgt:IMPORTED) target:

SDL::SDL
The SDL library, if found
```