### PR TITLE
Move double click detection to dm5680 thread

### DIFF
--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -230,24 +230,24 @@ static void btn_click(void) // short press enter key
     pthread_mutex_unlock(&lvgl_mutex);
 }
 
-void rbtn_click(uint8_t click_type) {
+void rbtn_click(right_button_t click_type) {
     if (g_init_done != 1)
         return;
     switch (g_app_state) {
     case APP_STATE_SUBMENU:
 		pthread_mutex_lock(&lvgl_mutex);
-        if (click_type == 0)
+        if (click_type == RIGHT_CLICK)
             submenu_right_button(true);
-        else if (click_type == 1)
+        else if (click_type == RIGHT_LONG_PRESS)
             submenu_right_button(false);
 		pthread_mutex_unlock(&lvgl_mutex);
         break;
     case APP_STATE_VIDEO:
-        if (click_type == 0) {
+        if (click_type == RIGHT_CLICK) {
             dvr_cmd(DVR_TOGGLE);
-        } else if (click_type == 1) {
+        } else if (click_type == RIGHT_LONG_PRESS) {
             step_topfan();
-        } else if (click_type == 2) {
+        } else if (click_type == RIGHT_DOUBLE_CLICK) {
             ht_set_center_position();
         }
         break;

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -235,10 +235,12 @@ void rbtn_click(uint8_t click_type) {
         return;
     switch (g_app_state) {
     case APP_STATE_SUBMENU:
+		pthread_mutex_lock(&lvgl_mutex);
         if (click_type == 0)
             submenu_right_button(true);
         else if (click_type == 1)
             submenu_right_button(false);
+		pthread_mutex_unlock(&lvgl_mutex);
         break;
     case APP_STATE_VIDEO:
         if (click_type == 0) {

--- a/src/core/input_device.h
+++ b/src/core/input_device.h
@@ -3,9 +3,15 @@
 
 #include <stdbool.h>
 
+typedef enum {
+    RIGHT_CLICK = 0,
+    RIGHT_LONG_PRESS = 1,
+    RIGHT_DOUBLE_CLICK = 2
+} right_button_t;
+
 void input_device_init();
 void tune_channel_timer();
 void exit_tune_channel();
-void rbtn_click(uint8_t click_tyoe);
+void rbtn_click(right_button_t click_tyoe);
 
 #endif

--- a/src/core/input_device.h
+++ b/src/core/input_device.h
@@ -6,6 +6,6 @@
 void input_device_init();
 void tune_channel_timer();
 void exit_tune_channel();
-void rbtn_click(bool is_short);
+void rbtn_click(uint8_t click_tyoe);
 
 #endif

--- a/src/driver/dm5680.c
+++ b/src/driver/dm5680.c
@@ -121,10 +121,10 @@ void uart_parse(uint8_t sel, uint8_t *state, uint8_t *len, uint8_t *payload, uin
                 g_key = RIGHT_KEY_CLICK + (ptr[2] & 1);
                 LOGI("btn:%x", ptr[2]); // 0=short,1=long
                 if (ptr[2]) {
-                    rbtn_click(1);
+                    rbtn_click(RIGHT_LONG_PRESS);
                 } else if (wait_timeout != NULL) {
                     wait_timeout = NULL;
-                    rbtn_click(2);
+                    rbtn_click(RIGHT_DOUBLE_CLICK);
                 } else {
                     wait_timeout = &short_click_timeout;
                     wait_timeout->tv_usec = 250000;
@@ -210,7 +210,7 @@ static void *pthread_recv_dm5680r(void *arg) {
         else if (fds == 0) {
             // Short click timeout
             wait_timeout = NULL;
-            rbtn_click(0);
+            rbtn_click(RIGHT_CLICK);
         } else {
             len = uart_read(fd_dm5680r, buffer, 128);
             // if(len) LOGI("(UART2-%d)",len);

--- a/src/driver/dm5680.c
+++ b/src/driver/dm5680.c
@@ -38,6 +38,8 @@ uint8_t uart_buffer[2][256];
 uint8_t uart_rptr[2], uart_wptr[2];
 int fd_dm5680l = 0, fd_dm5680r = 0;
 pthread_mutex_t cmd_to5680_mutex;
+static struct timeval short_click_timeout;
+struct timeval *wait_timeout = NULL;
 
 uint8_t uart_parse_core(uint8_t *buff, uint8_t *rptr, uint8_t *wptr, uint8_t *state, uint8_t *len, uint8_t *payload, uint8_t *payload_ptr) {
     uint8_t pkt_cnt = 0;
@@ -117,8 +119,16 @@ void uart_parse(uint8_t sel, uint8_t *state, uint8_t *len, uint8_t *payload, uin
         case 0x20: // right_btn
             if (sel) {
                 g_key = RIGHT_KEY_CLICK + (ptr[2] & 1);
-                LOGI("btn:%x\n", ptr[2]); // 0=short,1=long
-                rbtn_click(!ptr[2]);
+                LOGI("btn:%x", ptr[2]); // 0=short,1=long
+                if (ptr[2]) {
+                    rbtn_click(1);
+                } else if (wait_timeout != NULL) {
+                    wait_timeout = NULL;
+                    rbtn_click(2);
+                } else {
+                    wait_timeout = &short_click_timeout;
+                    wait_timeout->tv_usec = 250000;
+                }
             }
             break;
 
@@ -194,22 +204,25 @@ static void *pthread_recv_dm5680r(void *arg) {
     for (;;) {
         FD_ZERO(&rd);
         FD_SET(fd_dm5680r, &rd);
-        while (FD_ISSET(fd_dm5680r, &rd)) {
-            if (select(fd_dm5680r + 1, &rd, NULL, NULL, NULL) < 0)
-                LOGE("UART2:select error!");
-            else {
-                len = uart_read(fd_dm5680r, buffer, 128);
-                // if(len) LOGI("(UART2-%d)",len);
-                for (i = 0; i < len; i++) {
-                    uart_buffer[1][uart_wptr[1]] = buffer[i];
-                    uart_wptr[1]++;
+        int fds = select(fd_dm5680r + 1, &rd, NULL, NULL, wait_timeout);
+        if (fds < 0)
+            LOGE("UART2:select error!");
+        else if (fds == 0) {
+            // Short click timeout
+            wait_timeout = NULL;
+            rbtn_click(0);
+        } else {
+            len = uart_read(fd_dm5680r, buffer, 128);
+            // if(len) LOGI("(UART2-%d)",len);
+            for (i = 0; i < len; i++) {
+                uart_buffer[1][uart_wptr[1]] = buffer[i];
+                uart_wptr[1]++;
 
-                    if (uart_wptr[1] == uart_rptr[1])
-                        LOGW("UART2 fifo full!");
-                }
-                if (len)
-                    uart_parse(1, &state, &len8, payload, &payload_ptr);
+                if (uart_wptr[1] == uart_rptr[1])
+                    LOGW("UART2 fifo full!");
             }
+            if (len)
+                uart_parse(1, &state, &len8, payload, &payload_ptr);
         }
     }
 
@@ -387,7 +400,7 @@ void DM5680_get_rssi(uint8_t sel, uint8_t *payload) {
         filter_rssi(&rx_status_ptr->rx_rssi[1], payload[3], &avg_buf[sel * 20 + 10]);
         rx_status_ptr->rx_DLQ = payload[4];
         rx_status_ptr->rx_Stat = payload[5];
-#if 0 
+#if 0
 		LOGI("(RSSI %x %x %x %x)",	rx_status[0].rx_rssi[0],
 										rx_status[0].rx_rssi[1],
 										rx_status[1].rx_rssi[0],


### PR DESCRIPTION
# Problem
There is a 2 second delay displaying the "REC" icon when pressing the right button

This was introduced when the double-click handler was added for centring the head tracker. Because the `dm5680` thread would set a timeout for detecting the single-click vs double-click and the timer is handled in the main thread (along with the OSD and other things), and the `dvr_cmd` code has a forced 2 second sleep after calling the command to start/stop the dvr.  And so the OSD would not update for 2 seconds after the button was clicked.

# Solution
Move the double-click detection code to the `dm5680` thread so the `dvr_cmd` is also called in that thread, as it was prior to the double-click detection code being added.