### PR TITLE
Add option to set startup OSD visibility

### DIFF
--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -84,9 +84,11 @@ void tune_channel(uint8_t action) {
             tune_state = 2;
             channel = g_setting.scan.channel;
         } else if (action == DIAL_KEY_CLICK) {
-            g_showRXOSD = !g_showRXOSD;
-            if (g_showRXOSD)
+            g_setting.osd.is_visible = !g_setting.osd.is_visible;
+            if (g_setting.osd.is_visible)
                 channel_osd_mode = CHANNEL_SHOWTIME;
+
+            settings_put_bool("osd", "is_visible", g_setting.osd.is_visible);
         }
     }
 

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -486,12 +486,12 @@ void osd_hdzero_update(void) {
         return;
     }
 
-    bool showRXOSD = g_showRXOSD && (g_source_info.source == SOURCE_HDZERO);
+    bool showRXOSD = g_setting.osd.is_visible && (g_source_info.source == SOURCE_HDZERO);
 
-    osd_rec_show(g_showRXOSD);
-    osd_llock_show(g_showRXOSD);
-    osd_topfan_show(g_showRXOSD);
-    osd_battery_voltage_show(g_showRXOSD);
+    osd_rec_show(g_setting.osd.is_visible);
+    osd_llock_show(g_setting.osd.is_visible);
+    osd_topfan_show(g_setting.osd.is_visible);
+    osd_battery_voltage_show(g_setting.osd.is_visible);
 
     if (gif_cnt % 10 == 0) { // delay needed to allow gif to flash
         osd_resource_path(buf, "%s", is_fhd, VrxTemp7_gif);

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -302,9 +302,9 @@ void settings_load(void) {
     // osd
     g_setting.osd.embedded_mode = ini_getl("osd", "embedded_mode", g_setting_defaults.osd.embedded_mode, SETTING_INI);
     g_setting.osd.startup_visibility = ini_getl("osd", "startup_visibility", g_setting_defaults.osd.startup_visibility, SETTING_INI);
-    g_setting.osd.is_visible = settings_get_bool("osd", "is_visible", g_setting_defaults.osd.is_visible);
 
     switch (g_setting.osd.startup_visibility) {
+    default:
     case SETTING_OSD_SHOW_AT_STARTUP_SHOW:
         g_setting.osd.is_visible = true;
         settings_put_bool("osd", "is_visible", g_setting.osd.is_visible);
@@ -313,7 +313,8 @@ void settings_load(void) {
         g_setting.osd.is_visible = false;
         settings_put_bool("osd", "is_visible", g_setting.osd.is_visible);
         break;
-    default:
+    case SETTING_OSD_SHOW_AT_STARTUP_LAST:
+        g_setting.osd.is_visible = settings_get_bool("osd", "is_visible", g_setting_defaults.osd.is_visible);
         break;
     }
 

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -71,6 +71,8 @@ const setting_t g_setting_defaults = {
     },
     .osd = {
         .embedded_mode = EMBEDDED_4x3,
+        .startup_visibility = SETTING_OSD_SHOW_AT_STARTUP_SHOW,
+        .is_visible = true,
         .element = {
             // OSD_GOGGLE_TOPFAN_SPEED
             {
@@ -299,6 +301,22 @@ void settings_load(void) {
 
     // osd
     g_setting.osd.embedded_mode = ini_getl("osd", "embedded_mode", g_setting_defaults.osd.embedded_mode, SETTING_INI);
+    g_setting.osd.startup_visibility = ini_getl("osd", "startup_visibility", g_setting_defaults.osd.startup_visibility, SETTING_INI);
+    g_setting.osd.is_visible = settings_get_bool("osd", "is_visible", g_setting_defaults.osd.is_visible);
+
+    switch (g_setting.osd.startup_visibility) {
+    case SETTING_OSD_SHOW_AT_STARTUP_SHOW:
+        g_setting.osd.is_visible = true;
+        settings_put_bool("osd", "is_visible", g_setting.osd.is_visible);
+        break;
+    case SETTING_OSD_SHOW_AT_STARTUP_HIDE:
+        g_setting.osd.is_visible = false;
+        settings_put_bool("osd", "is_visible", g_setting.osd.is_visible);
+        break;
+    default:
+        break;
+    }
+
     settings_load_osd_element(&g_setting.osd.element[OSD_GOGGLE_TOPFAN_SPEED], "topfan_speed", &g_setting_defaults.osd.element[OSD_GOGGLE_TOPFAN_SPEED]);
     settings_load_osd_element(&g_setting.osd.element[OSD_GOGGLE_LATENCY_LOCK], "latency_lock", &g_setting_defaults.osd.element[OSD_GOGGLE_LATENCY_LOCK]);
     settings_load_osd_element(&g_setting.osd.element[OSD_GOGGLE_VTX_TEMP], "vtx_temp", &g_setting_defaults.osd.element[OSD_GOGGLE_VTX_TEMP]);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -102,6 +102,12 @@ typedef enum {
     EMBEDDED_16x9
 } setting_embedded_mode_t;
 
+typedef enum {
+    SETTING_OSD_SHOW_AT_STARTUP_SHOW,
+    SETTING_OSD_SHOW_AT_STARTUP_HIDE,
+    SETTING_OSD_SHOW_AT_STARTUP_LAST
+} setting_osd_show_at_startup_t;
+
 typedef struct {
     int x;
     int y;
@@ -139,6 +145,8 @@ typedef enum {
 
 typedef struct {
     setting_embedded_mode_t embedded_mode;
+    setting_osd_show_at_startup_t startup_visibility;
+    bool is_visible;
     setting_osd_goggle_element_t element[OSD_GOGGLE_NUM];
 } setting_osd_t;
 

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -11,7 +11,6 @@ bool g_sdcard_det_req = false;
 int g_sdcard_size = 0;
 bool g_autoscan_exit = true;
 bool g_scanning = false;
-bool g_showRXOSD = true;
 bool g_latency_locked = false;
 source_info_t g_source_info;
 

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -122,7 +122,6 @@ extern bool g_sdcard_det_req;
 extern int g_sdcard_size;
 extern bool g_autoscan_exit;
 extern bool g_scanning;
-extern bool g_showRXOSD;
 extern bool g_latency_locked;
 extern source_info_t g_source_info;
 

--- a/src/ui/page_osd.c
+++ b/src/ui/page_osd.c
@@ -17,6 +17,7 @@
 
 enum {
     ROW_OSD_MODE = 0,
+    ROW_OSD_STARTUP_VISIBILITY,
     ROW_ADJUST_OSD_ELEMENTS,
     ROW_BACK,
 
@@ -28,6 +29,7 @@ static lv_coord_t col_dsc[] = {160, 180, 160, 160, 120, 160, LV_GRID_TEMPLATE_LA
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 static btn_group_t btn_group_osd_mode;
+static btn_group_t btn_group_osd_startup_visibility;
 
 static lv_obj_t *page_osd_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
@@ -57,6 +59,7 @@ static lv_obj_t *page_osd_create(lv_obj_t *parent, panel_arr_t *arr) {
     // create menu entries
     create_label_item(cont, "Adjust OSD Elements", 1, ROW_ADJUST_OSD_ELEMENTS, 1);
     create_btn_group_item(&btn_group_osd_mode, cont, 2, "OSD Mode", "4x3", "16x9", "", "", ROW_OSD_MODE);
+    create_btn_group_item(&btn_group_osd_startup_visibility, cont, 3, "At Startup", "Show", "Hide", "Last", "", ROW_OSD_STARTUP_VISIBILITY);
     create_label_item(cont, "< Back", 1, ROW_BACK, 1);
 
     lv_obj_t *label_user_hint = lv_label_create(cont);
@@ -71,6 +74,7 @@ static lv_obj_t *page_osd_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     // set ui values from settings
     btn_group_set_sel(&btn_group_osd_mode, g_setting.osd.embedded_mode);
+    btn_group_set_sel(&btn_group_osd_startup_visibility, g_setting.osd.startup_visibility);
 
     return page;
 }
@@ -112,6 +116,12 @@ static void on_click(uint8_t key, int sel) {
 
     case ROW_ADJUST_OSD_ELEMENTS:
         open_element_pos_preview();
+        break;
+
+    case ROW_OSD_STARTUP_VISIBILITY:
+        btn_group_toggle_sel(&btn_group_osd_startup_visibility);
+        g_setting.osd.startup_visibility = btn_group_get_sel(&btn_group_osd_startup_visibility);
+        ini_putl("osd", "startup_visibility", g_setting.osd.startup_visibility, SETTING_INI);
         break;
 
     case ROW_OSD_MODE:


### PR DESCRIPTION
Added a new option to the OSD page to set the startup visibility of the goggle OSD.
Closes #188 

![osd_startup_vis](https://github.com/hd-zero/hdzero-goggle/assets/35898034/a3969d2b-be9b-4693-aa46-ea7d373e342a)
