### PR TITLE
Offload beep to new thread, make audible.

### DIFF
--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -26,7 +26,7 @@
 #include "core/osd.h"
 #include "core/settings.h"
 #include "driver/dm5680.h"
-#include "driver/gpio.h"
+#include "driver/beep.h"
 #include "driver/hardware.h"
 #include "driver/rtc.h"
 #include "driver/uart.h"

--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -295,7 +295,7 @@ void msp_process_packet() {
             }
         } break;
         case MSP_SET_BUZZER:
-            beep_dur((packet.payload[0] | packet.payload[1] << 8) * 1000);
+            beep_dur((packet.payload[0] | packet.payload[1] << 8));
             break;
         case MSP_SET_OSD_ELEM:
             handle_osd(packet.payload, packet.payload_size);

--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -17,7 +17,7 @@
 #include "bmi270/accel_gyro.h"
 #include "core/settings.h"
 #include "driver/dm6302.h"
-#include "driver/gpio.h"
+#include "driver/beep.h"
 #include "driver/hardware.h"
 #include "driver/oled.h"
 #include "ui/page_common.h"

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -33,6 +33,7 @@
 #include "driver/mcp3021.h"
 #include "driver/oled.h"
 #include "driver/rtc.h"
+#include "driver/beep.h"
 #include "ui/page_power.h"
 #include "ui/page_scannow.h"
 #include "ui/page_source.h"
@@ -156,6 +157,7 @@ int main(int argc, char *argv[]) {
     esp32_init();
     elrs_init();
     ht_init();
+    beep_init();
 
     // 4. Initilize UI
     lvgl_init();

--- a/src/driver/beep.c
+++ b/src/driver/beep.c
@@ -1,0 +1,41 @@
+#include "beep.h"
+
+#include <pthread.h>
+#include <unistd.h>
+
+#include "core/defines.h"
+#include "gpio.h"
+
+static pthread_t beep_thread_handle;
+static pthread_mutex_t beep_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t beep_cond = PTHREAD_COND_INITIALIZER;
+static int beep_dur_ms = 0;
+
+static void *beep_thread(void *);
+
+void beep_init() {
+    pthread_create(&beep_thread_handle, NULL, beep_thread, NULL);
+}
+
+void beep_dur(int ms) {
+    pthread_mutex_lock(&beep_mutex);
+    beep_dur_ms = ms;
+    pthread_cond_signal(&beep_cond);
+    pthread_mutex_unlock(&beep_mutex);
+}
+
+static void *beep_thread(void *arg) {
+    while (1) {
+        pthread_mutex_lock(&beep_mutex);
+        pthread_cond_wait(&beep_cond, &beep_mutex);
+        int this_beep_ms = beep_dur_ms;
+        beep_dur_ms = 0;
+        pthread_mutex_unlock(&beep_mutex);
+
+        if (this_beep_ms > 0) {
+            gpio_set(GPIO_BEEP, 1);
+            usleep(this_beep_ms * 1000);
+            gpio_set(GPIO_BEEP, 0);
+        }
+    }
+}

--- a/src/driver/beep.h
+++ b/src/driver/beep.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define BEEP_SHORT 50
+#define BEEP_LONG 200
+
+#define beep() beep_dur(BEEP_SHORT)
+
+void beep_init(void);
+void beep_dur(int ms);

--- a/src/driver/gpio.c
+++ b/src/driver/gpio.c
@@ -1,10 +1,18 @@
 #include "gpio.h"
 
+#include <pthread.h>
 #include <stdio.h>
 #include <unistd.h>
 
 #include "core/defines.h"
 #include "util/file.h"
+
+static pthread_t beep_thread_handle;
+static pthread_mutex_t beep_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t beep_cond = PTHREAD_COND_INITIALIZER;
+static int beep_dur_ms = 0;
+
+static void *beep_thread(void *);
 
 void gpio_init() {
     gpio_open(GPIO_BEEP);
@@ -27,6 +35,8 @@ void gpio_init() {
 
     gpio_open(GPIO_ESP32_BOOT0);
     gpio_set(GPIO_ESP32_BOOT0, 0);
+
+    pthread_create(&beep_thread_handle, NULL, beep_thread, NULL);
 }
 
 void gpio_open(int port_num) {
@@ -48,13 +58,25 @@ void gpio_set(int port_num, bool val) {
     file_printf(buf, "%d", val ? 1 : 0);
 }
 
-void beep_dur(int dur_us) {
-    static bool bInit = true;
-    if (bInit) {
-        bInit = false;
-        gpio_open(GPIO_BEEP);
+void beep_dur(int ms) {
+    pthread_mutex_lock(&beep_mutex);
+    beep_dur_ms = ms;
+    pthread_cond_signal(&beep_cond);
+    pthread_mutex_unlock(&beep_mutex);
+}
+
+static void *beep_thread(void *arg) {
+    while (1) {
+        pthread_mutex_lock(&beep_mutex);
+        pthread_cond_wait(&beep_cond, &beep_mutex);
+        int this_beep_ms = beep_dur_ms;
+        beep_dur_ms = 0;
+        pthread_mutex_unlock(&beep_mutex);
+
+        if (this_beep_ms > 0) {
+            gpio_set(GPIO_BEEP, 1);
+            usleep(this_beep_ms * 1000);
+            gpio_set(GPIO_BEEP, 0);
+        }
     }
-    gpio_set(GPIO_BEEP, 1);
-    usleep(dur_us);
-    gpio_set(GPIO_BEEP, 0);
 }

--- a/src/driver/gpio.c
+++ b/src/driver/gpio.c
@@ -7,13 +7,6 @@
 #include "core/defines.h"
 #include "util/file.h"
 
-static pthread_t beep_thread_handle;
-static pthread_mutex_t beep_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t beep_cond = PTHREAD_COND_INITIALIZER;
-static int beep_dur_ms = 0;
-
-static void *beep_thread(void *);
-
 void gpio_init() {
     gpio_open(GPIO_BEEP);
     gpio_set(GPIO_BEEP, 0);
@@ -35,8 +28,6 @@ void gpio_init() {
 
     gpio_open(GPIO_ESP32_BOOT0);
     gpio_set(GPIO_ESP32_BOOT0, 0);
-
-    pthread_create(&beep_thread_handle, NULL, beep_thread, NULL);
 }
 
 void gpio_open(int port_num) {
@@ -56,27 +47,4 @@ void gpio_set(int port_num, bool val) {
     char buf[64];
     sprintf(buf, "/sys/class/gpio/gpio%d/value", port_num);
     file_printf(buf, "%d", val ? 1 : 0);
-}
-
-void beep_dur(int ms) {
-    pthread_mutex_lock(&beep_mutex);
-    beep_dur_ms = ms;
-    pthread_cond_signal(&beep_cond);
-    pthread_mutex_unlock(&beep_mutex);
-}
-
-static void *beep_thread(void *arg) {
-    while (1) {
-        pthread_mutex_lock(&beep_mutex);
-        pthread_cond_wait(&beep_cond, &beep_mutex);
-        int this_beep_ms = beep_dur_ms;
-        beep_dur_ms = 0;
-        pthread_mutex_unlock(&beep_mutex);
-
-        if (this_beep_ms > 0) {
-            gpio_set(GPIO_BEEP, 1);
-            usleep(this_beep_ms * 1000);
-            gpio_set(GPIO_BEEP, 0);
-        }
-    }
 }

--- a/src/driver/gpio.h
+++ b/src/driver/gpio.h
@@ -2,11 +2,6 @@
 
 #include <stdbool.h>
 
-#define BEEP_SHORT 50
-#define BEEP_LONG 200
-
-#define beep() beep_dur(BEEP_SHORT)
-
 void gpio_init();
 void gpio_open(int port_num);
 void gpio_set(int port_num, bool val);

--- a/src/driver/gpio.h
+++ b/src/driver/gpio.h
@@ -2,10 +2,13 @@
 
 #include <stdbool.h>
 
-#define beep() beep_dur(500)
+#define BEEP_SHORT 50
+#define BEEP_LONG 200
+
+#define beep() beep_dur(BEEP_SHORT)
 
 void gpio_init();
 void gpio_open(int port_num);
 void gpio_set(int port_num, bool val);
 
-void beep_dur(int us);
+void beep_dur(int ms);

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -15,7 +15,7 @@
 #include "driver/dm5680.h"
 #include "driver/esp32.h"
 #include "driver/fans.h"
-#include "driver/gpio.h"
+#include "driver/beep.h"
 #include "driver/i2c.h"
 #include "driver/uart.h"
 #include "ui/page_common.h"

--- a/src/ui/ui_statusbar.c
+++ b/src/ui/ui_statusbar.c
@@ -8,7 +8,7 @@
 #include "core/common.hh"
 #include "core/osd.h"
 #include "core/settings.h"
-#include "driver/gpio.h"
+#include "driver/beep.h"
 #include "ui/page_common.h"
 #include "ui/page_playback.h"
 #include "ui/ui_style.h"


### PR DESCRIPTION
This PR moves beep GPIO control to a separate thread so that beeps don't block and so can be made long enough to be audible. 😄 Calling parts of the system don't need to worry about it waiting anymore.

- The previous beep (via `beep()`) is only 500us (!) so just makes a little tap sound. The default beep is now 50ms, with a longer 200ms beep available for future use.
- `beep_dur` now takes milliseconds, rather than microseconds.