### PR TITLE
Enable formatting not mounted sdcards

### DIFF
--- a/src/ui/page_storage.c
+++ b/src/ui/page_storage.c
@@ -103,7 +103,7 @@ static void page_storage_close_status_box() {
  * The formatting routine.
  */
 static format_codes_t page_storage_format_sd() {
-    if (!sdcard_mounted()) {
+    if (!sdcard_inserted()) {
         return FMC_ERR_SDCARD_NOT_INSERTED;
     }
 

--- a/src/util/sdcard.c
+++ b/src/util/sdcard.c
@@ -1,6 +1,7 @@
 #include "sdcard.h"
 
 #include <sys/stat.h>
+#include <unistd.h>
 
 bool sdcard_mounted() {
     struct stat mountpoint;
@@ -14,4 +15,8 @@ bool sdcard_mounted() {
     }
 
     return false;
+}
+
+bool sdcard_inserted() {
+    return access(SD_BLOCK_DEVICE, F_OK) == 0;
 }

--- a/src/util/sdcard.h
+++ b/src/util/sdcard.h
@@ -2,4 +2,8 @@
 
 #include <stdbool.h>
 
+#define SD_BLOCK_DEVICE "/dev/mmcblk0"
+
 bool sdcard_mounted();
+
+bool sdcard_inserted();


### PR DESCRIPTION
Add block device exist check instead of sdcard mounted check. Now googles can format sdcards with unsupported file system to FAT32. 
Large capacity sd cards has exFat file system by default.

By the way, it would be nice to add support for exFat and ext4 in future releases. 