### PR TITLE
AnalogRX Power "Auto" -batch 2 goggle

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -124,7 +124,6 @@ static void device_init(void) {
     TP2825_Config(0, 0);
     DM5680_req_ver();
     fans_top_setspeed(g_setting.fans.top_speed);
-    DM5680_Power_AnalogModule(g_setting.power.power_ana);
 }
 
 void lvgl_init() {
@@ -188,7 +187,10 @@ int main(int argc, char *argv[]) {
 
     // 8. Synthetic counter for gif refresh
     gif_cnt = 0;
-
+    
+    // 8.1 set initial analog module power state
+    Analog_Module_Power(0);
+    
     // 10. Execute main loop
     g_init_done = 1;
     for (;;) {

--- a/src/driver/hardware.c
+++ b/src/driver/hardware.c
@@ -8,11 +8,13 @@
 
 #include <log/log.h>
 
+#include "../core/app_state.h"
 #include "../core/common.hh"
 #include "../core/osd.h"
 #include "../core/settings.h"
 #include "../ui/page_common.h"
 #include "TP2825.h"
+#include "beep.h"
 #include "defines.h"
 #include "dm5680.h"
 #include "dm6302.h"
@@ -591,6 +593,28 @@ void Set_HT_dat(uint16_t ch0, uint16_t ch1, uint16_t ch2) {
     I2C_Write(ADDR_FPGA, 0x75, (ch1 >> 8) & 0xff);
     I2C_Write(ADDR_FPGA, 0x76, ch2 & 0xff);
     I2C_Write(ADDR_FPGA, 0x77, (ch2 >> 8) & 0xff);
+}
+
+void Analog_Module_Power(bool ForceSet) {
+      // Batch 2 goggles only
+      if (getHwRevision() >= HW_REV_2) {
+          static bool Analog_Module_Power_State = 0;
+              static bool Analog_Module_Power_State_Last = 0;
+              if (g_setting.power.power_ana == 0) {
+              Analog_Module_Power_State = 0;
+              } else {
+                      if (g_source_info.source != SOURCE_EXPANSION) {
+                      Analog_Module_Power_State = 1;
+                      } else {
+                      Analog_Module_Power_State = 0;
+                      }
+              }       
+              if ((Analog_Module_Power_State_Last != Analog_Module_Power_State) || (ForceSet == 1)) {
+              beep();                 
+              Analog_Module_Power_State_Last = Analog_Module_Power_State;
+              DM5680_Power_AnalogModule(Analog_Module_Power_State);
+              }
+      }
 }
 
 int Get_VideoLatancy_status() // ret: 0=unlocked, 1=locked

--- a/src/driver/hardware.c
+++ b/src/driver/hardware.c
@@ -596,25 +596,25 @@ void Set_HT_dat(uint16_t ch0, uint16_t ch1, uint16_t ch2) {
 }
 
 void Analog_Module_Power(bool ForceSet) {
-      // Batch 2 goggles only
-      if (getHwRevision() >= HW_REV_2) {
-          static bool Analog_Module_Power_State = 0;
-              static bool Analog_Module_Power_State_Last = 0;
-              if (g_setting.power.power_ana == 0) {
-              Analog_Module_Power_State = 0;
-              } else {
-                      if (g_source_info.source != SOURCE_EXPANSION) {
-                      Analog_Module_Power_State = 1;
-                      } else {
-                      Analog_Module_Power_State = 0;
-                      }
-              }       
-              if ((Analog_Module_Power_State_Last != Analog_Module_Power_State) || (ForceSet == 1)) {
-              beep();                 
-              Analog_Module_Power_State_Last = Analog_Module_Power_State;
-              DM5680_Power_AnalogModule(Analog_Module_Power_State);
-              }
-      }
+    // Batch 2 goggles only
+    if (getHwRevision() >= HW_REV_2) {
+    static bool Analog_Module_Power_State = 0;
+    static bool Analog_Module_Power_State_Last = 0;
+        if (g_setting.power.power_ana == 0) {
+        Analog_Module_Power_State = 0;
+        } else {
+            if (g_source_info.source != SOURCE_EXPANSION) {
+            Analog_Module_Power_State = 1;
+            } else {
+            Analog_Module_Power_State = 0;
+            }
+        }       
+        if ((Analog_Module_Power_State_Last != Analog_Module_Power_State) || (ForceSet == 1)) {
+        beep();                 
+        Analog_Module_Power_State_Last = Analog_Module_Power_State;
+        DM5680_Power_AnalogModule(Analog_Module_Power_State);
+        }
+    }
 }
 
 int Get_VideoLatancy_status() // ret: 0=unlocked, 1=locked

--- a/src/driver/hardware.h
+++ b/src/driver/hardware.h
@@ -65,6 +65,8 @@ void Set_Saturation(uint8_t sat);
 void Set_HT_status(uint8_t is_open, uint8_t frame_period, uint8_t sync_len);
 void Set_HT_dat(uint16_t ch0, uint16_t ch1, uint16_t ch2);
 
+void Analog_Module_Power(bool Force);
+
 int HDZERO_detect();
 int AV_in_detect();
 void HDMI_in_detect();

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -10,6 +10,7 @@
 #include "core/common.hh"
 #include "core/settings.h"
 #include "driver/dm5680.h"
+#include "driver/hardware.h"
 #include "driver/mcp3021.h"
 #include "page_common.h"
 #include "ui/ui_style.h"
@@ -98,7 +99,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     // Batch 2 goggles only
     if (getHwRevision() >= HW_REV_2) {
-        create_btn_group_item(&btn_group_power_ana, cont, 2, "AnalogRX Power", "On", "Off", "", "", ROW_POWER_ANA);
+        create_btn_group_item(&btn_group_power_ana, cont, 2, "AnalogRX Power", "On", "Auto", "", "", ROW_POWER_ANA);
     }
 
     // Back entry
@@ -248,7 +249,7 @@ static void page_power_on_click(uint8_t key, int sel) {
             btn_group_toggle_sel(&btn_group_power_ana);
             g_setting.power.power_ana = btn_group_get_sel(&btn_group_power_ana);
             ini_putl("power", "power_ana_rx", g_setting.power.power_ana, SETTING_INI);
-            DM5680_Power_AnalogModule(g_setting.power.power_ana);
+            Analog_Module_Power(1); 
         }
         break;
 

--- a/src/ui/page_sleep.c
+++ b/src/ui/page_sleep.c
@@ -69,10 +69,8 @@ static void page_sleep_enter() {
 static void page_sleep_exit() {
     LOGI("page_sleep_exit");
     OLED_ON(1); // Turn on OLED
-    if (getHwRevision() >= HW_REV_2) {
-        DM5680_Power_AnalogModule(g_setting.power.power_ana);
-    }
-
+    Analog_Module_Power(1);
+    
     g_setting.fans.top_speed = fan_speed_save.top;
     g_setting.fans.left_speed = fan_speed_save.left;
     g_setting.fans.right_speed = fan_speed_save.right;

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -160,6 +160,7 @@ static void page_source_on_click(uint8_t key, int sel) {
             break;
         }
     }
+    Analog_Module_Power(0);
 }
 
 static void page_source_enter() {


### PR DESCRIPTION
This PR replaces the AnalogRX Power setting "Off" with "Auto" and adds a function to track/set analog module bay power only on state change. Currently this will beep on every commanded state change except initiation of Go Sleep! function.

WARNING!
This should read like a very familiar hangup with implementing a physical power switch. Adding this feature is important. However, creating any system to change the power state of a critical item introduces potential risk. So, This needs to be heavily tested prior to usage with remote equipment and commit of this PR into master.


Known issues while AnalogRX Power is set to "On":
-none this is similar to batch 1 goggle behavior

Known issues while AnalogRX Power is set to "Auto":
-Source page will report Expansion Module: Disconnected when Expansion Module is not the currently selected source. Just select Expansion Module to use it anyway.
-when using ELRS backpack without a Binding Phrase (traditional binding) in your analog bay you will loose your backpack binding by switching in/out of Expansion Module source within 30 seconds three times.


Potential future enhancement:
-Add "Off" back in as a distinct setting (On, Auto, Off).
-disable beep on state change.
-add priority settings for debug beeps.
