### PR TITLE
Softswitch only available on Batch 2 and greater

### DIFF
--- a/src/core/common.c
+++ b/src/core/common.c
@@ -15,7 +15,18 @@
 pthread_mutex_t lvgl_mutex;
 atomic_int g_key = 0;
 atomic_int g_init_done = 0; // 0= init not done, 1= done, -1= dial/up/down pressed
+static hw_revision_t g_hw_revsion = HW_REV_UNKNOWN;
 ///////////////////////////////////////////////////////////////////////////////
+
+void setHwRevision(hw_revision_t revision) {
+    if (revision > g_hw_revsion) {
+        g_hw_revsion = revision;
+    }
+}
+
+hw_revision_t getHwRevision() {
+    return g_hw_revsion;
+}
 
 uint8_t slow_key(left_dial_t key, uint8_t *state, uint8_t *cnt) {
     if ((key == LEFT_DAIL_CLICK) || (key == LEFT_DAIL_LONGPRESS)) {

--- a/src/core/common.hh
+++ b/src/core/common.hh
@@ -11,6 +11,15 @@
 
 #include "defines.h"
 
+typedef enum {
+    HW_REV_UNKNOWN = 0,
+    HW_REV_1,
+    HW_REV_2
+} hw_revision_t;
+
+void setHwRevision(hw_revision_t revision);
+hw_revision_t getHwRevision();
+
 #define DIAL_KEY_UP     1
 #define DIAL_KEY_DOWN   2
 #define DIAL_KEY_CLICK  3

--- a/src/driver/mcp3021.h
+++ b/src/driver/mcp3021.h
@@ -1,6 +1,4 @@
-#ifndef _MCP_3021_H
-#define _MCP_3021_H
+#pragma once
 
-int read_voltage(void);
-int ismcp();
-#endif
+void mcp3021_init();
+int read_voltage();

--- a/src/driver/nct75.c
+++ b/src/driver/nct75.c
@@ -21,10 +21,13 @@ int nct_read_temperature(nct_type_t type) {
     FILE *fp;
     int i;
 
-    if (ismcp() == -1)
+    if (getHwRevision() == HW_REV_UNKNOWN) {
         return -1;
+    }
 
-    sprintf(buf, "/sys/bus/iio/devices/iio:device%d/in_voltage0_raw", ((int)type) + ismcp());
+    int dev_id = type + (getHwRevision() == HW_REV_1 ? 1 : 0);
+
+    sprintf(buf, "/sys/bus/iio/devices/iio:device%d/in_voltage0_raw", dev_id);
     fp = fopen(buf, "r");
     if (!fp) {
         static bool bFirst = true;

--- a/src/ui/page_power.h
+++ b/src/ui/page_power.h
@@ -1,22 +1,6 @@
 #ifndef _PAGE_POWER_H
 #define _PAGE_POWER_H
 
-#define CELL_VOLTAGE_MIN 28
-#define CELL_VOLTAGE_MAX 42
-
-#define ROW_BATT_C_LABEL     0
-#define ROW_CELL_COUNT_MODE  1
-#define ROW_CELL_COUNT       2
-#define ROW_CELL_VOLTAGE     3
-#define ROW_OSD_DISPLAY_MODE 4
-#define ROW_WARN_TYPE        5
-#define ROW_POWER_ANA        6
-#define ROW_BACK             7
-
-#include <stdbool.h>
-
-#include <lvgl/lvgl.h>
-
 #include "ui/ui_main_menu.h"
 
 extern page_pack_t pp_power;


### PR DESCRIPTION
Added hw_revision_t to common.
Restructured startup behavior to ensure hardware comms was available prior to deriving revision type.
Batch 1 users will not be shown softswitch option in power as it is only available on newer hardware.

Tested on Batch 1 goggle and Emulator.  Will need feedback from Batch 2 goggle users prior to approving pull request.
