### PR TITLE
Fix osd font loading

### DIFF
--- a/src/core/msp_displayport.c
+++ b/src/core/msp_displayport.c
@@ -185,8 +185,8 @@ void parser_rx(uint8_t function, uint8_t index, uint8_t *rx_buf) {
         parser_osd(index, rx_buf);
 }
 
+video_resolution_t cur_cam = VR_720P60;
 void camTypeDetect(uint8_t rData) {
-    static video_resolution_t cur_cam = VR_720P60;
     static video_resolution_t last_cam = VR_720P50;
 
     switch (rData) {
@@ -233,9 +233,10 @@ void camTypeDetect(uint8_t rData) {
     }
     if (cur_cam == last_cam)
         CAM_MODE = cur_cam;
-    else if (cur_cam == VR_1080P30 || last_cam == VR_1080P30)
-        load_fc_osd_font(CAM_MODE == VR_1080P30);
-    // LOGI("Cam:%d",CAM_MODE);
+    else if (cur_cam == VR_1080P30 || last_cam == VR_1080P30) {
+        // LOGI("Cam_mode changed:%d", cur_cam);
+        load_fc_osd_font(cur_cam == VR_1080P30);
+    }
 }
 
 void fcTypeDetect(uint8_t *rData) {
@@ -249,10 +250,8 @@ void fcTypeDetect(uint8_t *rData) {
         for (i = 0; i < 4; i++)
             fc_variant[i] = fc_variant_rcv[i];
 
-        load_fc_osd_font(CAM_MODE == VR_1080P30);
-#if (0)
-        LOGI("fc_variant_rcv:%s", fc_variant_rcv);
-#endif
+        // LOGI("fc_variant changed:%s", fc_variant_rcv);
+        load_fc_osd_font(cur_cam == VR_1080P30);
     }
 }
 

--- a/src/core/msp_displayport.c
+++ b/src/core/msp_displayport.c
@@ -233,7 +233,7 @@ void camTypeDetect(uint8_t rData) {
     }
     if (cur_cam == last_cam)
         CAM_MODE = cur_cam;
-    else if (cur_cam == VR_1080P30 || cur_cam == VR_1080P30)
+    else if (cur_cam == VR_1080P30 || last_cam == VR_1080P30)
         load_fc_osd_font(CAM_MODE == VR_1080P30);
     // LOGI("Cam:%d",CAM_MODE);
 }

--- a/src/core/msp_displayport.c
+++ b/src/core/msp_displayport.c
@@ -46,7 +46,7 @@ static osd_resolution_t resolution_last = HD_5018;
 uint8_t lq_err_cnt = 0;
 uint8_t lq_rcv_cnt = 0;
 
-uint16_t osd_buf[HD_VMAX][HD_HMAX];
+uint16_t fc_osd[HD_VMAX][HD_HMAX];
 uint8_t osd_init_done = 0;
 
 uint16_t last_rcv_seconds0 = 0;
@@ -445,12 +445,12 @@ void parser_osd(uint8_t row, uint8_t *rx_buf) {
 void clear_screen() {
     for (int i = 0; i < HD_VMAX; i++) {
         for (int j = 0; j < HD_HMAX; j++) {
-            osd_buf[i][j] = 0x20;
+            fc_osd[i][j] = 0x20;
         }
     }
 }
 
 void update_osd(uint16_t *line_buf, uint8_t row) {
-    memcpy(osd_buf[row], line_buf, HD_HMAX * sizeof(uint16_t));
+    memcpy(fc_osd[row], line_buf, HD_HMAX * sizeof(uint16_t));
     osd_signal_update();
 }

--- a/src/core/msp_displayport.c
+++ b/src/core/msp_displayport.c
@@ -233,7 +233,8 @@ void camTypeDetect(uint8_t rData) {
     }
     if (cur_cam == last_cam)
         CAM_MODE = cur_cam;
-
+    else if (cur_cam == VR_1080P30 || cur_cam == VR_1080P30)
+        load_fc_osd_font(CAM_MODE == VR_1080P30);
     // LOGI("Cam:%d",CAM_MODE);
 }
 

--- a/src/core/msp_displayport.h
+++ b/src/core/msp_displayport.h
@@ -69,7 +69,7 @@ extern uint8_t vtxType;
 extern uint8_t vtxFcLock;
 extern uint8_t cam_4_3;
 
-extern uint16_t osd_buf[HD_VMAX][HD_HMAX];
+extern uint16_t fc_osd[HD_VMAX][HD_HMAX];
 extern uint8_t loc_buf[HD_VMAX][4];
 extern uint8_t osd_page_buf[HD_VMAX][7];
 

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -709,7 +709,7 @@ void *thread_osd(void *ptr) {
         // display osd
         for (int i = 0; i < HD_VMAX; i++) {
             for (int j = 0; j < HD_HMAX; j++) {
-                uint16_t ch = osd_buf[i][j];
+                uint16_t ch = fc_osd[i][j];
                 if (ch == 0x20)
                     ch = elrs_osd[i][j];
                 if (ch != osd_buf_shadow[i][j]) {

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -676,6 +676,17 @@ void load_fc_osd_font(uint8_t fhd) {
     }
 }
 
+void osd_shadow_clear(void) {
+    for (int i = 0; i < HD_VMAX; i++) {
+        for (int j = 0; j < HD_HMAX; j++) {
+            if (osd_buf_shadow[i][j] != 0x20) {
+                osd_buf_shadow[i][j] = 0x20;
+                draw_osd_on_screen(i, j);
+            }
+        }
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Threads for updating FC OSD
 
@@ -691,10 +702,7 @@ void *thread_osd(void *ptr) {
 
         // clear shadow buffer when mode changes
         if (fhd_d != is_fhd) {
-            for (int i = 0; i < HD_VMAX; i++) {
-                for (int j = 0; j < HD_HMAX; j++)
-                    osd_buf_shadow[i][j] = 0x20;
-            }
+            osd_shadow_clear();
             fhd_d = is_fhd;
         }
 


### PR DESCRIPTION
- Reload osd font when video resolution(1080P<->720P) changed.
- Fixed the problem that osd_shadow cannot be fully cleared when switching osd font.