### PR TITLE
Dropbear a SSH/SCP server allowing for remote access via WiFi.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 set(OS_APP_PATH ${PROJECT_SOURCE_DIR}/mkapp/app/app)
 set(RECORD_APP_PATH ${PROJECT_SOURCE_DIR}/mkapp/app/app/record)
+set(DROPBEAR_APP_PATH ${OS_APP_PATH}/dropbear)
 
 # common build settings
 set(STANDARD_LIBRARIES
@@ -46,6 +47,7 @@ if(EMULATOR_BUILD)
 endif()
 
 # dependencies
+add_subdirectory(ext/dropbear)
 add_subdirectory(lib/lvgl)
 add_subdirectory(lib/minIni)
 add_subdirectory(lib/log)
@@ -164,14 +166,18 @@ if(NOT EMULATOR_BUILD)
 		OUTPUT ${PROJECT_SOURCE_DIR}/out/${PROJECT_NAME}
 		COMMAND size -A ${PROJECT_NAME}
 		COMMAND mkdir -p ${PROJECT_SOURCE_DIR}/out/
+		COMMAND mkdir -p ${DROPBEAR_APP_PATH}
 		COMMAND cp ${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/out/
 		COMMAND cp record ${PROJECT_SOURCE_DIR}/out/
+		COMMAND cp rtspLive ${PROJECT_SOURCE_DIR}/out/
+		COMMAND cp ${dropbear_BINARY_DIR}/out/dropbearmulti ${PROJECT_SOURCE_DIR}/out/
 		COMMAND cp rtspLive ${PROJECT_SOURCE_DIR}/out/
 		COMMAND cp ${PROJECT_NAME} ${OS_APP_PATH}
 		COMMAND cp record ${RECORD_APP_PATH}
 		COMMAND cp rtspLive ${RECORD_APP_PATH}
+		COMMAND cp ${dropbear_BINARY_DIR}/out/dropbearmulti ${DROPBEAR_APP_PATH}/ 
 		COMMAND cd ${PROJECT_SOURCE_DIR} && ./mkapp/mkapp_ota.sh
-		DEPENDS ${PROJECT_NAME} record rtspLive
+		DEPENDS ${PROJECT_NAME} record rtspLive dropbearmulti
 	)
 	add_custom_target(${PROJECT_NAME}-OTA ALL
 		DEPENDS ${PROJECT_SOURCE_DIR}/out/${PROJECT_NAME}

--- a/ext/dropbear/CMakeLists.txt
+++ b/ext/dropbear/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.14)
+project (dropbear C)
+
+if(DEFINED CMAKE_TOOLCHAIN_FILE)
+	set(CMAKE_C_FLAGS "-mfpu=neon -mfloat-abi=hard")
+endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-function -Wno-unused-variable -ffunction-sections -fdata-sections -Wl,-gc-sections -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64")
+set(CMAKE_C_FLAGS_DEBUG "-g")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+
+if(DEFINED CMAKE_TOOLCHAIN_FILE)
+	get_filename_component(COMPILER_NAME ${CMAKE_C_COMPILER} NAME)
+	get_filename_component(COMPILER_PATH ${CMAKE_C_COMPILER} PATH)
+	string(REGEX REPLACE "(.*)-gcc" "\\1" TARGET_PLATFORM "${COMPILER_NAME}")
+	set(TARGET_OPTIONS
+		"CFLAGS=${CMAKE_C_FLAGS}"
+		"CC=${COMPILER_PATH}/${TARGET_PLATFORM}-gcc"
+		"AR=${COMPILER_PATH}/${TARGET_PLATFORM}-ar"
+		"LD=${COMPILER_PATH}/${TARGET_PLATFORM}-ld"
+		"RANLIB=${COMPILER_PATH}/${TARGET_PLATFORM}-ranlib"
+		"NM=${COMPILER_PATH}/${TARGET_PLATFORM}-nm"
+		"AS=${COMPILER_PATH}/${TARGET_PLATFORM}-as"
+		"OBJDUMP=${COMPILER_PATH}/${TARGET_PLATFORM}-objdump"
+		"OBJCOPY=${COMPILER_PATH}/${TARGET_PLATFORM}-objcopy"
+		"STRIP=${COMPILER_PATH}/${TARGET_PLATFORM}-strip"
+		"STRINGS=${COMPILER_PATH}/${TARGET_PLATFORM}-strings"
+		"SIZE=${COMPILER_PATH}/${TARGET_PLATFORM}-size"
+	)
+	set(ENV ${TARGET_OPTIONS})
+endif()
+
+include(FetchContent)
+
+FetchContent_Declare(
+	dropbear
+	GIT_REPOSITORY "https://github.com/mkj/dropbear.git"
+	GIT_TAG        "DROPBEAR_2022.83"
+	SOURCE_DIR     "src"
+	BINARY_DIR     "out"
+)
+FetchContent_MakeAvailable(dropbear)
+
+execute_process(
+	# GCC 4.9 bug, both stddef.h stdlib.h define NULL without inclusion guards.
+	COMMAND sed -i "s@#include <stddef.h>@//#include <stddef.h>@g" ${dropbear_SOURCE_DIR}/libtommath/tommath.h
+	COMMAND ./configure --host=${TARGET_PLATFORM} --disable-zlib --enable-static
+	WORKING_DIRECTORY ${dropbear_SOURCE_DIR}
+)
+
+add_custom_command(
+	OUTPUT dropbear_build
+	COMMAND cd ${dropbear_SOURCE_DIR} && make PROGRAMS='dropbear dbclient dropbearkey dropbearconvert scp' MULTI=1 SCPPROGRESS=1
+	COMMAND cp ${dropbear_SOURCE_DIR}/dropbearmulti ${dropbear_BINARY_DIR}
+)
+
+add_custom_command(
+	OUTPUT dropbear_clean
+	COMMAND find . -name '*.o' -delete
+	COMMAND find . -name '*.a' -delete
+	COMMAND rm -rf ${dropbear_BINARY_DIR}/*
+)
+
+add_custom_target(dropbearmulti ALL DEPENDS dropbear_build)
+add_custom_target(cleanall dropbearmulti DEPENDS dropbear_clean)

--- a/mkapp/app/script/dropbear_start.sh
+++ b/mkapp/app/script/dropbear_start.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+ln -sfn /mnt/app/app/dropbear/dropbearmulti /bin/dropbear
+ln -sfn /mnt/app/app/dropbear/dropbearmulti /bin/scp
+ln -sfn /mnt/app/app/dropbear/dropbearmulti /bin/ssh
+ln -sfn /mnt/app/app/dropbear/dropbearmulti /bin/dropbearkey
+
+# Generate host key once if it does not exist.
+if [ ! -e /etc/dropbear/dropbear_rsa_host_key ]; then
+    mkdir -p /etc/dropbear
+    /bin/dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
+fi
+
+dropbear

--- a/mkapp/app/script/rc.sh
+++ b/mkapp/app/script/rc.sh
@@ -75,6 +75,9 @@ usleep 2000
 #set Microphone Bias Control Register
 aww 0x050967c0 0x110e6100
 
+#dropbear process
+/mnt/app/script/dropbear_start.sh
+
 #record process
 source /mnt/app//app/record/record-env.sh
 if [ -e /mnt/extsd/RECORD.log ]; then

--- a/mkapp/app/script/rc.sh
+++ b/mkapp/app/script/rc.sh
@@ -76,7 +76,7 @@ usleep 2000
 aww 0x050967c0 0x110e6100
 
 #dropbear process
-/mnt/app/script/dropbear_start.sh
+/mnt/app/script/dropbear_start.sh &
 
 #record process
 source /mnt/app//app/record/record-env.sh


### PR DESCRIPTION
Provides the ability to SSH/SCP into goggles via WiFi.  Could be used for both debugging and transferring files remotely via SCP/WinSCP.

Eventually this service will be relocated to the OS distribution once we have the ability to update the OS distribution.  For now we will distribute this service as part of the application binary archive.

Note: Host key file will be automatically generated upon the initial installation and each user will have their own private host key.