### PR TITLE
ensure rtspLive is compiled without PIE/PIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if(NOT EMULATOR_BUILD)
 	file(GLOB SRC_FILES_RTSPLIVE_STREAM "src/rtspLive/stream/*.c" "src/rtspLive/stream/*.h")
 	file(GLOB SRC_FILES_RTSPLIVE_SERVER "src/rtspLive/server/*.cpp" "src/rtspLive/server/*.hh")
 
-	set(RTSPLIVE_BUILD_FLAGS "-DNO_OPENSSL=1")
+	set(RTSPLIVE_BUILD_FLAGS "-DNO_OPENSSL=1 -fno-pie -no-pie")
 
 	add_executable(rtspLive
 		${SRC_FILES_RTSPLIVE}
@@ -150,6 +150,7 @@ if(NOT EMULATOR_BUILD)
 	)
 	set_target_properties(rtspLive PROPERTIES
 		COMPILE_FLAGS ${RTSPLIVE_BUILD_FLAGS}
+		LINK_FLAGS ${RTSPLIVE_BUILD_FLAGS}
 	)
 	target_link_libraries(rtspLive PRIVATE
 		${STANDARD_LIBRARIES}

--- a/lib/live/CMakeLists.txt
+++ b/lib/live/CMakeLists.txt
@@ -13,7 +13,7 @@ set(PREBUILT_LIBRARIES
     ${CMAKE_CURRENT_SOURCE_DIR}/lib/libUsageEnvironment.a
 )
 
-add_library(live SHARED IMPORTED GLOBAL)
+add_library(live STATIC IMPORTED GLOBAL)
 set_target_properties(live PROPERTIES
     IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/lib/libliveMedia.a # dummy
     INTERFACE_INCLUDE_DIRECTORIES "${LIVE_INCLUDE_DIRECTORIES}"
@@ -21,4 +21,3 @@ set_target_properties(live PROPERTIES
 target_link_libraries(live INTERFACE
     ${PREBUILT_LIBRARIES}
 )
-install(FILES ${PREBUILT_LIBRARIES} TYPE LIB)


### PR DESCRIPTION
the prebuilt `libliveMedia.a` was compiled without PIC enabled.
to prevent linker errors with other toolchains, the cmake file must enforce `no-pie` during linking of the executable.