### PR TITLE
WiFi Module: added 3rd Page to configure System Options

### DIFF
--- a/mkapp/app/script/wlan_stop.sh
+++ b/mkapp/app/script/wlan_stop.sh
@@ -4,6 +4,7 @@ sleep 1
 killall rtspLive
 killall hostapd
 killall udhcpd
+killall dropbear
 ifconfig wlan0 down
 rmmod xradio_wlan.ko
 rmmod xradio_core.ko

--- a/mkapp/app/services/scripts/dropbear_start.sh
+++ b/mkapp/app/services/scripts/dropbear_start.sh
@@ -10,5 +10,3 @@ if [ ! -e /etc/dropbear/dropbear_rsa_host_key ]; then
     mkdir -p /etc/dropbear
     /bin/dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
 fi
-
-dropbear

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -175,6 +175,8 @@ const setting_t g_setting_defaults = {
         .gateway = "192.168.2.1",
         .dns = "192.168.2.1",
         .rf_channel = 6,
+        .root_pw = "divimath",
+        .ssh = false,
     },
     .storage = {
         .logging = false,
@@ -374,6 +376,8 @@ void settings_load(void) {
     ini_gets("wifi", "gateway", g_setting_defaults.wifi.gateway, g_setting.wifi.gateway, WIFI_NETWORK_MAX, SETTING_INI);
     ini_gets("wifi", "dns", g_setting_defaults.wifi.dns, g_setting.wifi.dns, WIFI_NETWORK_MAX, SETTING_INI);
     g_setting.wifi.rf_channel = ini_getl("wifi", "rf_channel", g_setting_defaults.wifi.rf_channel, SETTING_INI);
+    ini_gets("wifi", "root_pw", g_setting_defaults.wifi.root_pw, g_setting.wifi.root_pw, WIFI_PASSWD_MAX, SETTING_INI);
+    g_setting.wifi.ssh = settings_get_bool("wifi", "ssh", g_setting_defaults.wifi.ssh);
 
     //  no dial under video mode
     g_setting.ease.no_dial = file_exists(NO_DIAL_FILE);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -177,6 +177,8 @@ typedef struct {
     char gateway[WIFI_NETWORK_MAX];
     char dns[WIFI_NETWORK_MAX];
     uint8_t rf_channel;
+    char root_pw[WIFI_SSID_MAX];
+    bool ssh;
 } wifi_t;
 
 typedef struct {

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -17,6 +17,7 @@
 #define WIFI_OFF            "/mnt/app/script/wlan_stop.sh"
 #define WIFI_AP_ON          "/tmp/wlan_start_ap.sh"
 #define WIFI_STA_ON         "/tmp/wlan_start_sta.sh"
+#define ROOT_PW_SET         "/tmp/root_pw_set.sh"
 
 #define FC_OSD_LOCAL_PATH  "/mnt/app/resource/OSD/FC/"
 #define FC_OSD_SDCARD_PATH "/mnt/extsd/resource/OSD/FC/"

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -103,6 +103,13 @@ typedef struct {
 } page_options_t;
 
 /**
+ *  Constants
+ */
+#define PW_MIN_SIZE_STR       "Min 8 Characters"
+#define INVALID_TOO_SHORT_STR "#FF0000 Invalid Too Short#"
+#define INVALID_FORMAT_STR    "#FF0000 Invalid Format#"
+
+/**
  *  Globals
  */
 static lv_coord_t col_dsc[] = {160, 160, 160, 180, 160, 160, LV_GRID_TEMPLATE_LAST};
@@ -549,7 +556,7 @@ static void page_wifi_create_page_1(lv_obj_t *parent) {
     page_wifi.page_1.ssid.input = create_label_item(parent, g_setting.wifi.ssid[g_setting.wifi.mode], 2, 3, 2);
     page_wifi.page_1.passwd.label = create_label_item(parent, "Password", 1, 4, 1);
     page_wifi.page_1.passwd.input = create_label_item(parent, g_setting.wifi.passwd[g_setting.wifi.mode], 2, 4, 2);
-    page_wifi.page_1.passwd.status = create_label_item(parent, "Min 8 Characters", 4, 4, 2);
+    page_wifi.page_1.passwd.status = create_label_item(parent, PW_MIN_SIZE_STR, 4, 4, 2);
 
     page_wifi.page_1.apply_settings = create_label_item(parent, "Apply Settings", 1, 5, 3);
     page_wifi.page_1.back = create_label_item(parent, "< Back", 1, 6, 3);
@@ -596,7 +603,7 @@ static void page_wifi_create_page_2(lv_obj_t *parent) {
 static void page_wifi_create_page_3(lv_obj_t *parent) {
     page_wifi.page_3.root_pw.label = create_label_item(parent, "Root PW", 1, 1, 1);
     page_wifi.page_3.root_pw.input = create_label_item(parent, g_setting.wifi.root_pw, 2, 1, 2);
-    page_wifi.page_3.root_pw.status = create_label_item(parent, "Min 8 Characters", 4, 1, 2);
+    page_wifi.page_3.root_pw.status = create_label_item(parent, PW_MIN_SIZE_STR, 4, 1, 2);
 
     create_btn_group_item(&page_wifi.page_3.ssh.button, parent, 2, "SSH", "On", "Off", "", "", 2);
     btn_group_set_sel(&page_wifi.page_3.ssh.button, !g_setting.wifi.ssh);
@@ -673,10 +680,10 @@ static void page_wifi_exit() {
     lv_label_set_text(page_wifi.page_1.ssid.input, page_wifi.page_1.ssid.text[mode]);
     snprintf(page_wifi.page_1.passwd.text[mode], WIFI_PASSWD_MAX, "%s", g_setting.wifi.passwd[mode]);
     lv_label_set_text(page_wifi.page_1.passwd.input, page_wifi.page_1.passwd.text[mode]);
-    lv_label_set_text(page_wifi.page_1.passwd.status, "Min 8 Characters");
+    lv_label_set_text(page_wifi.page_1.passwd.status, PW_MIN_SIZE_STR);
     snprintf(page_wifi.page_3.root_pw.text, WIFI_PASSWD_MAX, "%s", g_setting.wifi.root_pw);
     lv_label_set_text(page_wifi.page_3.root_pw.input, page_wifi.page_3.root_pw.text);
-    lv_label_set_text(page_wifi.page_3.root_pw.status, "Min 8 Characters");
+    lv_label_set_text(page_wifi.page_3.root_pw.status, PW_MIN_SIZE_STR);
 
     page_wifi_dirty_flag_reset();
     page_wifi_apply_settings_reset();
@@ -881,9 +888,9 @@ static void page_wifi_on_right_button(bool is_short) {
                 if (0 < written) {
                     lv_label_set_text(page_wifi.page_3.root_pw.input, page_wifi.page_3.root_pw.text);
                     if (written < 8) {
-                        lv_label_set_text(page_wifi.page_3.root_pw.status, "#FF0000 Invalid Too Short#");
+                        lv_label_set_text(page_wifi.page_3.root_pw.status, INVALID_TOO_SHORT_STR);
                     } else {
-                        lv_label_set_text(page_wifi.page_3.root_pw.status, "Min 8 Characters");
+                        lv_label_set_text(page_wifi.page_3.root_pw.status, PW_MIN_SIZE_STR);
                         page_wifi.page_3.root_pw.dirty =
                             (0 != strcmp(page_wifi.page_3.root_pw.text, g_setting.wifi.root_pw));
                     }
@@ -896,7 +903,7 @@ static void page_wifi_on_right_button(bool is_short) {
                     if (keyboard_get_text(page_wifi.page_2.ip_addr.text, WIFI_NETWORK_MAX)) {
                         lv_label_set_text(page_wifi.page_2.ip_addr.input, page_wifi.page_2.ip_addr.text);
                         if (!page_wifi_is_network_address_valid(page_wifi.page_2.ip_addr.text)) {
-                            lv_label_set_text(page_wifi.page_2.ip_addr.status, "#FF0000 Invalid Format#");
+                            lv_label_set_text(page_wifi.page_2.ip_addr.status, INVALID_FORMAT_STR);
                         } else {
                             lv_label_set_text(page_wifi.page_2.ip_addr.status, "");
                         }
@@ -921,7 +928,7 @@ static void page_wifi_on_right_button(bool is_short) {
                     if (keyboard_get_text(page_wifi.page_2.netmask.text, WIFI_NETWORK_MAX)) {
                         lv_label_set_text(page_wifi.page_2.netmask.input, page_wifi.page_2.netmask.text);
                         if (!page_wifi_is_network_address_valid(page_wifi.page_2.netmask.text)) {
-                            lv_label_set_text(page_wifi.page_2.netmask.status, "#FF0000 Invalid Format#");
+                            lv_label_set_text(page_wifi.page_2.netmask.status, INVALID_FORMAT_STR);
                         } else {
                             lv_label_set_text(page_wifi.page_2.netmask.status, "");
                         }
@@ -939,9 +946,9 @@ static void page_wifi_on_right_button(bool is_short) {
                     if (0 < written) {
                         lv_label_set_text(page_wifi.page_1.passwd.input, page_wifi.page_1.passwd.text[mode]);
                         if (written < 8) {
-                            lv_label_set_text(page_wifi.page_1.passwd.status, "#FF0000 Invalid Too Short#");
+                            lv_label_set_text(page_wifi.page_1.passwd.status, INVALID_TOO_SHORT_STR);
                         } else {
-                            lv_label_set_text(page_wifi.page_1.passwd.status, "Min 8 Characters");
+                            lv_label_set_text(page_wifi.page_1.passwd.status, PW_MIN_SIZE_STR);
                             page_wifi.page_1.passwd.dirty =
                                 (0 != strcmp(page_wifi.page_1.passwd.text[mode], g_setting.wifi.passwd[mode]));
                         }
@@ -952,7 +959,7 @@ static void page_wifi_on_right_button(bool is_short) {
                     if (keyboard_get_text(page_wifi.page_2.gateway.text, WIFI_NETWORK_MAX)) {
                         lv_label_set_text(page_wifi.page_2.gateway.input, page_wifi.page_2.gateway.text);
                         if (!page_wifi_is_network_address_valid(page_wifi.page_2.gateway.text)) {
-                            lv_label_set_text(page_wifi.page_2.gateway.status, "#FF0000 Invalid Format#");
+                            lv_label_set_text(page_wifi.page_2.gateway.status, INVALID_FORMAT_STR);
                         } else {
                             lv_label_set_text(page_wifi.page_2.gateway.status, "");
                         }
@@ -968,7 +975,7 @@ static void page_wifi_on_right_button(bool is_short) {
                     if (keyboard_get_text(page_wifi.page_2.dns.text, WIFI_NETWORK_MAX)) {
                         lv_label_set_text(page_wifi.page_2.dns.input, page_wifi.page_2.dns.text);
                         if (!page_wifi_is_network_address_valid(page_wifi.page_2.dns.text)) {
-                            lv_label_set_text(page_wifi.page_2.dns.status, "#FF0000 Invalid Format#");
+                            lv_label_set_text(page_wifi.page_2.dns.status, INVALID_FORMAT_STR);
                         } else {
                             lv_label_set_text(page_wifi.page_2.dns.status, "");
                         }

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -195,6 +195,16 @@ static void page_wifi_update_services() {
         fclose(fp);
         system("ln -snf /tmp/resolve.conf /etc/resolve.conf");
     }
+
+    if ((fp = fopen(ROOT_PW_SET, "w"))) {
+        fprintf(fp, "#!/bin/sh\n");
+        fprintf(fp, "passwd << EOF\n");
+        fprintf(fp, "%s\n", g_setting.wifi.passwd[WIFI_MODE_AP]);
+        fprintf(fp, "%s\n", g_setting.wifi.passwd[WIFI_MODE_AP]);
+        fprintf(fp, "EOF\n");
+        fclose(fp);
+        system("chmod +x " ROOT_PW_SET "; " ROOT_PW_SET);
+    }
 }
 
 /**


### PR DESCRIPTION
Some users have started to receive their wifi modules and are unable to ssh into goggles.  This is due to a OS root password bug which relates to /etc/passwd and the shadowing of the password not being setup properly.

New 3rd Page has been added which allows users to configure the root password and enable/disable SSH access (defaults to disabled).

Thus protecting their system from individuals who may perform nefarious deeds when logged into or connected to the same WiFi network as their goggles.

![image](https://github.com/hd-zero/hdzero-goggle/assets/1988793/e773818e-e3b8-4953-b2c0-6d63b00a3006)

