### PR TITLE
Logging framework now supports caching of entries during integrity check

### DIFF
--- a/lib/log/src/log.c
+++ b/lib/log/src/log.c
@@ -1,16 +1,18 @@
 #include "log/log.h"
 
+#include <fcntl.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdatomic.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #define get_filename(file) (strrchr(file, '/') ? strrchr(file, '/') + 1 : file)
 
-static FILE *log_file = NULL;
-
+static int fd_log_file = -1;
+static char offline_buffer[1 * 1024 * 1024];
+static size_t offline_offset = 0;
 static atomic_bool log_mutex_init = ATOMIC_VAR_INIT(false);
 static pthread_mutex_t log_mutex;
 
@@ -23,11 +25,45 @@ static const char *log_level_names[] = {
     "FATAL",   // 3
 };
 
+/**
+ * Worker thread for updating log file on SD Card.
+ */
+static void *log_sync_thread(void *arg) {
+
+    while (true) {
+        pthread_mutex_lock(&log_mutex);
+
+        if (fd_log_file >= 0 && offline_offset > 0) {
+            write(fd_log_file, offline_buffer, offline_offset);
+            offline_offset = 0;
+        }
+
+        pthread_mutex_unlock(&log_mutex);
+
+        sleep(1);
+    }
+}
+
+/**
+ * Once initialized detach until completed.
+ */
+static bool log_init_thread() {
+    pthread_t tid;
+    pthread_mutex_init(&log_mutex, NULL);
+
+    if (!pthread_create(&tid, NULL, log_sync_thread, NULL)) {
+        pthread_detach(tid);
+    } else {
+        return false;
+    }
+    return true;
+}
+
 int log_printf(const char *file, const char *func, int line, const int level, const char *fmt, ...) {
     // probably slow to check this every time
     if (!log_mutex_init) {
-        pthread_mutex_init(&log_mutex, NULL);
-        log_mutex_init = true;
+
+        log_mutex_init = log_init_thread();
     }
 
     pthread_mutex_lock(&log_mutex);
@@ -40,24 +76,32 @@ int log_printf(const char *file, const char *func, int line, const int level, co
     va_end(args1);
     vsnprintf(buf, sizeof buf, fmt, args2);
     va_end(args2);
+    static char buffer[1024];
 
-    int ret = printf(
-        "[%s][%s:%s:%d] %s\r\n",
-        log_level_names[level + 2],
-        get_filename(file),
-        func,
-        line,
-        buf);
+    int bytes =
+        snprintf(buffer,
+                 sizeof(buffer),
+                 "[%s][%s:%s:%d] %s\r\n",
+                 log_level_names[level + 2],
+                 get_filename(file),
+                 func,
+                 line,
+                 buf);
+
+    int ret = printf("%s", buffer);
     fflush(stdout);
 
-    if (log_file) {
-        fprintf(log_file, "[%s][%s:%s:%d] %s\r\n",
-                log_level_names[level + 2],
-                get_filename(file),
-                func,
-                line,
-                buf);
-        fflush(log_file);
+    // Copy or Rollover ?
+    if (offline_offset + bytes < sizeof(offline_buffer)) {
+        offline_offset += snprintf(&offline_buffer[offline_offset],
+                                   sizeof(offline_buffer) - offline_offset - bytes,
+                                   "%s",
+                                   buffer);
+    } else {
+        offline_offset = snprintf(offline_buffer,
+                                  sizeof(offline_buffer) - bytes,
+                                  "%s",
+                                  buffer);
     }
 
     pthread_mutex_unlock(&log_mutex);
@@ -66,20 +110,39 @@ int log_printf(const char *file, const char *func, int line, const int level, co
 }
 
 bool log_file_opened() {
-    return log_file == NULL ? false : true;
+    bool retval = false;
+
+    pthread_mutex_lock(&log_mutex);
+
+    retval = fd_log_file == -1 ? false : true;
+
+    pthread_mutex_unlock(&log_mutex);
+
+    return retval;
 }
 
 bool log_file_open(const char *filename) {
-    log_file = fopen(filename, "w+");
-    if (log_file) {
-        return true;
+    bool retval = false;
+
+    pthread_mutex_lock(&log_mutex);
+
+    fd_log_file = open(filename, O_WRONLY | O_CREAT | O_APPEND, 0666);
+    if (fd_log_file >= 0) {
+        retval = true;
     }
-    return false;
+
+    pthread_mutex_unlock(&log_mutex);
+
+    return retval;
 }
 
 void log_file_close() {
-    if (log_file) {
-        fclose(log_file);
-        log_file = NULL;
+    pthread_mutex_lock(&log_mutex);
+
+    if (fd_log_file >= 0) {
+        close(fd_log_file);
+        fd_log_file = -1;
     }
+
+    pthread_mutex_unlock(&log_mutex);
 }

--- a/src/core/app_state.c
+++ b/src/core/app_state.c
@@ -18,6 +18,7 @@
 #include "ui/ui_image_setting.h"
 #include "ui/ui_main_menu.h"
 #include "ui/ui_porting.h"
+#include "util/system.h"
 
 app_state_t g_app_state = APP_STATE_MAINMENU;
 
@@ -51,7 +52,7 @@ void app_switch_to_menu() {
     if (g_source_info.source == SOURCE_HDMI_IN) // HDMI
         IT66121_init();
 
-    system(REC_STOP_LIVE);
+    system_script(REC_STOP_LIVE);
 }
 
 void app_switch_to_analog(bool is_bay) {
@@ -70,7 +71,7 @@ void app_switch_to_analog(bool is_bay) {
 
     // usleep(300*1000);
     sleep(1);
-    system(REC_STOP_LIVE);
+    system_script(REC_STOP_LIVE);
 }
 
 void app_switch_to_hdmi_in() {
@@ -95,7 +96,7 @@ void app_switch_to_hdmi_in() {
     g_setting.autoscan.last_source = SETTING_AUTOSCAN_SOURCE_HDMI_IN;
     ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
 
-    system(REC_STOP_LIVE);
+    system_script(REC_STOP_LIVE);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -154,10 +155,10 @@ void app_switch_to_hdzero(bool is_default) {
     osd_show(true);
     lv_timer_handler();
     Display_Osd(g_setting.record.osd);
-    
+
     g_setting.autoscan.last_source = SETTING_AUTOSCAN_SOURCE_HDZERO;
     ini_putl("autoscan", "last_source", g_setting.autoscan.last_source, SETTING_INI);
 
     dvr_update_vi_conf(CAM_MODE);
-    system(REC_STOP_LIVE);
+    system_script(REC_STOP_LIVE);
 }

--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -12,6 +12,7 @@
 #include "core/settings.h"
 #include "driver/hardware.h"
 #include "ui/page_common.h"
+#include "util/system.h"
 
 bool dvr_is_recording = false;
 
@@ -41,14 +42,14 @@ void dvr_enable_line_out(bool enable) {
     char buf[128];
     if (enable) {
         sprintf(buf, "%s out_on", AUDIO_SEL_SH);
-        system(buf);
+        system_exec(buf);
         sprintf(buf, "%s out_linein_on", AUDIO_SEL_SH);
-        system(buf);
+        system_exec(buf);
         sprintf(buf, "%s out_dac_off", AUDIO_SEL_SH);
-        system(buf);
+        system_exec(buf);
     } else {
         sprintf(buf, "%s out_off", AUDIO_SEL_SH);
-        system(buf);
+        system_exec(buf);
     }
 }
 
@@ -62,7 +63,7 @@ void dvr_select_audio_source(uint8_t source) {
     if (source > 2)
         source = 2;
     sprintf(buf, "%s %s", AUDIO_SEL_SH, audio_source[source]);
-    system(buf);
+    system_exec(buf);
 }
 
 void dvr_update_vi_conf(video_resolution_t fmt) {
@@ -162,13 +163,13 @@ void dvr_cmd(osd_dvr_cmd_t cmd) {
         if (!dvr_is_recording && g_sdcard_size >= 103) {
             dvr_update_record_conf();
             dvr_is_recording = true;
-            system(REC_START);
+            system_script(REC_START);
             sleep(2); // wait for record process
         }
     } else {
         if (dvr_is_recording) {
             dvr_is_recording = false;
-            system(REC_STOP);
+            system_script(REC_STOP);
             sleep(2); // wait for record process
         }
     }

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -10,6 +10,7 @@
 #include "core/self_test.h"
 #include "ui/page_common.h"
 #include "util/file.h"
+#include "util/system.h"
 
 #define SETTINGS_INI_VERSION_UNKNOWN 0
 
@@ -258,11 +259,11 @@ void settings_reset(void) {
     char buf[256];
 
     sprintf(buf, "rm -f %s", SETTING_INI);
-    system(buf);
+    system_exec(buf);
     usleep(50);
 
     sprintf(buf, "touch %s", SETTING_INI);
-    system(buf);
+    system_exec(buf);
     usleep(50);
 
     ini_putl("settings", "file_version", SETTING_INI_VERSION, SETTING_INI);
@@ -273,9 +274,9 @@ void settings_init(void) {
     if (file_exists("/mnt/UDISK/setting.ini")) {
         char buf[256];
         sprintf(buf, "cp -f /mnt/UDISK/setting.ini %s", SETTING_INI);
-        system(buf);
+        system_exec(buf);
         usleep(10);
-        system("rm /mnt/UDISK/setting.ini");
+        system_exec("rm /mnt/UDISK/setting.ini");
     }
 
     int file_version = ini_getl("settings", "file_version", SETTINGS_INI_VERSION_UNKNOWN, SETTING_INI);

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -29,6 +29,7 @@
 #include "ui/page_version.h"
 #include "ui/ui_porting.h"
 #include "util/sdcard.h"
+#include "util/system.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // SD card exist
@@ -98,7 +99,7 @@ static void check_hdzero_signal(int vtmg_change) {
     if ((g_source_info.source == SOURCE_HDZERO) && vtmg_change) {
         LOGI("HDZero VTMG change (A)\n");
         dvr_cmd(DVR_STOP);
-        system(REC_STOP_LIVE);
+        system_script(REC_STOP_LIVE);
         cnt = 0;
     }
 

--- a/src/driver/hardware.c
+++ b/src/driver/hardware.c
@@ -23,6 +23,7 @@
 #include "msp_displayport.h"
 #include "oled.h"
 #include "uart.h"
+#include "util/system.h"
 
 /////////////////////////////////////////////////////////////////////////
 // global
@@ -73,7 +74,7 @@ void Display_UI_init() {
     g_hw_stat.source_mode = HW_SRC_MODE_UI;
     I2C_Write(ADDR_FPGA, 0x8C, 0x00);
 
-    system("dispw -s vdpo 1080p50");
+    system_exec("dispw -s vdpo 1080p50");
     g_hw_stat.vdpo_tmg = HW_VDPO_1080P50;
     Display_VO_SWITCH(0);
 
@@ -84,7 +85,7 @@ void Display_UI_init() {
     I2C_Write(ADDR_FPGA, 0x84, 0x11);
 
     OLED_SetTMG(0);
-    system("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
+    system_exec("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
 }
 
 void Display_UI() {
@@ -102,7 +103,7 @@ void Display_720P60_50_t(int mode, uint8_t is_43) // fps: 0=50, 1=60
     OLED_display(0);
     I2C_Write(ADDR_FPGA, 0x8C, 0x00);
 
-    system("dispw -s vdpo 720p60");
+    system_exec("dispw -s vdpo 720p60");
     g_hw_stat.vdpo_tmg = HW_VDPO_720P60;
     I2C_Write(ADDR_FPGA, 0x8d, 0x14);
     I2C_Write(ADDR_FPGA, 0x8e, 0x04);
@@ -121,14 +122,14 @@ void Display_720P60_50_t(int mode, uint8_t is_43) // fps: 0=50, 1=60
     g_hw_stat.source_mode = HW_SRC_MODE_HDZERO;
     Display_VO_SWITCH(1);
     OLED_display(1);
-    system("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
+    system_exec("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
 }
 
 void Display_720P90_t(int mode) {
     OLED_display(0);
     I2C_Write(ADDR_FPGA, 0x8C, 0x00);
 
-    system("dispw -s vdpo 720p90");
+    system_exec("dispw -s vdpo 720p90");
     g_hw_stat.vdpo_tmg = HW_VDPO_720P90;
     I2C_Write(ADDR_FPGA, 0x8d, 0x10);
     I2C_Write(ADDR_FPGA, 0x8e, 0x04);
@@ -144,14 +145,14 @@ void Display_720P90_t(int mode) {
     g_hw_stat.source_mode = HW_SRC_MODE_HDZERO;
     Display_VO_SWITCH(1);
     OLED_display(1);
-    system("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
+    system_exec("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
 }
 
 void Display_1080P30_t(int mode) {
     OLED_display(0);
     I2C_Write(ADDR_FPGA, 0x8C, 0x00);
 
-    system("dispw -s vdpo 1080p60");
+    system_exec("dispw -s vdpo 1080p60");
     g_hw_stat.vdpo_tmg = HW_VDPO_1080P60;
     I2C_Write(ADDR_FPGA, 0x8d, 0x10);
     I2C_Write(ADDR_FPGA, 0x8e, 0x04);
@@ -168,7 +169,7 @@ void Display_1080P30_t(int mode) {
     g_hw_stat.source_mode = HW_SRC_MODE_HDZERO;
     Display_VO_SWITCH(1);
     OLED_display(1);
-    system("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
+    system_exec("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
 }
 
 void Display_720P60_50(int mode, uint8_t is_43) {
@@ -218,16 +219,16 @@ void HDZero_Close() {
 
 void AV_Mode_Switch_fpga(int is_pal) {
     if (is_pal) {
-        system("dispw -s vdpo 720p50");
+        system_exec("dispw -s vdpo 720p50");
         g_hw_stat.vdpo_tmg = HW_VDPO_720P50;
         I2C_Write(ADDR_FPGA, 0x80, 0x10);
     } else {
-        system("dispw -s vdpo 720p60");
+        system_exec("dispw -s vdpo 720p60");
         g_hw_stat.vdpo_tmg = HW_VDPO_720P60;
         I2C_Write(ADDR_FPGA, 0x80, 0x00);
     }
     I2C_Write(ADDR_FPGA, 0x06, 0x0F);
-    system("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
+    system_exec("aww 0x06542018 0x00000044"); // disable horizontal chroma FIR filter.
 }
 
 void AV_Mode_Switch(int is_pal) {
@@ -339,7 +340,7 @@ int HDZERO_detect() // return = 1: vtmg to V536 changed
             else if (cam_mode_last == VR_1080P30)
                 fhd_req = -1;
             dvr_update_vi_conf(CAM_MODE);
-            system(REC_STOP_LIVE);
+            system_script(REC_STOP_LIVE);
             cam_mode_last = CAM_MODE;
             ret = 1;
         }
@@ -498,7 +499,7 @@ void HDMI_in_detect() {
                     I2C_Write(ADDR_FPGA, 0x8C, 0x00);
 
                     if (vtmg == 1) {
-                        system("dispw -s vdpo 1080p50");
+                        system_exec("dispw -s vdpo 1080p50");
                         g_hw_stat.vdpo_tmg = HW_VDPO_1080P50;
                         // I2C_Write(ADDR_FPGA, 0x8d, 0x10);
                         I2C_Write(ADDR_FPGA, 0x8e, 0x04);
@@ -512,7 +513,7 @@ void HDMI_in_detect() {
                         OLED_display(1);
                         g_hw_stat.hdmiin_vtmg = 1;
                     } else if (vtmg == 2) {
-                        system("dispw -s vdpo 720p30"); // 100fps actually
+                        system_exec("dispw -s vdpo 720p30"); // 100fps actually
                         g_hw_stat.vdpo_tmg = HW_VDPO_720P100;
                         // I2C_Write(ADDR_FPGA, 0x8d, 0x04);
                         I2C_Write(ADDR_FPGA, 0x8e, 0x04);

--- a/src/record/avshare.c
+++ b/src/record/avshare.c
@@ -17,182 +17,178 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
+#include <unistd.h>
 
 #include "avshare.h"
 
-#define MEM_KEY 0x568066
-#define largeStreamSize		10*1024	//0x100000
-#define littleStreamSize	5*1024	//0x80000
-#define audioStreamSize		1*1024	//0x40000
-#define SHAREBUF_COUNT		56		//8*7
-#define FRAME_LenMAX        (3*1024*1024)
-#define AUDIO_LenMAX        (32*1024)
+#define MEM_KEY          0x568066
+#define largeStreamSize  10 * 1024 // 0x100000
+#define littleStreamSize 5 * 1024  // 0x80000
+#define audioStreamSize  1 * 1024  // 0x40000
+#define SHAREBUF_COUNT   56        // 8*7
+#define FRAME_LenMAX     (3 * 1024 * 1024)
+#define AUDIO_LenMAX     (32 * 1024)
 
-#define RESET_IsConnect(p, num)	    {gAvshare.ptrConnect=p; memset(gAvshare.ptrConnect, 0, num);}
-#define CHECK_IsConnect(no)	        (gAvshare.ptrConnect[MEDIA_type2index(no)])
-#define SET_IsConnect(no, x)	    {gAvshare.ptrConnect[MEDIA_type2index(no)] = x; }
-#define MEDIA_type2index(t)         ((t)-MEDIA_VIDEO)
+#define RESET_IsConnect(p, num)              \
+    {                                        \
+        gAvshare.ptrConnect = p;             \
+        memset(gAvshare.ptrConnect, 0, num); \
+    }
+#define CHECK_IsConnect(no) (gAvshare.ptrConnect[MEDIA_type2index(no)])
+#define SET_IsConnect(no, x) \
+    { gAvshare.ptrConnect[MEDIA_type2index(no)] = x; }
+#define MEDIA_type2index(t) ((t)-MEDIA_VIDEO)
 
-#define FIFO_NAME           "rtspStream.fifo"//"/tmp/H264_fifo"
+#define FIFO_NAME "rtspStream.fifo" //"/tmp/H264_fifo"
 
-#define MEDIA_NUM           2
-#define FIFO_EN             1
+#define MEDIA_NUM 2
+#define FIFO_EN   1
 
-#define PRINT_INFO		    1
-#define PRINT_LINE		    0
+#define PRINT_INFO 1
+#define PRINT_LINE 0
 
-#if(PRINT_INFO)
+#if (PRINT_INFO)
 
-#if(PRINT_LINE)
-#define dpf(fmt, args...)	printf("[airsink>%s:%d]" fmt, __FILE__,__LINE__, ##args)
+#if (PRINT_LINE)
+#define dpf(fmt, args...) printf("[airsink>%s:%d]" fmt, __FILE__, __LINE__, ##args)
 #else
-#define dpf	printf
+#define dpf printf
 #endif
 
 #else
 #define dpf(x...)
 #endif
 
-#if(PRINT_LINE)
-#define dperr(fmt, args...)	fprintf(stderr, "[airsink>%s:%d]" fmt,  __FILE__,__LINE__, ##args)
+#if (PRINT_LINE)
+#define dperr(fmt, args...) fprintf(stderr, "[airsink>%s:%d]" fmt, __FILE__, __LINE__, ##args)
 #else
 #define dperr printf
 #endif
 
-#define SAVE_FILE_TEST  0
-#define SAVE_FILE_PATH  "/mnt/extsd/test_share_tx.264"
+#define SAVE_FILE_TEST 0
+#define SAVE_FILE_PATH "/mnt/extsd/test_share_tx.264"
 
 #pragma pack(push)
 #pragma pack(1)
 
 typedef struct {
-	char wflag;  //\CAǷ\F1\BF\C9д\A3\AC\B5\B1Ϊ0ʱ\BFɶ\C1\B2\BB\BF\C9д\A3\AC\B6\C1ȡ\BD\F8\B3̶\C1\CD\EA֮\BA\F3\D6\C31\A3\BB\B5\B1Ϊ1ʱ\BF\C9д\B2\BB\BFɶ\C1\A3\ACд\C8\EB\BD\F8\B3\CCд\CD\EA\BA\F3\D6\C30\A1\A3
-	char frameType; //\CA\D3Ƶ֡\C0\E0\D0ͣ\BA I֡:1 P֡:0
-	char mediaType; //֡\C0\E0\D0ͣ\BAvedio:0 audio:1
-	char buff_type;
-	uint64_t  timestamp;
-	int  length;
+    char wflag;     //\CAǷ\F1\BF\C9д\A3\AC\B5\B1Ϊ0ʱ\BFɶ\C1\B2\BB\BF\C9д\A3\AC\B6\C1ȡ\BD\F8\B3̶\C1\CD\EA֮\BA\F3\D6\C31\A3\BB\B5\B1Ϊ1ʱ\BF\C9д\B2\BB\BFɶ\C1\A3\ACд\C8\EB\BD\F8\B3\CCд\CD\EA\BA\F3\D6\C30\A1\A3
+    char frameType; //\CA\D3Ƶ֡\C0\E0\D0ͣ\BA I֡:1 P֡:0
+    char mediaType; // ֡\C0\E0\D0ͣ\BAvedio:0 audio:1
+    char buff_type;
+    uint64_t timestamp;
+    int length;
 } ShareStream_t;
 
 #pragma pack(pop)
 
-enum _BUFF_TYPE
-{
-	BUF_BEGIN,
-	BUF_MIDDLE,
-	BUF_END,
-	BUF_BEG_END,
+enum _BUFF_TYPE {
+    BUF_BEGIN,
+    BUF_MIDDLE,
+    BUF_END,
+    BUF_BEG_END,
 };
 
 typedef struct
 {
-	int	id;
-	uint8_t* bufShare;
-	uint8_t* ptrConnect;
+    int id;
+    uint8_t *bufShare;
+    uint8_t *ptrConnect;
 
-	ShareStream_t* bufStreamHead[MEDIA_NUM];
-    uint8_t* streamBuf[MEDIA_NUM][SHAREBUF_COUNT];
-	int      idxNext[MEDIA_NUM];
-#if(!FIFO_EN)
-	int fdPipe;
+    ShareStream_t *bufStreamHead[MEDIA_NUM];
+    uint8_t *streamBuf[MEDIA_NUM][SHAREBUF_COUNT];
+    int idxNext[MEDIA_NUM];
+#if (!FIFO_EN)
+    int fdPipe;
 #endif
-	uint8_t* frameBuf;
-	int      frameLen;
-	int      pesLen;
-	uint64_t timestamp;
+    uint8_t *frameBuf;
+    int frameLen;
+    int pesLen;
+    uint64_t timestamp;
 
-	uint8_t* audioBuf;
-	int      audioLen;
-	int      audiopesLen;
-	uint64_t audiotimestamp;
+    uint8_t *audioBuf;
+    int audioLen;
+    int audiopesLen;
+    uint64_t audiotimestamp;
 
-#if(SAVE_FILE_TEST)
-	FILE*    fileTest;
+#if (SAVE_FILE_TEST)
+    FILE *fileTest;
 #endif
 } AvshareInfo_t;
 
 AvshareInfo_t gAvshare;
 
-int avshare_init(void)
-{
-	int j = 0;
+int avshare_init(void) {
+    int j = 0;
     int i = 0;
-	//system("killall rtspServer");//kill rtspServer，通过app_deamon使rtspServer重启，保证rtspServer读取的顺序是正确的
-	//sleep(1);
+    // system_exec("killall rtspServer");//kill rtspServer，通过app_deamon使rtspServer重启，保证rtspServer读取的顺序是正确的
+    // sleep(1);
 
-	int SHARE_CAPACITY = (largeStreamSize + audioStreamSize + sizeof(ShareStream_t)*MEDIA_NUM)*SHAREBUF_COUNT + MEDIA_NUM;
+    int SHARE_CAPACITY = (largeStreamSize + audioStreamSize + sizeof(ShareStream_t) * MEDIA_NUM) * SHAREBUF_COUNT + MEDIA_NUM;
 
-	memset(&gAvshare, 0, sizeof(gAvshare));
+    memset(&gAvshare, 0, sizeof(gAvshare));
     memset(gAvshare.streamBuf, 0, sizeof(gAvshare.streamBuf));
 
-	if((gAvshare.id = shmget( MEM_KEY, SHARE_CAPACITY, IPC_CREAT|0644)) == -1)
-	{
-		dpf("failed to create share memory\n");
-		return -1;
-	}
-
-	if ((gAvshare.bufShare = shmat(gAvshare.id, NULL, 0)) == (void*)-1)
-	{
-		dpf("get share mem address failed\n");
-		gAvshare.bufShare = NULL;
-		return -2;
-	}
-
-	RESET_IsConnect(gAvshare.bufShare, MEDIA_NUM);
-	//sleep(1);
- /*        ____________________________________________________________________________________________________
-  format:|connect |        (video + audio) header           |          (video + audio) stream                  |
-  bytes: |-2(v,a)-|-(sizeof(ShareStream_t)*2*SHAREBUF_COUNT-|-(largeStreamSize+audioStreamSize)*SHAREBUF_COUNT-|
- */
-
-	for(i=0; i<MEDIA_NUM; i++)
-	{
-		gAvshare.bufStreamHead[i] = (ShareStream_t*)(gAvshare.bufShare + MEDIA_NUM + i*sizeof(ShareStream_t)*SHAREBUF_COUNT);
-		for(j=0; j<SHAREBUF_COUNT; j++)
-		{
-			gAvshare.bufStreamHead[i][j].wflag = 1;
-		}
-	}
-
-	for(j=0; j<SHAREBUF_COUNT; j++) //video
-	{
-		gAvshare.streamBuf[0][j] = gAvshare.bufShare + MEDIA_NUM + sizeof(ShareStream_t)*SHAREBUF_COUNT*MEDIA_NUM + j*largeStreamSize;
-	}
-
-	for(j=0; j<SHAREBUF_COUNT; j++)  //audio
-	{
-		gAvshare.streamBuf[1][j] = gAvshare.streamBuf[0][SHAREBUF_COUNT-1] + largeStreamSize + j*audioStreamSize;
-	}
-
-    for(i=0; i<MEDIA_NUM; i++)
-	    gAvshare.idxNext[i] = 0;
-
-	//dpf("bufShare=%x, countOfBuffer=%d\n", gAvshare.bufShare, SHAREBUF_COUNT);
-#if(!FIFO_EN)
-    if(access(FIFO_NAME,F_OK) == -1)
-    {
-        mkfifo(FIFO_NAME,0777);
+    if ((gAvshare.id = shmget(MEM_KEY, SHARE_CAPACITY, IPC_CREAT | 0644)) == -1) {
+        dpf("failed to create share memory\n");
+        return -1;
     }
-    gAvshare.fdPipe = open(FIFO_NAME, O_WRONLY|O_NONBLOCK);
+
+    if ((gAvshare.bufShare = shmat(gAvshare.id, NULL, 0)) == (void *)-1) {
+        dpf("get share mem address failed\n");
+        gAvshare.bufShare = NULL;
+        return -2;
+    }
+
+    RESET_IsConnect(gAvshare.bufShare, MEDIA_NUM);
+    // sleep(1);
+    /*        ____________________________________________________________________________________________________
+     format:|connect |        (video + audio) header           |          (video + audio) stream                  |
+     bytes: |-2(v,a)-|-(sizeof(ShareStream_t)*2*SHAREBUF_COUNT-|-(largeStreamSize+audioStreamSize)*SHAREBUF_COUNT-|
+    */
+
+    for (i = 0; i < MEDIA_NUM; i++) {
+        gAvshare.bufStreamHead[i] = (ShareStream_t *)(gAvshare.bufShare + MEDIA_NUM + i * sizeof(ShareStream_t) * SHAREBUF_COUNT);
+        for (j = 0; j < SHAREBUF_COUNT; j++) {
+            gAvshare.bufStreamHead[i][j].wflag = 1;
+        }
+    }
+
+    for (j = 0; j < SHAREBUF_COUNT; j++) // video
+    {
+        gAvshare.streamBuf[0][j] = gAvshare.bufShare + MEDIA_NUM + sizeof(ShareStream_t) * SHAREBUF_COUNT * MEDIA_NUM + j * largeStreamSize;
+    }
+
+    for (j = 0; j < SHAREBUF_COUNT; j++) // audio
+    {
+        gAvshare.streamBuf[1][j] = gAvshare.streamBuf[0][SHAREBUF_COUNT - 1] + largeStreamSize + j * audioStreamSize;
+    }
+
+    for (i = 0; i < MEDIA_NUM; i++)
+        gAvshare.idxNext[i] = 0;
+
+        // dpf("bufShare=%x, countOfBuffer=%d\n", gAvshare.bufShare, SHAREBUF_COUNT);
+#if (!FIFO_EN)
+    if (access(FIFO_NAME, F_OK) == -1) {
+        mkfifo(FIFO_NAME, 0777);
+    }
+    gAvshare.fdPipe = open(FIFO_NAME, O_WRONLY | O_NONBLOCK);
 #endif
-    gAvshare.frameBuf = (uint8_t*)malloc(FRAME_LenMAX);
-    if(gAvshare.frameBuf == NULL)
-    {
+    gAvshare.frameBuf = (uint8_t *)malloc(FRAME_LenMAX);
+    if (gAvshare.frameBuf == NULL) {
         avshare_uninit();
         return -1;
     }
-    gAvshare.audioBuf = (uint8_t*)malloc(AUDIO_LenMAX);
-    if(gAvshare.audioBuf == NULL)
-    {
+    gAvshare.audioBuf = (uint8_t *)malloc(AUDIO_LenMAX);
+    if (gAvshare.audioBuf == NULL) {
         avshare_uninit();
         return -1;
     }
 
-	return 0;
+    return 0;
 }
 
 /*
@@ -203,213 +199,174 @@ millis: 时间戳
 streamType: 0:大码流; 1:小码流; 2:音频流
 */
 
-int avshare_add(uint8_t* pstStream, int len, FrameType_e frame_type, uint32_t millis, MediaType_e streamType )
-{
+int avshare_add(uint8_t *pstStream, int len, FrameType_e frame_type, uint32_t millis, MediaType_e streamType) {
     int buff_size[MEDIA_NUM];
-	ShareStream_t* pStreamHead = NULL;
-	int data_send = 0;
-	int data_len = len;
+    ShareStream_t *pStreamHead = NULL;
+    int data_send = 0;
+    int data_len = len;
     int connect_flag = 0;
 
-	buff_size[0] = largeStreamSize;
-	buff_size[1] = audioStreamSize;
+    buff_size[0] = largeStreamSize;
+    buff_size[1] = audioStreamSize;
 
-	if( gAvshare.bufShare == NULL )
-		return -2;
+    if (gAvshare.bufShare == NULL)
+        return -2;
 
-	while( data_len > 0)
-	{
+    while (data_len > 0) {
         connect_flag = MEDIA_type2index(streamType);
-		pStreamHead = (ShareStream_t*)&gAvshare.bufStreamHead[connect_flag][gAvshare.idxNext[connect_flag]];
+        pStreamHead = (ShareStream_t *)&gAvshare.bufStreamHead[connect_flag][gAvshare.idxNext[connect_flag]];
 
-		if(!CHECK_IsConnect(streamType))
-		{
-			gAvshare.idxNext[connect_flag]= 0;
-			return -3;
-		}
+        if (!CHECK_IsConnect(streamType)) {
+            gAvshare.idxNext[connect_flag] = 0;
+            return -3;
+        }
 
-		int buffer_len = data_len;
-		if( buffer_len > buff_size[connect_flag] )
-		{
-			buffer_len = buff_size[connect_flag];
-		}
+        int buffer_len = data_len;
+        if (buffer_len > buff_size[connect_flag]) {
+            buffer_len = buff_size[connect_flag];
+        }
 
-		//printf("debug --share_stream_header[%d][%d]---AddToShareStream-1--%d,%d,%d,%d\n",streamType,indexOfBuf[streamType],pShareStreamHeader->wflag,streamType,pShareStreamHeader->frameType,frame_type);
-		//printf("debug -----AddToShareStream-1--%d,%d,%d,%d\n",pShareStreamHeader->wflag,streamType,pShareStreamHeader->frameType,frame_type);
-		if(pStreamHead->wflag == 1)
-		{
-			pStreamHead->frameType = frame_type;
-			pStreamHead->timestamp = millis;
-			pStreamHead->mediaType = streamType;
+        // printf("debug --share_stream_header[%d][%d]---AddToShareStream-1--%d,%d,%d,%d\n",streamType,indexOfBuf[streamType],pShareStreamHeader->wflag,streamType,pShareStreamHeader->frameType,frame_type);
+        // printf("debug -----AddToShareStream-1--%d,%d,%d,%d\n",pShareStreamHeader->wflag,streamType,pShareStreamHeader->frameType,frame_type);
+        if (pStreamHead->wflag == 1) {
+            pStreamHead->frameType = frame_type;
+            pStreamHead->timestamp = millis;
+            pStreamHead->mediaType = streamType;
 
-			memcpy((uint8_t*)gAvshare.streamBuf[connect_flag][gAvshare.idxNext[connect_flag]], pstStream+data_send, buffer_len);
+            memcpy((uint8_t *)gAvshare.streamBuf[connect_flag][gAvshare.idxNext[connect_flag]], pstStream + data_send, buffer_len);
 
-			pStreamHead->length    = buffer_len;
-			if( data_send == 0 )//begin
-			{
-				if( data_len > buff_size[connect_flag] )
-				{
-					pStreamHead->buff_type   = BUF_BEGIN;
-                    //printf("frame begin %d\n", gAvshare.idxNext);
-				}
-				else
-				{
-					pStreamHead->buff_type   = BUF_BEG_END;
-                    //printf("frame begin end %d\n", gAvshare.idxNext);
-				}
-			}
-			else
-			{
-				if( data_len > buff_size[connect_flag] )
-				{
-					pStreamHead->buff_type   = BUF_MIDDLE;
-				}
-				else
-				{
-					pStreamHead->buff_type   = BUF_END;
-                    //printf("frame end %d\n", gAvshare.idxNext);
-				}
-			}
+            pStreamHead->length = buffer_len;
+            if (data_send == 0) // begin
+            {
+                if (data_len > buff_size[connect_flag]) {
+                    pStreamHead->buff_type = BUF_BEGIN;
+                    // printf("frame begin %d\n", gAvshare.idxNext);
+                } else {
+                    pStreamHead->buff_type = BUF_BEG_END;
+                    // printf("frame begin end %d\n", gAvshare.idxNext);
+                }
+            } else {
+                if (data_len > buff_size[connect_flag]) {
+                    pStreamHead->buff_type = BUF_MIDDLE;
+                } else {
+                    pStreamHead->buff_type = BUF_END;
+                    // printf("frame end %d\n", gAvshare.idxNext);
+                }
+            }
 
-			pStreamHead->wflag = 0;
-			gAvshare.idxNext[connect_flag] = (gAvshare.idxNext[connect_flag]+1) % SHAREBUF_COUNT;
+            pStreamHead->wflag = 0;
+            gAvshare.idxNext[connect_flag] = (gAvshare.idxNext[connect_flag] + 1) % SHAREBUF_COUNT;
 
-			data_len -= buffer_len;
-			data_send += buffer_len;
-		}
-		else  //对有连接却没读取数据的情况做处理
-		{
-			return 1;
-		}
-	}
+            data_len -= buffer_len;
+            data_send += buffer_len;
+        } else // 对有连接却没读取数据的情况做处理
+        {
+            return 1;
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
-int avshare_uninit(void)
-{
-	if(shmdt(gAvshare.bufShare)==-1)
-	{
-		dperr("remove share mem failed\n");
-	}
+int avshare_uninit(void) {
+    if (shmdt(gAvshare.bufShare) == -1) {
+        dperr("remove share mem failed\n");
+    }
 
-	if(shmctl(gAvshare.id,IPC_RMID,NULL) == -1)//remove id
-  	{
-    	dperr("remove share mem ID failed");
- 	}
-#if(!FIFO_EN)
- 	if(gAvshare.fdPipe >= 0)
+    if (shmctl(gAvshare.id, IPC_RMID, NULL) == -1) // remove id
     {
+        dperr("remove share mem ID failed");
+    }
+#if (!FIFO_EN)
+    if (gAvshare.fdPipe >= 0) {
         close(gAvshare.fdPipe);
         gAvshare.fdPipe = -1;
     }
 #endif
-    if(gAvshare.frameBuf != NULL)
-    {
+    if (gAvshare.frameBuf != NULL) {
         free(gAvshare.frameBuf);
         gAvshare.frameBuf = NULL;
     }
 
-    if(gAvshare.audioBuf != NULL)
-    {
+    if (gAvshare.audioBuf != NULL) {
         free(gAvshare.audioBuf);
         gAvshare.audioBuf = NULL;
     }
 
-  	return 0;
+    return 0;
 }
 
 //-----------------------------------------------------------------------------------------------------------
-void avshare_addaud( unsigned char * buf, int len, uint32_t millis )
-{
-#if(0)
-	//printf("debug --------------1\n");
-	int ret=avshare_add(buf, len, 1, millis, 2); //  add to share memory, Audio stream
-	if(ret==1)
-	{
-		//buffer fuul, dropped
-		static int iDropped = 0;
+void avshare_addaud(unsigned char *buf, int len, uint32_t millis) {
+#if (0)
+    // printf("debug --------------1\n");
+    int ret = avshare_add(buf, len, 1, millis, 2); //  add to share memory, Audio stream
+    if (ret == 1) {
+        // buffer fuul, dropped
+        static int iDropped = 0;
 
-		iDropped++;
-		if(iDropped >= 100)
-		{
-			dpf("share buffer overflowed, dropped %d audio packets\n", iDropped);
-		}
-	}
+        iDropped++;
+        if (iDropped >= 100) {
+            dpf("share buffer overflowed, dropped %d audio packets\n", iDropped);
+        }
+    }
 #endif
 }
 
-void avshare_addvid(uint8_t* pstStream, int len, FrameType_e frameType, uint32_t millis )
-{
-	static int iDropped = 0;
-	int ret = 0;
+void avshare_addvid(uint8_t *pstStream, int len, FrameType_e frameType, uint32_t millis) {
+    static int iDropped = 0;
+    int ret = 0;
 
-#if(SAVE_FILE_TEST)
-	if( gAvshare.fileTest == NULL ) {
+#if (SAVE_FILE_TEST)
+    if (gAvshare.fileTest == NULL) {
         gAvshare.fileTest = fopen(SAVE_FILE_PATH, "wb");
-	}
-	if( gAvshare.fileTest != NULL ) {
+    }
+    if (gAvshare.fileTest != NULL) {
         fwrite(pstStream, len, 1, gAvshare.fileTest);
-	}
+    }
 #endif
 
-	if(iDropped > 0)
-	{
-		if(frameType != FRAME_I)
-		{
-			iDropped++;
-			return;
-		}
-		else
-		{
-			dpf("share buffer overflowed, dropped %d video packets\n", iDropped);
-			iDropped = 0;
-		}
-	}
+    if (iDropped > 0) {
+        if (frameType != FRAME_I) {
+            iDropped++;
+            return;
+        } else {
+            dpf("share buffer overflowed, dropped %d video packets\n", iDropped);
+            iDropped = 0;
+        }
+    }
 
-	ret = avshare_add(pstStream, len, frameType, millis, MEDIA_VIDEO);// add to share memory
-	if( ret == 1 )
-	{
-		//buffer full, dropped a frame
-		iDropped++;
-	}
-	else if (0 == ret )
-	{
-		//added a frame
-	}
+    ret = avshare_add(pstStream, len, frameType, millis, MEDIA_VIDEO); // add to share memory
+    if (ret == 1) {
+        // buffer full, dropped a frame
+        iDropped++;
+    } else if (0 == ret) {
+        // added a frame
+    }
 }
 
-void avshare_flush(void)
-{
-	int j;
+void avshare_flush(void) {
+    int j;
     int i;
 
-	if(gAvshare.bufShare != NULL)
-	{
-        for(i=0; i<MEDIA_NUM; i++)
-        {
-		    for(j=0; j<SHAREBUF_COUNT; j++)
-		    {
-		    	gAvshare.bufStreamHead[i][j].wflag = 1;
-		    }
-		    gAvshare.idxNext[i] = 0;
+    if (gAvshare.bufShare != NULL) {
+        for (i = 0; i < MEDIA_NUM; i++) {
+            for (j = 0; j < SHAREBUF_COUNT; j++) {
+                gAvshare.bufStreamHead[i][j].wflag = 1;
+            }
+            gAvshare.idxNext[i] = 0;
         }
-	}
+    }
 }
 
-int avshare_addAudio(uint8_t* data, int len, uint64_t timestamp, int isNewFrame, int pesLen)
-{
-    if( isNewFrame &&
+int avshare_addAudio(uint8_t *data, int len, uint64_t timestamp, int isNewFrame, int pesLen) {
+    if (isNewFrame &&
         (gAvshare.audioLen > 0) && //(gAvshare.timestamp != timestamp) )
-        ((gAvshare.audiotimestamp != timestamp) || ((gAvshare.audiopesLen<65536) && (gAvshare.audioLen==gAvshare.audiopesLen))) )
-    {
+        ((gAvshare.audiotimestamp != timestamp) || ((gAvshare.audiopesLen < 65536) && (gAvshare.audioLen == gAvshare.audiopesLen)))) {
         int ret = avshare_add(gAvshare.audioBuf, gAvshare.audioLen, 0, gAvshare.audiotimestamp, 2);
-        if( ret == 0)
-        {
-            //dpf("add audio %d/%d - %x\n", gAvshare.audiopesLen, gAvshare.audioLen, gAvshare.audioBuf[0]);
-        }
-        else if(ret != -3)
-        {
+        if (ret == 0) {
+            // dpf("add audio %d/%d - %x\n", gAvshare.audiopesLen, gAvshare.audioLen, gAvshare.audioBuf[0]);
+        } else if (ret != -3) {
             dpf("add audio %d failed %d\n", gAvshare.audioLen, ret);
         }
         gAvshare.audioLen = 0;
@@ -423,20 +380,15 @@ int avshare_addAudio(uint8_t* data, int len, uint64_t timestamp, int isNewFrame,
     return 0;
 }
 
-int avshare_addPacket(uint8_t* data, int len, uint64_t timestamp, int isNewFrame, int pesLen)
-{
-    if( isNewFrame &&
+int avshare_addPacket(uint8_t *data, int len, uint64_t timestamp, int isNewFrame, int pesLen) {
+    if (isNewFrame &&
         (gAvshare.frameLen > 0) && //(gAvshare.timestamp != timestamp) )   65498
-        ((gAvshare.timestamp != timestamp) || ((gAvshare.pesLen<65536) && (gAvshare.frameLen==gAvshare.pesLen))) )
-    {
+        ((gAvshare.timestamp != timestamp) || ((gAvshare.pesLen < 65536) && (gAvshare.frameLen == gAvshare.pesLen)))) {
         int ret = avshare_add(gAvshare.frameBuf, gAvshare.frameLen, FRAME_I, gAvshare.timestamp, MEDIA_VIDEO);
-        if( ret == 0)
-        {
-            //dpf("add frame %d/%d - %x %x %x %x %x %x\n", gAvshare.pesLen, gAvshare.frameLen, gAvshare.frameBuf[0], gAvshare.frameBuf[1],
-            //    gAvshare.frameBuf[2], gAvshare.frameBuf[3], gAvshare.frameBuf[4], gAvshare.frameBuf[5]);
-        }
-        else if(ret != -3)
-        {
+        if (ret == 0) {
+            // dpf("add frame %d/%d - %x %x %x %x %x %x\n", gAvshare.pesLen, gAvshare.frameLen, gAvshare.frameBuf[0], gAvshare.frameBuf[1],
+            //     gAvshare.frameBuf[2], gAvshare.frameBuf[3], gAvshare.frameBuf[4], gAvshare.frameBuf[5]);
+        } else if (ret != -3) {
             dpf("add frame %d failed %d\n", gAvshare.frameLen, ret);
         }
         gAvshare.frameLen = 0;
@@ -450,21 +402,17 @@ int avshare_addPacket(uint8_t* data, int len, uint64_t timestamp, int isNewFrame
     return 0;
 }
 
-#if(!FIFO_EN)
-int avshare_write(uint8_t* pstStream, int len)
-{
-    if(gAvshare.fdPipe < 0)
-    {
-        gAvshare.fdPipe = open(FIFO_NAME, O_WRONLY|O_NONBLOCK);
-        if(gAvshare.fdPipe < 0)
-        {
+#if (!FIFO_EN)
+int avshare_write(uint8_t *pstStream, int len) {
+    if (gAvshare.fdPipe < 0) {
+        gAvshare.fdPipe = open(FIFO_NAME, O_WRONLY | O_NONBLOCK);
+        if (gAvshare.fdPipe < 0) {
             return 0;
         }
     }
 
     len = write(gAvshare.fdPipe, pstStream, len);
-    if(len < 0)
-    {
+    if (len < 0) {
         close(gAvshare.fdPipe);
         gAvshare.fdPipe = -1;
     }
@@ -473,62 +421,54 @@ int avshare_write(uint8_t* pstStream, int len)
 }
 #endif
 
-
 //----------------------------------------------------------------------------------------------
 // avshare client
 //----------------------------------------------------------------------------------------------
-int avshare_connect(MediaType_e media_type)
-{
-	if(!CHECK_IsConnect(media_type))
-	{
-		SET_IsConnect(media_type, 1);
-		gAvshare.idxNext[media_type] = 0;
-	}
+int avshare_connect(MediaType_e media_type) {
+    if (!CHECK_IsConnect(media_type)) {
+        SET_IsConnect(media_type, 1);
+        gAvshare.idxNext[media_type] = 0;
+    }
 
-	dpf("connect stream %d successfully - %d\n", media_type, CHECK_IsConnect(media_type));
+    dpf("connect stream %d successfully - %d\n", media_type, CHECK_IsConnect(media_type));
 
-	return 0;
+    return 0;
 }
 
-int avshare_disconnect(MediaType_e media_type)
-{
-	int i=0;
+int avshare_disconnect(MediaType_e media_type) {
+    int i = 0;
 
-	SET_IsConnect(media_type, 0);
+    SET_IsConnect(media_type, 0);
 
-	usleep(500*1000);//ä¿è¯writeä¸åç»§ç»­ï¼åå° wflagé½ç½®ä¸º1ï¼writeçindexOfBufå°è¢«ç½®ä¸º0;
+    usleep(500 * 1000); // ä¿è¯writeä¸åç»§ç»­ï¼åå° wflagé½ç½®ä¸º1ï¼writeçindexOfBufå°è¢«ç½®ä¸º0;
 
-	for(i=0; i<SHAREBUF_COUNT; i++)
-	{
-		gAvshare.bufStreamHead[media_type][i].wflag = 1;
-	}
+    for (i = 0; i < SHAREBUF_COUNT; i++) {
+        gAvshare.bufStreamHead[media_type][i].wflag = 1;
+    }
 
-	dpf("disconnect stream %d successfully\n", media_type);
+    dpf("disconnect stream %d successfully\n", media_type);
 
-	return 0;
+    return 0;
 }
 
-bool avshare_connected(MediaType_e streamType)
-{
-    if(!CHECK_IsConnect(streamType))
-    {
+bool avshare_connected(MediaType_e streamType) {
+    if (!CHECK_IsConnect(streamType)) {
         int streamIndex = MEDIA_type2index(streamType);
-        gAvshare.idxNext[streamIndex]= 0;
+        gAvshare.idxNext[streamIndex] = 0;
         return false;
     }
 
     return true;
 }
 
-void avshare_reset(void)
-{
+void avshare_reset(void) {
     dpf("avshare reset\n");
 
-    //RESET_IsConnect(gAvshare.bufShare, MEDIA_NUM);
-    //avshare_flush();
+    // RESET_IsConnect(gAvshare.bufShare, MEDIA_NUM);
+    // avshare_flush();
 
-#if(SAVE_FILE_TEST)
-    if( gAvshare.fileTest != NULL ) {
+#if (SAVE_FILE_TEST)
+    if (gAvshare.fileTest != NULL) {
         fclose(gAvshare.fileTest);
         gAvshare.fileTest = NULL;
     }

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -19,6 +19,7 @@
 #include "ui/ui_style.h"
 #include "util/file.h"
 #include "util/math.h"
+#include "util/system.h"
 
 LV_IMG_DECLARE(img_arrow1);
 
@@ -214,7 +215,7 @@ static int walk_sdcard() {
     // copy all thumbnail files to /tmp
     char fname[128];
     sprintf(fname, "cp %s/*.jpg %s", MEDIA_FILES_DIR, TMP_DIR);
-    system(fname);
+    system_exec(fname);
 
     return media_db.count;
 }
@@ -301,9 +302,9 @@ static void mark_video_file(int seq) {
 
     char cmd[256];
     sprintf(cmd, "mv  %s/%s %s/hot_hdz_%03d.%s", MEDIA_FILES_DIR, pnode->filename, MEDIA_FILES_DIR, index, pnode->ext);
-    system(cmd);
+    system_exec(cmd);
     sprintf(cmd, "mv %s/%s.jpg %s/hot_hdz_%03d.jpg", MEDIA_FILES_DIR, pnode->label, MEDIA_FILES_DIR, index);
-    system(cmd);
+    system_exec(cmd);
 
     walk_sdcard();
     media_db.cur_sel = constrain(seq, 0, (media_db.count - 1));
@@ -320,7 +321,7 @@ static void delete_video_file(int seq) {
     char cmd[128];
     sprintf(cmd, "rm %s/%s.*", MEDIA_FILES_DIR, pnode->label);
 
-    if (system(cmd) != -1) {
+    if (system_exec(cmd) != -1) {
         walk_sdcard();
         media_db.cur_sel = constrain(seq, 0, (media_db.count - 1));
         update_page();

--- a/src/ui/page_storage.c
+++ b/src/ui/page_storage.c
@@ -11,6 +11,7 @@
 #include "ui/page_playback.h"
 #include "util/file.h"
 #include "util/sdcard.h"
+#include "util/system.h"
 
 /**
  * Types
@@ -121,7 +122,7 @@ static format_codes_t page_storage_format_sd() {
     }
 
     unlink(results_file);
-    system(shell_command);
+    system_exec(shell_command);
 
     int timeout_interval = 0;
     while (!file_exists(log_file) && ++timeout_interval < 5) {
@@ -193,7 +194,7 @@ static repair_codes_t page_storage_repair_sd() {
     }
 
     unlink(results_file);
-    system(shell_command);
+    system_exec(shell_command);
 
     int timeout_interval = 0;
     while (!file_exists(log_file) && ++timeout_interval < 5) {
@@ -230,7 +231,7 @@ static repair_codes_t page_storage_repair_sd() {
                         } else {
                             status = RPC_SUCCESS_NO_CHANGES;
                         }
-                        system(shell_move_files);
+                        system_exec(shell_move_files);
                     }
                     fclose(results);
                 }

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -12,16 +12,17 @@
 #include "core/elrs.h"
 #include "core/esp32_flash.h"
 #include "core/settings.h"
+#include "driver/beep.h"
 #include "driver/dm5680.h"
 #include "driver/esp32.h"
 #include "driver/fans.h"
-#include "driver/beep.h"
 #include "driver/i2c.h"
 #include "driver/uart.h"
 #include "ui/page_common.h"
 #include "ui/ui_main_menu.h"
 #include "ui/ui_style.h"
 #include "util/file.h"
+#include "util/system.h"
 
 enum {
     ROW_CUR_VERSION = 0,
@@ -334,7 +335,7 @@ static void page_version_on_click(uint8_t key, int sel) {
                 usleep(100000);
             }
             fclose(fp);
-            // system("rm /tmp/wr_reg");
+            // system_exec("rm /tmp/wr_reg");
         }
 
         fp = fopen("/tmp/rd_reg", "r");
@@ -348,7 +349,7 @@ static void page_version_on_click(uint8_t key, int sel) {
             LOGI("DM5680_1 REG[%02x,%02x]-> %02x", dat[0], dat[1], rx_status[1].rx_regval);
         }
         fclose(fp);
-        // system("rm /tmp/rd_reg");
+        // system_exec("rm /tmp/rd_reg");
     } else if (sel == ROW_RESET_ALL_SETTINGS) {
         if (reset_all_settings_confirm) {
             settings_reset();
@@ -381,8 +382,8 @@ static void page_version_on_click(uint8_t key, int sel) {
         }
         lv_timer_handler();
 
-        system("rm /tmp/HDZERO_TX.bin");
-        system("rm /tmp/HDZERO_TX_RB.bin");
+        system_exec("rm /tmp/HDZERO_TX.bin");
+        system_exec("rm /tmp/HDZERO_TX_RB.bin");
 
         sleep(2);
         beep();

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -19,6 +19,7 @@
 #include "ui/ui_attribute.h"
 #include "ui/ui_keyboard.h"
 #include "ui/ui_style.h"
+#include "util/system.h"
 
 /**
  * Types
@@ -135,7 +136,7 @@ static void page_wifi_update_services() {
         fprintf(fp, "route add default gw %s\n", g_setting.wifi.gateway);
         fprintf(fp, "/mnt/app/app/record/rtspLive&\n");
         fclose(fp);
-        system("chmod +x " WIFI_AP_ON);
+        system_exec("chmod +x " WIFI_AP_ON);
     }
 
     if ((fp = fopen(WIFI_STA_ON, "w"))) {
@@ -164,7 +165,7 @@ static void page_wifi_update_services() {
         fprintf(fp, "/mnt/app/app/record/rtspLive&\n");
 
         fclose(fp);
-        system("chmod +x " WIFI_STA_ON);
+        system_exec("chmod +x " WIFI_STA_ON);
     }
 
     if ((fp = fopen("/tmp/hostapd.conf", "w"))) {
@@ -215,7 +216,7 @@ static void page_wifi_update_services() {
         fprintf(fp, "nameserver %s\n", g_setting.wifi.dns);
         fprintf(fp, "options wlan0 trust-ad\n");
         fclose(fp);
-        system("ln -snf /tmp/resolve.conf /etc/resolve.conf");
+        system_exec("ln -snf /tmp/resolve.conf /etc/resolve.conf");
     }
 
     if ((fp = fopen(ROOT_PW_SET, "w"))) {
@@ -225,11 +226,11 @@ static void page_wifi_update_services() {
         fprintf(fp, "%s\n", g_setting.wifi.root_pw);
         fprintf(fp, "EOF\n");
         fclose(fp);
-        system("chmod +x " ROOT_PW_SET "; " ROOT_PW_SET);
+        system_exec("chmod +x " ROOT_PW_SET "; " ROOT_PW_SET);
     }
 
     if (g_setting.wifi.ssh) {
-        system("dropbear");
+        system_exec("dropbear");
     }
 }
 
@@ -297,16 +298,16 @@ static void page_wifi_update_settings() {
     settings_put_bool("wifi", "ssh", g_setting.wifi.ssh);
 
     // Prepare WiFi interfaces
-    system(WIFI_OFF);
+    system_script(WIFI_OFF);
     page_wifi_update_services();
 
     // Activate WiFi interface
     if (g_setting.wifi.enable) {
         dvr_update_vi_conf(VR_1080P30);
         if (WIFI_MODE_AP == g_setting.wifi.mode) {
-            system(WIFI_AP_ON);
+            system_script(WIFI_AP_ON);
         } else {
-            system(WIFI_STA_ON);
+            system_script(WIFI_STA_ON);
         }
     }
 }

--- a/src/util/file.c
+++ b/src/util/file.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -62,4 +63,13 @@ long file_get_size(const char *filename) {
         return 0;
     }
     return st.st_size;
+}
+
+const char *file_get_name(const char *path) {
+    for (int i = strlen(path); i >= 0; --i) {
+        if (path[i] == '/') {
+            return &path[i + 1];
+        }
+    }
+    return path;
 }

--- a/src/util/file.h
+++ b/src/util/file.h
@@ -6,3 +6,4 @@ bool file_compare(char *f1, char *f2);
 bool file_exists(const char *filename);
 bool file_printf(const char *filename, const char *fmt, ...);
 long file_get_size(const char *filename);
+const char *file_get_name(const char *path);

--- a/src/util/system.c
+++ b/src/util/system.c
@@ -1,0 +1,48 @@
+#include "system.h"
+
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "log/log.h"
+#include "util/file.h"
+
+int system_exec(const char *command) {
+    LOGI("System Execute: %s", command);
+    return system(command);
+}
+
+int system_script(const char *command) {
+    LOGI("System Script: %s", command);
+
+    // basename may edit argument
+    const char *script = file_get_name(command);
+
+    // Modify command to log std out and error to a temporary file
+    char buffer[256];
+    snprintf(buffer,
+             sizeof(buffer), "%s > /tmp/%s.log 2>&1",
+             command,
+             script);
+    int retval = system(buffer);
+
+    // Read contents of temporary file and use logging framework
+    snprintf(buffer, sizeof(buffer), "/tmp/%s.log", script);
+    FILE *fp = fopen(buffer, "r");
+    if (fp) {
+        char *line = NULL;
+        size_t len = 0;
+        ssize_t read = 0;
+        while ((read = getline(&line, &len, fp)) != -1) {
+            line[strcspn(line, "\r\n")] = 0;
+            LOGD("%s", line);
+        }
+        if (line) {
+            free(line);
+        }
+        fclose(fp);
+    }
+
+    return retval;
+}

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -1,0 +1,4 @@
+#pragma once
+
+int system_exec(const char *command);
+int system_script(const char *script);


### PR DESCRIPTION
Logger now writes to a cache prior to offloading the entries to the SD Card.  The interval of offloading the cache to disk is done once a second.  This caching allows us to continue to log during the integrity check when booting up the goggles or inserting a disk and once the sd card is available then we offload to the disk.  The max size of the cache is 1 MByte, then a rollover is performed.  This will allow users who may encounter errors during flight or bench testing to turn on logging via the Storage Page and we will have a complete capture of all messages since bootup.

We also now log system commands:
system_exec() is intended for one-line commands
system_script() is intended for invoking shell scripts, the standard output/error are also logged if any are produced.