### PR TITLE
Fixed various bugs that were identified in GCC11

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -42,7 +42,7 @@
 #include "ui/ui_statusbar.h"
 #include "util/file.h"
 
-extern int gif_cnt = 0;
+int gif_cnt = 0;
 
 static void *thread_autoscan(void *ptr) {
     for (;;) {

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -35,7 +35,7 @@
 //////////////////////////////////////////////////////////////////
 // local
 static sem_t osd_semaphore;
-static uint8_t is_fhd; // 1=1080p osd,0=720p
+static osd_resource_t is_fhd;
 
 static uint16_t osd_buf_shadow[HD_VMAX][HD_HMAX];
 
@@ -44,18 +44,18 @@ extern pthread_mutex_t lvgl_mutex;
 extern int gif_cnt;
 
 // Use SDCARD for Embedded Glyph if the glyph exists otherwise use goggle FS
-void osd_resource_path(char *buf, const char *fmt, uint8_t HD, ...) {
+void osd_resource_path(char *buf, const char *fmt, osd_resource_t osd_resource_type, ...) {
     char filename[128];
     char buf2[128];
 
     va_list args;
-    va_start(args, HD);
+    va_start(args, osd_resource_type);
     vsprintf(filename, fmt, args);
     va_end(args);
     strcpy(buf2, buf);
     strcpy(buf, RESOURCE_PATH_SDCARD);
 
-    if (HD) {
+    if (osd_resource_type == OSD_RESOURCE_1080) {
         strcat(buf, "FHD/");
     }
     strcat(buf, filename);
@@ -63,7 +63,7 @@ void osd_resource_path(char *buf, const char *fmt, uint8_t HD, ...) {
     if (access(buf, F_OK) != 0) {
         strcpy(buf, buf2);
         strcpy(buf, RESOURCE_PATH);
-        if (HD) {
+        if (osd_resource_type == OSD_RESOURCE_1080) {
             strcat(buf, "FHD/");
         }
         strcat(buf, filename);

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -41,8 +41,7 @@ static uint16_t osd_buf_shadow[HD_VMAX][HD_HMAX];
 
 extern lv_style_t style_osd;
 extern pthread_mutex_t lvgl_mutex;
-
-int gif_cnt;
+extern int gif_cnt;
 
 // Use SDCARD for Embedded Glyph if the glyph exists otherwise use goggle FS
 void osd_resource_path(char *buf, const char *fmt, uint8_t HD, ...) {

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -49,7 +49,7 @@ void osd_resource_path(char *buf, const char *fmt, uint8_t HD, ...) {
     char buf2[128];
 
     va_list args;
-    va_start(args, fmt);
+    va_start(args, HD);
     vsprintf(filename, fmt, args);
     va_end(args);
     strcpy(buf2, buf);

--- a/src/core/osd.h
+++ b/src/core/osd.h
@@ -16,6 +16,11 @@
 #define OSD_BOUNDRY_0  0
 #define OSD_BOUNDRY_1  6
 
+typedef enum {
+    OSD_RESOURCE_720 = 0,
+    OSD_RESOURCE_1080
+} osd_resource_t;
+
 typedef struct {
     lv_obj_t *topfan_speed[2]; // 0
     lv_obj_t *vtx_temp[2];     // 1
@@ -79,6 +84,6 @@ void osd_update_mode();
 char *channel2str(uint8_t channel);
 void load_fc_osd_font(uint8_t);
 void *thread_osd(void *ptr);
-void osd_resource_path(char *buf, const char *fmt, uint8_t HD, ...);
+void osd_resource_path(char *buf, const char *fmt, osd_resource_t osd_resource_type, ...);
 
 #endif

--- a/src/rtspLive/stream/version.h
+++ b/src/rtspLive/stream/version.h
@@ -1,18 +1,17 @@
 #ifndef __VERSION_H_
 #define __VERSION_H_
 
-#if defined (__cplusplus)
+#if defined(__cplusplus)
 extern "C" {
 #endif
 
-#define VERSION_MAJOR   "1"
-#define VERSION_MINOR   "0"
-#define VERSION_BUILD   "0126"
-#define VERSION_FULL    VERSION_MAJOR"."VERSION_MINOR"."VERSION_BUILD
+#define VERSION_MAJOR "1"
+#define VERSION_MINOR "0"
+#define VERSION_BUILD "0126"
+#define VERSION_FULL  VERSION_MAJOR "." VERSION_MINOR "." VERSION_BUILD
 
-#if defined (__cplusplus)
+#if defined(__cplusplus)
 }
 #endif
 
 #endif //__VERSION_H_
-

--- a/src/ui/page_focus_chart.c
+++ b/src/ui/page_focus_chart.c
@@ -2,6 +2,8 @@
 
 #include <stdio.h>
 
+#include "core/osd.h"
+
 static lv_obj_t *focus_chart_img;
 
 lv_obj_t *page_focus_chart_create(lv_obj_t *parent, panel_arr_t *arr) {
@@ -33,7 +35,7 @@ lv_obj_t *page_focus_chart_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_size(focus_chart_img, 1920, 1080);
 
     char filename[128];
-    sprintf(filename, "%s%s", RESOURCE_PATH, FOCUS_CHART_IMG);
+    osd_resource_path(filename, "%s", OSD_RESOURCE_720, FOCUS_CHART_IMG);
     lv_img_set_src(focus_chart_img, filename);
 
     return page;

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -179,7 +179,7 @@ static int walk_sdcard() {
             continue;
         }
 
-        char fname[128];
+        char fname[512];
         sprintf(fname, "%s/%s", MEDIA_FILES_DIR, in_file->d_name);
 
         long size = file_get_size(fname);
@@ -298,7 +298,7 @@ static void mark_video_file(int seq) {
 
     const int index = find_hot_index();
 
-    char cmd[128];
+    char cmd[256];
     sprintf(cmd, "mv  %s/%s %s/hot_hdz_%03d.%s", MEDIA_FILES_DIR, pnode->filename, MEDIA_FILES_DIR, index, pnode->ext);
     system(cmd);
     sprintf(cmd, "mv %s/%s.jpg %s/hot_hdz_%03d.jpg", MEDIA_FILES_DIR, pnode->label, MEDIA_FILES_DIR, index);

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -13,6 +13,7 @@
 
 #include "common.hh"
 #include "core/app_state.h"
+#include "core/osd.h"
 #include "ui/page_common.h"
 #include "ui/ui_player.h"
 #include "ui/ui_style.h"
@@ -104,7 +105,7 @@ static void show_pb_item(uint8_t pos, char *label) {
     if (file_exists(fname))
         sprintf(fname, "A:%s/%s.jpg", TMP_DIR, label);
     else
-        sprintf(fname, "%s%s", RESOURCE_PATH, DEF_VIDEOICON);
+        osd_resource_path(fname, "%s", OSD_RESOURCE_720, DEF_VIDEOICON);
     lv_img_set_src(pb_ui[pos]._img, fname);
 
     if (pb_ui[pos].state == ITEM_STATE_HIGHLIGHT) {

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -136,27 +136,27 @@ int generate_current_version(sys_version_t *sys_ver) {
     fclose(fp);
 
     if (strlen(sys_ver->commit)) {
-        LOGI("app: %hhd.%hhd.%hhd-%s rx: %d va: %d",
+        LOGI("app: %hhu.%hhu.%hhu-%s rx: %u va: %u",
              sys_ver->app_major,
              sys_ver->app_minor,
              sys_ver->app_patch,
              sys_ver->commit,
              sys_ver->rx, sys_ver->va);
 
-        sprintf(sys_ver->current, "app: %hhd.%hhd.%hhd-%s rx: %d va: %d",
+        sprintf(sys_ver->current, "app: %hhu.%hhu.%hhu-%s rx: %u va: %u",
                 sys_ver->app_major,
                 sys_ver->app_minor,
                 sys_ver->app_patch,
                 sys_ver->commit,
                 sys_ver->rx, sys_ver->va);
     } else {
-        LOGI("app: %hhd.%hhd.%hhd rx: %d va: %d",
+        LOGI("app: %hhu.%hhu.%hhu rx: %u va: %u",
              sys_ver->app_major,
              sys_ver->app_minor,
              sys_ver->app_patch,
              sys_ver->rx, sys_ver->va);
 
-        sprintf(sys_ver->current, "app: %hhd.%hhd.%hhd rx: %d va: %d",
+        sprintf(sys_ver->current, "app: %hhu.%hhu.%hhu rx: %u va: %u",
                 sys_ver->app_major,
                 sys_ver->app_minor,
                 sys_ver->app_patch,

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -128,35 +128,35 @@ int generate_current_version(sys_version_t *sys_ver) {
     if (!fp) {
         return -1;
     }
-    fscanf(fp, "%d.%d.%d-%s",
+    fscanf(fp, "%hhd.%hhd.%hhd-%s",
            &sys_ver->app_major,
            &sys_ver->app_minor,
            &sys_ver->app_patch,
-           &sys_ver->commit);
+           sys_ver->commit);
     fclose(fp);
 
     if (strlen(sys_ver->commit)) {
-        LOGI("app: %d.%d.%d-%s rx: %d va: %d",
+        LOGI("app: %hhd.%hhd.%hhd-%s rx: %d va: %d",
              sys_ver->app_major,
              sys_ver->app_minor,
              sys_ver->app_patch,
              sys_ver->commit,
              sys_ver->rx, sys_ver->va);
 
-        sprintf(sys_ver->current, "app: %d.%d.%d-%s rx: %d va: %d",
+        sprintf(sys_ver->current, "app: %hhd.%hhd.%hhd-%s rx: %d va: %d",
                 sys_ver->app_major,
                 sys_ver->app_minor,
                 sys_ver->app_patch,
                 sys_ver->commit,
                 sys_ver->rx, sys_ver->va);
     } else {
-        LOGI("app: %d.%d.%d rx: %d va: %d",
+        LOGI("app: %hhd.%hhd.%hhd rx: %d va: %d",
              sys_ver->app_major,
              sys_ver->app_minor,
              sys_ver->app_patch,
              sys_ver->rx, sys_ver->va);
 
-        sprintf(sys_ver->current, "app: %d.%d.%d rx: %d va: %d",
+        sprintf(sys_ver->current, "app: %hhd.%hhd.%hhd rx: %d va: %d",
                 sys_ver->app_major,
                 sys_ver->app_minor,
                 sys_ver->app_patch,

--- a/src/ui/page_version.h
+++ b/src/ui/page_version.h
@@ -6,6 +6,7 @@
 #include "ui/ui_main_menu.h"
 
 #define CURRENT_VER_MAX (64)
+#define COMMIT_VER_MAX  (8)
 
 typedef struct {
     uint8_t rx;
@@ -13,8 +14,8 @@ typedef struct {
     uint8_t app_major;
     uint8_t app_minor;
     uint8_t app_patch;
-    char commit[CURRENT_VER_MAX];
-    char current[CURRENT_VER_MAX * 2];
+    char commit[COMMIT_VER_MAX];
+    char current[CURRENT_VER_MAX];
 } sys_version_t;
 
 extern page_pack_t pp_version;

--- a/src/ui/page_version.h
+++ b/src/ui/page_version.h
@@ -14,7 +14,7 @@ typedef struct {
     uint8_t app_minor;
     uint8_t app_patch;
     char commit[CURRENT_VER_MAX];
-    char current[CURRENT_VER_MAX];
+    char current[CURRENT_VER_MAX * 2];
 } sys_version_t;
 
 extern page_pack_t pp_version;

--- a/src/ui/page_version.h
+++ b/src/ui/page_version.h
@@ -6,7 +6,7 @@
 #include "ui/ui_main_menu.h"
 
 #define CURRENT_VER_MAX (64)
-#define COMMIT_VER_MAX  (8)
+#define COMMIT_VER_MAX  (10)
 
 typedef struct {
     uint8_t rx;


### PR DESCRIPTION
Emulator build failed to compile due to duplicate symbols.  Issue was found by Mart in Discord.
Fixed all warnings currently identified by GCC-11
Fixed resource loading of Playback Icon and Focus Chart