### PR TITLE
adjust ANT OSD order

### DIFF
--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -527,16 +527,16 @@ void osd_hdzero_update(void) {
         osd_battery_low_show();
     }
 
-    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[0].rx_rssi[0]));
+    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[0].rx_rssi[1]));
     lv_img_set_src(g_osd_hdzero.ant0[is_fhd], buf);
 
-    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[0].rx_rssi[1]));
+    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[0].rx_rssi[0]));
     lv_img_set_src(g_osd_hdzero.ant1[is_fhd], buf);
 
-    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[1].rx_rssi[0]));
+    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[1].rx_rssi[1]));
     lv_img_set_src(g_osd_hdzero.ant2[is_fhd], buf);
 
-    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[1].rx_rssi[1]));
+    osd_resource_path(buf, "ant%d.bmp", is_fhd, RSSI2Ant(rx_status[1].rx_rssi[0]));
     lv_img_set_src(g_osd_hdzero.ant3[is_fhd], buf);
 
     if (showRXOSD && g_setting.osd.element[OSD_GOGGLE_ANT0].show)


### PR DESCRIPTION
![Screenshot from 2023-07-03 15-38-40](https://github.com/hd-zero/hdzero-goggle/assets/59721724/7e607c59-b352-497e-9a5d-bbf3a1ecd68a)
After adjustment, the order of the antennas osd(7/8/9/10) is the same as the manual.