### PR TITLE
Prevent corrupt MP4 when powerloss occurs.

### DIFF
--- a/src/record/ai2aenc.c
+++ b/src/record/ai2aenc.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include "ai2aenc.h"
+#include "record.h"
 
 static void ai2aenc_configAiAttr(Ai2Aenc_t *aa, AiParams_t *param) {
     memset(&aa->aiAttr, 0, sizeof(AIO_ATTR_S));
@@ -31,14 +32,21 @@ static void ai2aenc_configAiAttr(Ai2Aenc_t *aa, AiParams_t *param) {
 }
 
 static void ai2aenc_configAencAttr(Ai2Aenc_t *aa, AiParams_t *aiParam, AencParams_t *aeParam) {
+    RecordContext_t *recCtx = (RecordContext_t *)aa->contextOfOnFrame;
+
     memset(&aa->aeAttr, 0, sizeof(AENC_ATTR_S));
 
     aa->aeAttr.sampleRate = aiParam->sampleRate;
     aa->aeAttr.channels = aiParam->channels;
     aa->aeAttr.bitRate = aeParam->bitRate; // usful when codec G726
     aa->aeAttr.bitsPerSample = aiParam->bitsPerSample;
-    aa->aeAttr.attachAACHeader = 1; // ADTS
     aa->aeAttr.Type = aeParam->codecType;
+
+    if (strcmp(recCtx->params.packType, REC_packTS) == 0) {
+        aa->aeAttr.attachAACHeader = 1; // ADTS
+    } else {
+        aa->aeAttr.attachAACHeader = 0; // ACC
+    }
 }
 
 static ERRORTYPE MPPCallbackWrapper(void *cookie, MPP_CHN_S *pChn, MPP_EVENT_TYPE event, void *pEventData) {

--- a/src/record/ai2aenc.c
+++ b/src/record/ai2aenc.c
@@ -11,54 +11,46 @@
   History       :
 ******************************************************************************/
 
-//#define LOG_NDEBUG 0
+// #define LOG_NDEBUG 0
 #define LOG_TAG "ai2aenc"
 #include <log/log.h>
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "ai2aenc.h"
 
-static void ai2aenc_configAiAttr(Ai2Aenc_t* aa, AiParams_t* param)
-{
+static void ai2aenc_configAiAttr(Ai2Aenc_t *aa, AiParams_t *param) {
     memset(&aa->aiAttr, 0, sizeof(AIO_ATTR_S));
 
     aa->aiAttr.u32ChnCnt = param->channels;
     aa->aiAttr.enSamplerate = (AUDIO_SAMPLE_RATE_E)param->sampleRate;
-    aa->aiAttr.enBitwidth = (AUDIO_BIT_WIDTH_E)(param->bitsPerSample/8-1);
+    aa->aiAttr.enBitwidth = (AUDIO_BIT_WIDTH_E)(param->bitsPerSample / 8 - 1);
 }
 
-static void ai2aenc_configAencAttr(Ai2Aenc_t* aa, AiParams_t* aiParam, AencParams_t* aeParam)
-{
+static void ai2aenc_configAencAttr(Ai2Aenc_t *aa, AiParams_t *aiParam, AencParams_t *aeParam) {
     memset(&aa->aeAttr, 0, sizeof(AENC_ATTR_S));
 
     aa->aeAttr.sampleRate = aiParam->sampleRate;
     aa->aeAttr.channels = aiParam->channels;
-    aa->aeAttr.bitRate = aeParam->bitRate;             // usful when codec G726
+    aa->aeAttr.bitRate = aeParam->bitRate; // usful when codec G726
     aa->aeAttr.bitsPerSample = aiParam->bitsPerSample;
-    aa->aeAttr.attachAACHeader = 1;     // ADTS
+    aa->aeAttr.attachAACHeader = 1; // ADTS
     aa->aeAttr.Type = aeParam->codecType;
 }
 
-static ERRORTYPE MPPCallbackWrapper(void *cookie, MPP_CHN_S *pChn, MPP_EVENT_TYPE event, void *pEventData)
-{
-    //Ai2Aenc_t *aa = (Ai2Aenc_t *)cookie;
+static ERRORTYPE MPPCallbackWrapper(void *cookie, MPP_CHN_S *pChn, MPP_EVENT_TYPE event, void *pEventData) {
+    // Ai2Aenc_t *aa = (Ai2Aenc_t *)cookie;
 
-    if (pChn->mModId == MOD_ID_AI)
-    {
-        switch (event)
-        {
+    if (pChn->mModId == MOD_ID_AI) {
+        switch (event) {
         default:
             break;
         }
-    }
-    else if (pChn->mModId == MOD_ID_AENC)
-    {
-        switch (event)
-        {
+    } else if (pChn->mModId == MOD_ID_AENC) {
+        switch (event) {
         default:
             break;
         }
@@ -67,37 +59,29 @@ static ERRORTYPE MPPCallbackWrapper(void *cookie, MPP_CHN_S *pChn, MPP_EVENT_TYP
     return SUCCESS;
 }
 
-static ERRORTYPE ai2aenc_createAencChn(Ai2Aenc_t* aa, AiParams_t* aiParam, AencParams_t* aeParam)
-{
+static ERRORTYPE ai2aenc_createAencChn(Ai2Aenc_t *aa, AiParams_t *aiParam, AencParams_t *aeParam) {
     ERRORTYPE ret;
     BOOL nSuccessFlag = FALSE;
     AENC_CHN aeChn = 0;
 
     ai2aenc_configAencAttr(aa, aiParam, aeParam);
     aa->aeChn = 0;
-    while (aeChn < AENC_MAX_CHN_NUM)
-    {
-        ret = AW_MPI_AENC_CreateChn(aeChn, (AENC_CHN_ATTR_S*)&aa->aeAttr);
-        if (SUCCESS == ret)
-        {
+    while (aeChn < AENC_MAX_CHN_NUM) {
+        ret = AW_MPI_AENC_CreateChn(aeChn, (AENC_CHN_ATTR_S *)&aa->aeAttr);
+        if (SUCCESS == ret) {
             nSuccessFlag = TRUE;
             LOGD("create aenc channel[%d] success!", aeChn);
             break;
-        }
-        else if(ERR_AENC_EXIST == ret)
-        {
+        } else if (ERR_AENC_EXIST == ret) {
             LOGD("aenc channel[%d] exist, find next!", aeChn);
             aeChn++;
-        }
-        else
-        {
+        } else {
             LOGD("create aenc channel[%d] ret[0x%x], find next!", aeChn, ret);
             aeChn++;
         }
     }
 
-    if(FALSE == nSuccessFlag)
-    {
+    if (FALSE == nSuccessFlag) {
         aa->aeChn = MM_INVALID_CHN;
         LOGE("fatal error! create aenc channel fail!");
         return FAILURE;
@@ -105,48 +89,40 @@ static ERRORTYPE ai2aenc_createAencChn(Ai2Aenc_t* aa, AiParams_t* aiParam, AencP
     aa->aeChn = aeChn;
 
     MPPCallbackInfo cbInfo;
-    cbInfo.cookie = (void*)aa;
-    cbInfo.callback = MPPCallbackWrapper;//NULL;
+    cbInfo.cookie = (void *)aa;
+    cbInfo.callback = MPPCallbackWrapper; // NULL;
 
     AW_MPI_AENC_RegisterCallback(aa->aeChn, &cbInfo);
     return SUCCESS;
 }
 
-static ERRORTYPE ai2aenc_createAiChn(Ai2Aenc_t* aa, AiParams_t* aiParam)
-{
+static ERRORTYPE ai2aenc_createAiChn(Ai2Aenc_t *aa, AiParams_t *aiParam) {
     ERRORTYPE ret;
     BOOL bSuccessFlag = FALSE;
 
     aa->aiDev = aiParam->aiDev;
     ai2aenc_configAiAttr(aa, aiParam);
     AW_MPI_AI_SetPubAttr(aa->aiDev, &aa->aiAttr);
-    //AW_MPI_AI_Enable(aa->aiDev);
+    // AW_MPI_AI_Enable(aa->aiDev);
 
     AI_CHN aiChn = 0;
     aa->aiChn = 0;
-    while (aiChn < AIO_MAX_CHN_NUM)
-    {
+    while (aiChn < AIO_MAX_CHN_NUM) {
         ret = AW_MPI_AI_CreateChn(aa->aiDev, aiChn);
-        if (SUCCESS == ret)
-        {
+        if (SUCCESS == ret) {
             bSuccessFlag = TRUE;
             LOGD("create ai channel[%d] success!", aiChn);
             break;
-        }
-        else if (ERR_AI_EXIST == ret)
-        {
+        } else if (ERR_AI_EXIST == ret) {
             LOGD("ai channel[%d] exist, find next!", aiChn);
             aiChn++;
-        }
-        else
-        {
+        } else {
             LOGD("create ai channel[%d] ret[0x%x], find next!", aiChn, ret);
             aiChn++;
         }
     }
 
-    if (FALSE == bSuccessFlag)
-    {
+    if (FALSE == bSuccessFlag) {
         aa->aiChn = MM_INVALID_CHN;
         LOGE("fatal error! create ai channel fail!");
         return FAILURE;
@@ -154,31 +130,26 @@ static ERRORTYPE ai2aenc_createAiChn(Ai2Aenc_t* aa, AiParams_t* aiParam)
     aa->aiChn = aiChn;
 
     MPPCallbackInfo cbInfo;
-    cbInfo.cookie = (void*)aa;
+    cbInfo.cookie = (void *)aa;
     cbInfo.callback = NULL;
     AW_MPI_AI_RegisterCallback(aa->aiDev, aa->aiChn, &cbInfo);
     return SUCCESS;
 }
 
-static void *ai2aenc_frameProc(void *pThreadData)
-{
+static void *ai2aenc_frameProc(void *pThreadData) {
     AUDIO_STREAM_S stream;
     Ai2Aenc_t *aa = (Ai2Aenc_t *)pThreadData;
 
     LOGD("aenc thread: dev[%d] chn[%d] ae[%d]", aa->aiDev, aa->aiChn, aa->aeChn);
 
-    while (!aa->bExit)
-    {
-        if (SUCCESS == AW_MPI_AENC_GetStream(aa->aeChn, &stream, 100/*0*/))
-        {
-            //LOGD("get one stream with size: [%d]", stream.mLen);
-            if( aa->cbOnFrame != NULL)
-            {
+    while (!aa->bExit) {
+        if (SUCCESS == AW_MPI_AENC_GetStream(aa->aeChn, &stream, 100 /*0*/)) {
+            // LOGD("get one stream with size: [%d]", stream.mLen);
+            if (aa->cbOnFrame != NULL) {
                 aa->cbOnFrame(aa, stream.pStream, stream.mLen, stream.mTimeStamp, aa->contextOfOnFrame);
             }
             AW_MPI_AENC_ReleaseStream(aa->aeChn, &stream);
-        }
-        else {
+        } else {
             usleep(1000);
         }
     }
@@ -188,11 +159,9 @@ static void *ai2aenc_frameProc(void *pThreadData)
     return NULL;
 }
 
-Ai2Aenc_t* ai2aenc_initSys(CB_onAencFrame cbOnFrame, void* context)
-{
-    Ai2Aenc_t* aa = (Ai2Aenc_t*)malloc(sizeof(Ai2Aenc_t));
-    if( aa == NULL )
-    {
+Ai2Aenc_t *ai2aenc_initSys(CB_onAencFrame cbOnFrame, void *context) {
+    Ai2Aenc_t *aa = (Ai2Aenc_t *)malloc(sizeof(Ai2Aenc_t));
+    if (aa == NULL) {
         return NULL;
     }
 
@@ -206,17 +175,14 @@ Ai2Aenc_t* ai2aenc_initSys(CB_onAencFrame cbOnFrame, void* context)
     return aa;
 }
 
-void ai2aenc_deinitSys(Ai2Aenc_t* aa)
-{
-    if (aa->aiChn >= 0)
-    {
+void ai2aenc_deinitSys(Ai2Aenc_t *aa) {
+    if (aa->aiChn >= 0) {
         AW_MPI_AI_ResetChn(aa->aiDev, aa->aiChn);
         AW_MPI_AI_DestroyChn(aa->aiDev, aa->aiChn);
         AW_MPI_AI_Disable(aa->aiDev);
     }
 
-    if (aa->aeChn >= 0)
-    {
+    if (aa->aeChn >= 0) {
         AW_MPI_AENC_ResetChn(aa->aeChn);
         AW_MPI_AENC_DestroyChn(aa->aeChn);
     }
@@ -226,24 +192,20 @@ void ai2aenc_deinitSys(Ai2Aenc_t* aa)
     LOGD("done");
 }
 
-ERRORTYPE ai2aenc_prepare(Ai2Aenc_t* aa, AiParams_t* aiParams, AencParams_t* aeParams)
-{
+ERRORTYPE ai2aenc_prepare(Ai2Aenc_t *aa, AiParams_t *aiParams, AencParams_t *aeParams) {
     ERRORTYPE ret = ai2aenc_createAiChn(aa, aiParams);
-    if (ret < 0)
-    {
+    if (ret < 0) {
         LOGE("create ai chn fail");
         return ret;
     }
 
     ret = ai2aenc_createAencChn(aa, aiParams, aeParams);
-    if (ret < 0)
-    {
+    if (ret < 0) {
         LOGE("create ae chn fail");
         return ret;
     }
 
-    if (aa->aiChn >= 0)
-    {
+    if (aa->aiChn >= 0) {
         LOGD("bind ai & aenc");
         MPP_CHN_S AiChn = {MOD_ID_AI, aa->aiDev, aa->aiChn};
         MPP_CHN_S AencChn = {MOD_ID_AENC, 0, aa->aeChn};
@@ -253,24 +215,21 @@ ERRORTYPE ai2aenc_prepare(Ai2Aenc_t* aa, AiParams_t* aiParams, AencParams_t* aeP
     return ret;
 }
 
-ERRORTYPE ai2aenc_start(Ai2Aenc_t* aa)
-{
+ERRORTYPE ai2aenc_start(Ai2Aenc_t *aa) {
     ERRORTYPE ret = SUCCESS;
 
     LOGD("start");
 
-    //start transe
+    // start transe
     ret = AW_MPI_AI_EnableChn(aa->aiDev, aa->aiChn);
-    if (ret != SUCCESS)
-    {
+    if (ret != SUCCESS) {
         LOGE("AI enable error: %d", ret);
         return ret;
     }
 
-    if (aa->aeChn >= 0)
-    {
+    if (aa->aeChn >= 0) {
         ret = AW_MPI_AENC_StartRecvPcm(aa->aeChn);
-        if( ret != SUCCESS ) {
+        if (ret != SUCCESS) {
             LOGE("start recv pic error: %d", ret);
             return ret;
         }
@@ -283,42 +242,36 @@ ERRORTYPE ai2aenc_start(Ai2Aenc_t* aa)
     return ret;
 }
 
-ERRORTYPE ai2aenc_stop(Ai2Aenc_t* aa, bool disableDev)
-{
+ERRORTYPE ai2aenc_stop(Ai2Aenc_t *aa, bool disableDev) {
     LOGD("stop");
 
     aa->bExit = true;
-    if( aa->threadId > 0 ) {
+    if (aa->threadId > 0) {
         pthread_join(aa->threadId, NULL);
         aa->threadId = 0;
     }
 
-    //stop
-    if (aa->aiChn >= 0)
-    {
+    // stop
+    if (aa->aiChn >= 0) {
         AW_MPI_AI_DisableChn(aa->aiDev, aa->aiChn);
     }
 
-    if (aa->aeChn >= 0)
-    {
+    if (aa->aeChn >= 0) {
         LOGD("stop aenc");
         AW_MPI_AENC_StopRecvPcm(aa->aeChn);
     }
 
-    if (aa->aiChn >= 0)
-    {
+    if (aa->aiChn >= 0) {
         AW_MPI_AI_ResetChn(aa->aiDev, aa->aiChn);
         AW_MPI_AI_DestroyChn(aa->aiDev, aa->aiChn);
-        if(disableDev)
-        {
+        if (disableDev) {
             AW_MPI_AI_Disable(aa->aiDev);
         }
         aa->aiDev = MM_INVALID_DEV;
         aa->aiChn = MM_INVALID_CHN;
     }
 
-    if (aa->aeChn >= 0)
-    {
+    if (aa->aeChn >= 0) {
         AW_MPI_AENC_ResetChn(aa->aeChn);
         AW_MPI_AENC_DestroyChn(aa->aeChn);
         aa->aeChn = MM_INVALID_CHN;
@@ -329,7 +282,7 @@ ERRORTYPE ai2aenc_stop(Ai2Aenc_t* aa, bool disableDev)
     return SUCCESS;
 }
 
-#define  ADTS_HEADER_SIZE (7)
+#define ADTS_HEADER_SIZE (7)
 
 typedef struct
 {
@@ -339,57 +292,45 @@ typedef struct
     int channel_conf;
 } ADTSContext;
 
-int aac_decode_extradata(ADTSContext *adts, unsigned char *pbuf, int bufsize)
-{
+int aac_decode_extradata(ADTSContext *adts, unsigned char *pbuf, int bufsize) {
     int aot, aotext, samfreindex;
     int channelconfig;
     unsigned char *p = pbuf;
-    if (!adts || !pbuf || bufsize<2)
-    {
+    if (!adts || !pbuf || bufsize < 2) {
         return -1;
     }
-    aot = (p[0]>>3)&0x1f;
-    if (aot == 31)
-    {
-        aotext = (p[0]<<3 | (p[1]>>5)) & 0x3f;
+    aot = (p[0] >> 3) & 0x1f;
+    if (aot == 31) {
+        aotext = (p[0] << 3 | (p[1] >> 5)) & 0x3f;
         aot = 32 + aotext;
-        samfreindex = (p[1]>>1) & 0x0f;
-        if (samfreindex == 0x0f)
-        {
-            channelconfig = ((p[4]<<3) | (p[5]>>5)) & 0x0f;
+        samfreindex = (p[1] >> 1) & 0x0f;
+        if (samfreindex == 0x0f) {
+            channelconfig = ((p[4] << 3) | (p[5] >> 5)) & 0x0f;
+        } else {
+            channelconfig = ((p[1] << 3) | (p[2] >> 5)) & 0x0f;
         }
-        else
-        {
-            channelconfig = ((p[1]<<3)|(p[2]>>5)) & 0x0f;
-        }
-    }
-    else
-    {
-        samfreindex = ((p[0]<<1)|p[1]>>7) & 0x0f;
-        if (samfreindex == 0x0f)
-        {
-            channelconfig = (p[4]>>3) & 0x0f;
-        }
-        else
-        {
-            channelconfig = (p[1]>>3) & 0x0f;
+    } else {
+        samfreindex = ((p[0] << 1) | p[1] >> 7) & 0x0f;
+        if (samfreindex == 0x0f) {
+            channelconfig = (p[4] >> 3) & 0x0f;
+        } else {
+            channelconfig = (p[1] >> 3) & 0x0f;
         }
     }
 #ifdef AOT_PROFILE_CTRL
-    if (aot < 2) aot = 2;
+    if (aot < 2)
+        aot = 2;
 #endif
-    adts->objecttype = aot-1;
+    adts->objecttype = aot - 1;
     adts->sample_rate_index = samfreindex;
     adts->channel_conf = channelconfig;
     adts->write_adts = 1;
     return 0;
 }
 
-int aac_set_adts_head(ADTSContext *acfg, uint8_t *buf, int size)
-{
+int aac_set_adts_head(ADTSContext *acfg, uint8_t *buf, int size) {
     uint8_t byte;
-    if (size < ADTS_HEADER_SIZE)
-    {
+    if (size < ADTS_HEADER_SIZE) {
         return -1;
     }
     buf[0] = 0xff;
@@ -419,73 +360,67 @@ int aac_set_adts_head(ADTSContext *acfg, uint8_t *buf, int size)
 #define ADTS_HEADER__LEN 7
 
 const int sampling_frequencies[] = {
-    96000,  // 0x0
-    88200,  // 0x1
-    64000,  // 0x2
-    48000,  // 0x3
-    44100,  // 0x4
-    32000,  // 0x5
-    24000,  // 0x6
-    22050,  // 0x7
-    16000,  // 0x8
-    12000,  // 0x9
-    11025,  // 0xa
+    96000, // 0x0
+    88200, // 0x1
+    64000, // 0x2
+    48000, // 0x3
+    44100, // 0x4
+    32000, // 0x5
+    24000, // 0x6
+    22050, // 0x7
+    16000, // 0x8
+    12000, // 0x9
+    11025, // 0xa
     8000   // 0xb
     // 0xc d e f是保留的
 };
 
-int adts_header(char * const p_adts_header, const int data_length,
+int adts_header(char *const p_adts_header, const int data_length,
                 const int profile, const int samplerate,
-                const int channels)
-{
+                const int channels) {
     int sampling_frequency_index = 3; // 默认使用48000hz
     int adtsLen = data_length + 7;
 
     int frequencies_size = sizeof(sampling_frequencies) / sizeof(sampling_frequencies[0]);
     int i = 0;
-    for(i = 0; i < frequencies_size; i++)
-    {
-        if(sampling_frequencies[i] == samplerate)
-        {
+    for (i = 0; i < frequencies_size; i++) {
+        if (sampling_frequencies[i] == samplerate) {
             sampling_frequency_index = i;
             break;
         }
     }
-    if(i >= frequencies_size)
-    {
+    if (i >= frequencies_size) {
         printf("unsupport samplerate:%d\n", samplerate);
         return -1;
     }
 
-    p_adts_header[0] = 0xff;         //syncword:0xfff                          高8bits
-    p_adts_header[1] = 0xf0;         //syncword:0xfff                          低4bits
-    p_adts_header[1] |= (0 << 3);    //MPEG Version:0 for MPEG-4,1 for MPEG-2  1bit
-    p_adts_header[1] |= (0 << 1);    //Layer:0                                 2bits
-    p_adts_header[1] |= 1;           //protection absent:1                     1bit
+    p_adts_header[0] = 0xff;      // syncword:0xfff                          高8bits
+    p_adts_header[1] = 0xf0;      // syncword:0xfff                          低4bits
+    p_adts_header[1] |= (0 << 3); // MPEG Version:0 for MPEG-4,1 for MPEG-2  1bit
+    p_adts_header[1] |= (0 << 1); // Layer:0                                 2bits
+    p_adts_header[1] |= 1;        // protection absent:1                     1bit
 
-    p_adts_header[2] = (profile) << 6;            //profile:profile               2bits
-    p_adts_header[2] |= (sampling_frequency_index & 0x0f) << 2; //sampling frequency index:sampling_frequency_index  4bits
-    p_adts_header[2] |= (0 << 1);             //private bit:0                   1bit
-    p_adts_header[2] |= (channels & 0x04) >> 2; //channel configuration:channels  高1bit
+    p_adts_header[2] = (profile) << 6;                          // profile:profile               2bits
+    p_adts_header[2] |= (sampling_frequency_index & 0x0f) << 2; // sampling frequency index:sampling_frequency_index  4bits
+    p_adts_header[2] |= (0 << 1);                               // private bit:0                   1bit
+    p_adts_header[2] |= (channels & 0x04) >> 2;                 // channel configuration:channels  高1bit
 
-    p_adts_header[3] = (channels & 0x03) << 6; //channel configuration:channels 低2bits
-    p_adts_header[3] |= (0 << 5);               //original：0                1bit
-    p_adts_header[3] |= (0 << 4);               //home：0                    1bit
-    p_adts_header[3] |= (0 << 3);               //copyright id bit：0        1bit
-    p_adts_header[3] |= (0 << 2);               //copyright id start：0      1bit
-    p_adts_header[3] |= ((adtsLen & 0x1800) >> 11);           //frame length：value   高2bits
+    p_adts_header[3] = (channels & 0x03) << 6;      // channel configuration:channels 低2bits
+    p_adts_header[3] |= (0 << 5);                   // original：0                1bit
+    p_adts_header[3] |= (0 << 4);                   // home：0                    1bit
+    p_adts_header[3] |= (0 << 3);                   // copyright id bit：0        1bit
+    p_adts_header[3] |= (0 << 2);                   // copyright id start：0      1bit
+    p_adts_header[3] |= ((adtsLen & 0x1800) >> 11); // frame length：value   高2bits
 
-    p_adts_header[4] = (uint8_t)((adtsLen & 0x7f8) >> 3);     //frame length:value    中间8bits
-    p_adts_header[5] = (uint8_t)((adtsLen & 0x7) << 5);       //frame length:value    低3bits
-    p_adts_header[5] |= 0x1f;                                 //buffer fullness:0x7ff 高5bits
-    p_adts_header[6] = 0xfc;      //11111100      //buffer fullness:0x7ff 低6bits
+    p_adts_header[4] = (uint8_t)((adtsLen & 0x7f8) >> 3); // frame length:value    中间8bits
+    p_adts_header[5] = (uint8_t)((adtsLen & 0x7) << 5);   // frame length:value    低3bits
+    p_adts_header[5] |= 0x1f;                             // buffer fullness:0x7ff 高5bits
+    p_adts_header[6] = 0xfc;                              // 11111100      //buffer fullness:0x7ff 低6bits
     // number_of_raw_data_blocks_in_frame：
     //    表示ADTS帧中有number_of_raw_data_blocks_in_frame + 1个AAC原始帧。
 
     return 0;
 }
 
-void ai2aenc_getAacADTS(uint8_t* aacData, int len)
-{
-
+void ai2aenc_getAacADTS(uint8_t *aacData, int len) {
 }

--- a/src/record/ffpack.c
+++ b/src/record/ffpack.c
@@ -99,7 +99,7 @@ FFPack_t *ffpack_openFile(char *sName, void *context) {
     ff->cbContext = context;
 
     // Configure AvDictionary
-    av_dict_set(&ffpack_encoder_params, "movflags", "faststart+frag_keyframe+empty_moov", 0);
+    av_dict_set(&ffpack_encoder_params, "movflags", "frag_keyframe", 0);
 
     LOGD("format %s[%s]\n", ff->ofmtContext->oformat->name, ff->ofmtContext->oformat->long_name);
 

--- a/src/record/ffpack.c
+++ b/src/record/ffpack.c
@@ -1,99 +1,86 @@
-//#define LOG_NDEBUG 0
+// #define LOG_NDEBUG 0
 #define LOG_TAG "ffpack"
+#include "ffpack.h"
 #include <log/log.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
-#include "ffpack.h"
 
-#define FFPack_bufSIZE  65535
-#define FFPack(p)       ((FFPack_t*)(p))
+#define FFPack_bufSIZE 65535
+#define FFPack(p)      ((FFPack_t *)(p))
 
-void ff_printerr(char* sPrefix, int err)
-{
-	char strError[256] = {0};
-	av_strerror(err,strError,256);
-	if(sPrefix==NULL)
-    {
+void ff_printerr(char *sPrefix, int err) {
+    char strError[256] = {0};
+    av_strerror(err, strError, 256);
+    if (sPrefix == NULL) {
         LOGD("ff-failed: %s", strError);
-    }
-    else
-    {
+    } else {
         LOGD(sPrefix);
         LOGD("%d: %s", err, strError);
     }
 }
 
-int write_packet(void *opaque, uint8_t *buf, int buf_size)
-{
-    FFPack_t* ff = FFPack(opaque);
+int write_packet(void *opaque, uint8_t *buf, int buf_size) {
+    FFPack_t *ff = FFPack(opaque);
     ff->cbOnData(ff, 0, buf, buf_size, ff->cbContext);
 
-	return 0;
+    return 0;
 }
 
-FFPack_t* ffpack_open(CB_onData cbOnData, void* context)
-{
-    FFPack_t* ff = (FFPack_t*)malloc(sizeof(FFPack_t));
-    if(ff == NULL)
-    {
+FFPack_t *ffpack_open(CB_onData cbOnData, void *context) {
+    FFPack_t *ff = (FFPack_t *)malloc(sizeof(FFPack_t));
+    if (ff == NULL) {
         return NULL;
     }
 
     memset(ff, 0, sizeof(FFPack_t));
 
     int nRet = avformat_alloc_output_context2(&ff->ofmtContext, NULL, "mpegts", NULL);
-    //int nRet = avformat_alloc_output_context2(&ff->ofmtContext, NULL, "mp4", NULL);
-    if(nRet < 0)
-	{
-		ff_printerr("failed: ", nRet);
-		free(ff);
-		return NULL;
-	}
+    // int nRet = avformat_alloc_output_context2(&ff->ofmtContext, NULL, "mp4", NULL);
+    if (nRet < 0) {
+        ff_printerr("failed: ", nRet);
+        free(ff);
+        return NULL;
+    }
 
-	uint8_t* buf = (uint8_t*)av_mallocz(sizeof(uint8_t)* FFPack_bufSIZE);
-	AVIOContext* pb = avio_alloc_context(buf, FFPack_bufSIZE, 1, ff, NULL, write_packet, NULL);//注意：第3个参数赋值为1，否则write_packet回调将不能被成功调用
+    uint8_t *buf = (uint8_t *)av_mallocz(sizeof(uint8_t) * FFPack_bufSIZE);
+    AVIOContext *pb = avio_alloc_context(buf, FFPack_bufSIZE, 1, ff, NULL, write_packet, NULL); // 注意：第3个参数赋值为1，否则write_packet回调将不能被成功调用
 
-	ff->ofmtContext->pb = pb;//这个是关键，指定ps输出的方式
-	ff->ofmtContext->flags |= AVFMT_FLAG_CUSTOM_IO;
-	ff->ofmtContext->flags |= AVFMT_FLAG_FLUSH_PACKETS;
-	ff->ofmtContext->flags |= AVFMT_NOFILE; //不生成文件
+    ff->ofmtContext->pb = pb; // 这个是关键，指定ps输出的方式
+    ff->ofmtContext->flags |= AVFMT_FLAG_CUSTOM_IO;
+    ff->ofmtContext->flags |= AVFMT_FLAG_FLUSH_PACKETS;
+    ff->ofmtContext->flags |= AVFMT_NOFILE; // 不生成文件
 
-	ff->cbOnData = cbOnData;
-	ff->cbContext= context;
+    ff->cbOnData = cbOnData;
+    ff->cbContext = context;
 
-	LOGD("format %s[%s]\n", ff->ofmtContext->oformat->name, ff->ofmtContext->oformat->long_name);
+    LOGD("format %s[%s]\n", ff->ofmtContext->oformat->name, ff->ofmtContext->oformat->long_name);
 
     return ff;
 }
 
-FFPack_t* ffpack_openFile(char* sName, void* context)
-{
-    FFPack_t* ff = (FFPack_t*)malloc(sizeof(FFPack_t));
-    if(ff == NULL)
-    {
+FFPack_t *ffpack_openFile(char *sName, void *context) {
+    FFPack_t *ff = (FFPack_t *)malloc(sizeof(FFPack_t));
+    if (ff == NULL) {
         return NULL;
     }
 
     memset(ff, 0, sizeof(FFPack_t));
 
     int nRet = avformat_alloc_output_context2(&ff->ofmtContext, NULL, NULL, sName);
-    //int nRet = avformat_alloc_output_context2(&ff->ofmtContext, NULL, "mp4", NULL);
-    //int nRet = avformat_alloc_output_context2(&ff->ofmtContext, av_guess_format("mp4", NULL, "video/mp4"), NULL, NULL);
-	if(nRet < 0)
-	{
-		ff_printerr("failed: ", nRet);
-		free(ff);
-		return NULL;
-	}
+    // int nRet = avformat_alloc_output_context2(&ff->ofmtContext, NULL, "mp4", NULL);
+    // int nRet = avformat_alloc_output_context2(&ff->ofmtContext, av_guess_format("mp4", NULL, "video/mp4"), NULL, NULL);
+    if (nRet < 0) {
+        ff_printerr("failed: ", nRet);
+        free(ff);
+        return NULL;
+    }
 
-    if(!(ff->ofmtContext->flags & AVFMT_NOFILE))
-    {
+    if (!(ff->ofmtContext->flags & AVFMT_NOFILE)) {
         nRet = avio_open(&ff->ofmtContext->pb, sName, AVIO_FLAG_WRITE);
-        if(nRet < 0)
-        {
-            ff_printerr( "pb failed: ", nRet);
+        if (nRet < 0) {
+            ff_printerr("pb failed: ", nRet);
 
             // pb open will failed if sdcard is read-only, treat it as fatal error
             // sdcard will be mounted as read-only sometimes by the following operations:
@@ -107,50 +94,46 @@ FFPack_t* ffpack_openFile(char* sName, void* context)
         }
     }
 
-	ff->cbContext= context;
+    ff->cbContext = context;
 
-	LOGD("format %s[%s]\n", ff->ofmtContext->oformat->name, ff->ofmtContext->oformat->long_name);
+    LOGD("format %s[%s]\n", ff->ofmtContext->oformat->name, ff->ofmtContext->oformat->long_name);
 
     return ff;
 }
 
-void ffpack_close(FFPack_t* ff)
-{
+void ffpack_close(FFPack_t *ff) {
     LOGD("ff=%p\n", ff);
 
-    //flush all data
+    // flush all data
     av_write_frame(ff->ofmtContext, NULL);
 
-    //LOGD("ofmt=%p\n", ff->ofmtContext);
+    // LOGD("ofmt=%p\n", ff->ofmtContext);
 
-    //Write file trailer
+    // Write file trailer
     av_write_trailer(ff->ofmtContext);
 
-    if( ff->ofmtContext != NULL )
-    {
-        if(!(ff->ofmtContext->flags & AVFMT_NOFILE))
-        {
-            //LOGD("close pb=%p\n", ff->ofmtContext->pb);
+    if (ff->ofmtContext != NULL) {
+        if (!(ff->ofmtContext->flags & AVFMT_NOFILE)) {
+            // LOGD("close pb=%p\n", ff->ofmtContext->pb);
             avio_close(ff->ofmtContext->pb);
-        }
-        else {
-            //LOGD("free pb=%p\n", ff->ofmtContext->pb);
+        } else {
+            // LOGD("free pb=%p\n", ff->ofmtContext->pb);
             avio_context_free(&ff->ofmtContext->pb);
         }
 
-#if(0)
+#if (0)
         /* would cause an exception */
         int i;
-        AVCodecParameters* cp;
-        for( i=0; i<ff->ofmtContext->nb_streams; i++ ) {
+        AVCodecParameters *cp;
+        for (i = 0; i < ff->ofmtContext->nb_streams; i++) {
             cp = ff->ofmtContext->streams[i]->codecpar;
-            if( (cp->extradata_size > 0) && (cp->extradata != NULL) ) {
+            if ((cp->extradata_size > 0) && (cp->extradata != NULL)) {
                 av_free(cp->extradata);
             }
         }
 #endif
 
-        //LOGD("free ofmt\n");
+        // LOGD("free ofmt\n");
         avformat_free_context(ff->ofmtContext);
     }
 
@@ -159,16 +142,15 @@ void ffpack_close(FFPack_t* ff)
     LOGD("done\n");
 }
 
-int ffpack_newProgram(FFPack_t* ff, char* sName)
-{
-    AVFormatContext* fmtContext = ff->ofmtContext;
+int ffpack_newProgram(FFPack_t *ff, char *sName) {
+    AVFormatContext *fmtContext = ff->ofmtContext;
     AVProgram *program = av_new_program(fmtContext, fmtContext->nb_programs + 1);
 
     if (program) {
         av_dict_set(&program->metadata, "service_name", sName, 0);
-        //av_dict_set(&program->metadata, "title", "testTitle1", 0);
+        // av_dict_set(&program->metadata, "title", "testTitle1", 0);
         av_dict_set(&program->metadata, "service_provider", "avsoon", 0);
-        //av_dict_set(&program->metadata, "language", "English", 0);
+        // av_dict_set(&program->metadata, "language", "English", 0);
 
         return program->id;
     }
@@ -176,79 +158,71 @@ int ffpack_newProgram(FFPack_t* ff, char* sName)
     return 0;
 }
 
-int ffpack_newVideoStream(FFPack_t* ff, uint16_t programId, FFStreamParameters_t* param)
-{
-    if(param->mediaType != AVMEDIA_TYPE_VIDEO)
-    {
+int ffpack_newVideoStream(FFPack_t *ff, uint16_t programId, FFStreamParameters_t *param) {
+    if (param->mediaType != AVMEDIA_TYPE_VIDEO) {
         LOGD("unsupported type: %d", param->mediaType);
         return -1;
     }
 
     AVStream *stream = avformat_new_stream(ff->ofmtContext, NULL);
-    if (!stream)
-    {
+    if (!stream) {
         LOGD("failed!\n");
         return -1;
     }
 
-    AVCodecParameters* cp = stream->codecpar;
-    stream->r_frame_rate.num = 0;//param->video.fps;
-    stream->r_frame_rate.den = 0;//1;
+    AVCodecParameters *cp = stream->codecpar;
+    stream->r_frame_rate.num = 0; // param->video.fps;
+    stream->r_frame_rate.den = 0; // 1;
     stream->avg_frame_rate.num = param->video.fps;
     stream->avg_frame_rate.den = 1;
-    stream->time_base.num = 1;//0;
-    stream->time_base.den = param->video.fps;//100000;//1; //10us
+    stream->time_base.num = 1;                // 0;
+    stream->time_base.den = param->video.fps; // 100000;//1; //10us
     cp->codec_type = param->mediaType;
     cp->codec_id = param->codecId;
     cp->width = param->video.width;
-    cp->height= param->video.height;
+    cp->height = param->video.height;
 
-    //mp4 needed
+    // mp4 needed
     cp->codec_tag = 0;
     cp->format = 12;
-    //cp->profile = 100;
-    //cp->level = 51;
+    // cp->profile = 100;
+    // cp->level = 51;
 
-    if( param->codecId == AV_CODEC_ID_HEVC ) {
-        //compatible with macos's quicktime
+    if (param->codecId == AV_CODEC_ID_HEVC) {
+        // compatible with macos's quicktime
         cp->codec_tag = MKTAG('h', 'v', 'c', '1');
     }
 
-    if( param->spsData != NULL ) {
+    if (param->spsData != NULL) {
         cp->extradata_size = param->spsLen;
         cp->extradata = av_mallocz(cp->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
-        if (!cp->extradata)
-        {
+        if (!cp->extradata) {
             LOGE("outof memory");
             return -1;
         }
         memcpy(cp->extradata, param->spsData, cp->extradata_size);
     }
 
-    if(programId >=0)
-    {
+    if (programId >= 0) {
         av_program_add_stream_index(ff->ofmtContext, programId, stream->index);
     }
 
     return stream->index;
 }
 
-int  ffpack_newAudioStream(FFPack_t* ff, uint16_t programId, FFStreamParameters_t* param)
-{
-    if(param->mediaType != AVMEDIA_TYPE_AUDIO)
-    {
+int ffpack_newAudioStream(FFPack_t *ff, uint16_t programId, FFStreamParameters_t *param) {
+    if (param->mediaType != AVMEDIA_TYPE_AUDIO) {
         LOGD("unsupported type: %d", param->mediaType);
         return -1;
     }
 
     AVStream *stream = avformat_new_stream(ff->ofmtContext, NULL);
-    if (!stream)
-    {
+    if (!stream) {
         LOGD("failed");
         return -1;
     }
 
-    AVCodecParameters* cp = stream->codecpar;
+    AVCodecParameters *cp = stream->codecpar;
     stream->time_base.num = 1;
     stream->time_base.den = param->audio.sample_rate;
     cp->codec_type = param->mediaType;
@@ -257,30 +231,26 @@ int  ffpack_newAudioStream(FFPack_t* ff, uint16_t programId, FFStreamParameters_
     cp->sample_rate = param->audio.sample_rate;
     cp->codec_tag = 0;
 
-    if(programId >=0)
-    {
+    if (programId >= 0) {
         av_program_add_stream_index(ff->ofmtContext, programId, stream->index);
     }
 
     return stream->index;
 }
 
-int  ffpack_newDataStream (FFPack_t* ff, uint16_t programId, FFStreamParameters_t* param)
-{
-    if(param->mediaType != AVMEDIA_TYPE_DATA)
-    {
+int ffpack_newDataStream(FFPack_t *ff, uint16_t programId, FFStreamParameters_t *param) {
+    if (param->mediaType != AVMEDIA_TYPE_DATA) {
         LOGD("unsupported type: %d", param->mediaType);
         return -1;
     }
 
     AVStream *stream = avformat_new_stream(ff->ofmtContext, NULL);
-    if (!stream)
-    {
+    if (!stream) {
         LOGD("failed");
         return -1;
     }
 
-    AVCodecParameters* cp = stream->codecpar;
+    AVCodecParameters *cp = stream->codecpar;
     stream->time_base.num = 0;
     stream->time_base.den = 1;
     cp->codec_type = param->mediaType;
@@ -291,19 +261,15 @@ int  ffpack_newDataStream (FFPack_t* ff, uint16_t programId, FFStreamParameters_
     return stream->index;
 }
 
-bool ffpack_isVideoStream(AVStream* st)
-{
+bool ffpack_isVideoStream(AVStream *st) {
     return st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO;
 }
 
-int ffpack_getFps(FFPack_t* ff)
-{
+int ffpack_getFps(FFPack_t *ff) {
     int i;
 
-    for(i=0; i<ff->ofmtContext->nb_streams; i++)
-    {
-        if(ffpack_isVideoStream(ff->ofmtContext->streams[i]))
-        {
+    for (i = 0; i < ff->ofmtContext->nb_streams; i++) {
+        if (ffpack_isVideoStream(ff->ofmtContext->streams[i])) {
             return ff->ofmtContext->streams[i]->r_frame_rate.num;
         }
     }
@@ -311,32 +277,27 @@ int ffpack_getFps(FFPack_t* ff)
     return 0;
 }
 
-void ffpack_dumpTimebase(FFPack_t* ff)
-{
+void ffpack_dumpTimebase(FFPack_t *ff) {
     int i = 0;
-    AVStream* st;
+    AVStream *st;
 
-    for( i=0; i<ff->ofmtContext->nb_streams; i++ )
-    {
+    for (i = 0; i < ff->ofmtContext->nb_streams; i++) {
         st = ff->ofmtContext->streams[i];
         LOGD("stream %d: time_base(num,den) = %d,%d", i, st->time_base.num, st->time_base.den);
-        if( ffpack_isVideoStream(st) )
-        {
+        if (ffpack_isVideoStream(st)) {
             LOGD("stream %d: avg_framerate(num,den) = %d,%d", i, st->avg_frame_rate.num, st->avg_frame_rate.den);
             LOGD("stream %d: r_framerate(num,den) = %d,%d", i, st->r_frame_rate.num, st->r_frame_rate.den);
         }
     }
 }
 
-int ffpack_start(FFPack_t* ff)
-{
+int ffpack_start(FFPack_t *ff) {
     int ret = 0;
 
-    //ffpack_dumpTimebase(ff);
+    // ffpack_dumpTimebase(ff);
 
     ret = avformat_write_header(ff->ofmtContext, NULL);
-    if (ret < 0)
-    {
+    if (ret < 0) {
         ff_printerr("failed: ", ret);
         return ret;
     }
@@ -348,44 +309,41 @@ int ffpack_start(FFPack_t* ff)
     return ret;
 }
 
-AVStream* ffpack_findStream(FFPack_t* ff, int streamIndex)
-{
-    for(int i=0; i<ff->ofmtContext->nb_streams; i++)
-    {
-        if(ff->ofmtContext->streams[i]->index == streamIndex)
-        {
+AVStream *ffpack_findStream(FFPack_t *ff, int streamIndex) {
+    for (int i = 0; i < ff->ofmtContext->nb_streams; i++) {
+        if (ff->ofmtContext->streams[i]->index == streamIndex) {
             return ff->ofmtContext->streams[i];
         }
     }
     return NULL;
 }
 
-void ffpack_setParams(FFPack_t* ff, int streamIndex, void* param)
-{
-    AVStream* stream = ffpack_findStream(ff, streamIndex);
-    AVCodecParameters* cp = stream->codecpar;
+void ffpack_setParams(FFPack_t *ff, int streamIndex, void *param) {
+    AVStream *stream = ffpack_findStream(ff, streamIndex);
+    AVCodecParameters *cp = stream->codecpar;
 
-#if(1)
+#if (1)
     int w = cp->width;
     int h = cp->height;
 
-    avcodec_parameters_copy(stream->codecpar, (const AVCodecParameters*)param);
+    avcodec_parameters_copy(stream->codecpar, (const AVCodecParameters *)param);
 
-    if(cp->width == 0) cp->width = w;
-    if(cp->height== 0) cp->height= h;
+    if (cp->width == 0)
+        cp->width = w;
+    if (cp->height == 0)
+        cp->height = h;
 #else
-    AVCodecParameters* src = (AVCodecParameters*)param;
-    AVCodecParameters* dst = stream->codecpar;
+    AVCodecParameters *src = (AVCodecParameters *)param;
+    AVCodecParameters *dst = stream->codecpar;
 
-    //for mp4
-    dst->codec_tag = 0;//src->codec_tag;
-    //dst->format = 12;//src->format;
-    //dst->profile = 100;//src->profile;
-    //dst->level = 51;//src->level;
+    // for mp4
+    dst->codec_tag = 0; // src->codec_tag;
+    // dst->format = 12;//src->format;
+    // dst->profile = 100;//src->profile;
+    // dst->level = 51;//src->level;
 
-    //for mpegts
-    if(src->extradata)
-    {
+    // for mpegts
+    if (src->extradata) {
         dst->extradata = av_mallocz(src->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
         if (!dst->extradata)
             return;
@@ -395,101 +353,96 @@ void ffpack_setParams(FFPack_t* ff, int streamIndex, void* param)
 #endif
 }
 
-int ffpack_input(FFPack_t* ff, int streamIndex, uint8_t* frameData, int frameLen, bool keyFrame, uint64_t pts)
-{
-	int nRet = 0;
+int ffpack_input(FFPack_t *ff, int streamIndex, uint8_t *frameData, int frameLen, bool keyFrame, uint64_t pts) {
+    int nRet = 0;
 
-	AVPacket pkt;
+    AVPacket pkt;
 
-	av_init_packet(&pkt);
+    av_init_packet(&pkt);
 
-	pkt.stream_index = streamIndex;
-	pkt.data = frameData;
-	pkt.size = frameLen;
-	pkt.pts = pkt.dts = pts;
-	pkt.flags |= keyFrame ? AV_PKT_FLAG_KEY : 0;
+    pkt.stream_index = streamIndex;
+    pkt.data = frameData;
+    pkt.size = frameLen;
+    pkt.pts = pkt.dts = pts;
+    pkt.flags |= keyFrame ? AV_PKT_FLAG_KEY : 0;
 
-#if(1)
-	AVStream* st = ff->ofmtContext->streams[streamIndex];
+#if (1)
+    AVStream *st = ff->ofmtContext->streams[streamIndex];
 
-	//LOGD("pts0: %lld", pkt.pts);
+    // LOGD("pts0: %lld", pkt.pts);
     AVRational time_base = (AVRational){1, 100000};
     av_packet_rescale_ts(&pkt, time_base, st->time_base);
-	//LOGD("pts1: %lld", pkt.pts);
-	//LOGD("codec_tag=%d", st->codecpar->codec_tag);
-	//LOGD("extradata_size=%d", st->codecpar->extradata_size);
-	//LOGD("format=%d", st->codecpar->format);
-	//LOGD("sample_aspect_ratio=%d,%d", st->codecpar->sample_aspect_ratio.num, st->codecpar->sample_aspect_ratio.den);
-	//LOGD("video_delay=%d", st->codecpar->video_delay);
+    // LOGD("pts1: %lld", pkt.pts);
+    // LOGD("codec_tag=%d", st->codecpar->codec_tag);
+    // LOGD("extradata_size=%d", st->codecpar->extradata_size);
+    // LOGD("format=%d", st->codecpar->format);
+    // LOGD("sample_aspect_ratio=%d,%d", st->codecpar->sample_aspect_ratio.num, st->codecpar->sample_aspect_ratio.den);
+    // LOGD("video_delay=%d", st->codecpar->video_delay);
 #endif
 
-	nRet = av_interleaved_write_frame(ff->ofmtContext, &pkt);
-	//nRet = av_write_frame(ff->ofmtContext, &pkt);
+    nRet = av_interleaved_write_frame(ff->ofmtContext, &pkt);
+    // nRet = av_write_frame(ff->ofmtContext, &pkt);
 
-	//av_packet_unref(&pkt);
+    // av_packet_unref(&pkt);
 
-	ff->nbTotalSize += frameLen;
+    ff->nbTotalSize += frameLen;
 
-	if(nRet != 0)
-    {
+    if (nRet != 0) {
         ff_printerr("ffpack_Input: ", nRet);
     }
 
-	return nRet;
+    return nRet;
 }
 
-int ffpack_inputStream(FFPack_t* ff, int streamIndex, void* pstream, void* ppkt)
-{
+int ffpack_inputStream(FFPack_t *ff, int streamIndex, void *pstream, void *ppkt) {
     static int nbFrames = 0;
-	int nRet = 0;
+    int nRet = 0;
 
-	AVStream* in_stream = (AVStream*)pstream;
-	AVPacket* pkt = (AVPacket*)ppkt;
-	AVStream* stream = ffpack_findStream(ff, streamIndex);
+    AVStream *in_stream = (AVStream *)pstream;
+    AVPacket *pkt = (AVPacket *)ppkt;
+    AVStream *stream = ffpack_findStream(ff, streamIndex);
 
-#if(1)
-    if(pkt->pts==AV_NOPTS_VALUE){
-        //Write PTS
-        AVRational time_base1=in_stream->time_base;
-        //Duration between 2 frames (us)
-        int64_t calc_duration=(double)AV_TIME_BASE/av_q2d(in_stream->r_frame_rate);
-        //Parameters
-        pkt->pts=(double)(nbFrames*calc_duration)/(double)(av_q2d(time_base1)*AV_TIME_BASE);
-        pkt->dts=pkt->pts;
-        pkt->duration=(double)calc_duration/(double)(av_q2d(time_base1)*AV_TIME_BASE);
+#if (1)
+    if (pkt->pts == AV_NOPTS_VALUE) {
+        // Write PTS
+        AVRational time_base1 = in_stream->time_base;
+        // Duration between 2 frames (us)
+        int64_t calc_duration = (double)AV_TIME_BASE / av_q2d(in_stream->r_frame_rate);
+        // Parameters
+        pkt->pts = (double)(nbFrames * calc_duration) / (double)(av_q2d(time_base1) * AV_TIME_BASE);
+        pkt->dts = pkt->pts;
+        pkt->duration = (double)calc_duration / (double)(av_q2d(time_base1) * AV_TIME_BASE);
     }
-    pkt->pts = av_rescale_q_rnd(pkt->pts, in_stream->time_base, stream->time_base, (enum AVRounding)(AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
-    pkt->dts = av_rescale_q_rnd(pkt->dts, in_stream->time_base, stream->time_base, (enum AVRounding)(AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX));
+    pkt->pts = av_rescale_q_rnd(pkt->pts, in_stream->time_base, stream->time_base, (enum AVRounding)(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
+    pkt->dts = av_rescale_q_rnd(pkt->dts, in_stream->time_base, stream->time_base, (enum AVRounding)(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX));
     pkt->duration = av_rescale_q(pkt->duration, in_stream->time_base, stream->time_base);
     pkt->pos = -1;
 #else
-    pkt->pts = nbFrames * 30*90;
+    pkt->pts = nbFrames * 30 * 90;
     pkt->dts = pkt->pts;
 #endif
-	pkt->stream_index = streamIndex;
+    pkt->stream_index = streamIndex;
 
-	nRet = av_interleaved_write_frame(ff->ofmtContext, pkt);
-	//nRet = av_write_frame(ff->ofmtContext, pkt);
+    nRet = av_interleaved_write_frame(ff->ofmtContext, pkt);
+    // nRet = av_write_frame(ff->ofmtContext, pkt);
 
-	nbFrames++;
-	ff->nbTotalSize += pkt->size;
+    nbFrames++;
+    ff->nbTotalSize += pkt->size;
 
-	if(nRet != 0)
-    {
+    if (nRet != 0) {
         ff_printerr("ffpack_Input: ", nRet);
     }
 
-	return nRet;
+    return nRet;
 }
 
-int  ffpack_setExtradata(FFPack_t* ff, int streamIndex, void* extradata, int extradataSize)
-{
+int ffpack_setExtradata(FFPack_t *ff, int streamIndex, void *extradata, int extradataSize) {
     int nRet = 0;
 
-    AVCodecParameters* cp = ff->ofmtContext->streams[streamIndex]->codecpar;
-    if( cp->extradata_size == 0 ) {
+    AVCodecParameters *cp = ff->ofmtContext->streams[streamIndex]->codecpar;
+    if (cp->extradata_size == 0) {
         cp->extradata_size = extradataSize;
-        cp->extradata = (uint8_t*)av_mallocz(cp->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
+        cp->extradata = (uint8_t *)av_mallocz(cp->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
         memcpy(cp->extradata, extradata, extradataSize);
 
         nRet = ffpack_start(ff);

--- a/src/record/ffpack.c
+++ b/src/record/ffpack.c
@@ -99,7 +99,7 @@ FFPack_t *ffpack_openFile(char *sName, void *context) {
     ff->cbContext = context;
 
     // Configure AvDictionary
-    av_dict_set(&ffpack_encoder_params, "movflags", "frag_keyframe", 0);
+    av_dict_set(&ffpack_encoder_params, "movflags", "frag_keyframe+empty_moov+default_base_moof", 0);
 
     LOGD("format %s[%s]\n", ff->ofmtContext->oformat->name, ff->ofmtContext->oformat->long_name);
 

--- a/src/record/ffpack.c
+++ b/src/record/ffpack.c
@@ -10,6 +10,8 @@
 #define FFPack_bufSIZE 65535
 #define FFPack(p)      ((FFPack_t *)(p))
 
+static AVDictionary *ffpack_encoder_params = NULL;
+
 void ff_printerr(char *sPrefix, int err) {
     char strError[256] = {0};
     av_strerror(err, strError, 256);
@@ -95,6 +97,9 @@ FFPack_t *ffpack_openFile(char *sName, void *context) {
     }
 
     ff->cbContext = context;
+
+    // Configure AvDictionary
+    av_dict_set(&ffpack_encoder_params, "movflags", "faststart+frag_keyframe+empty_moov", 0);
 
     LOGD("format %s[%s]\n", ff->ofmtContext->oformat->name, ff->ofmtContext->oformat->long_name);
 
@@ -296,7 +301,7 @@ int ffpack_start(FFPack_t *ff) {
 
     // ffpack_dumpTimebase(ff);
 
-    ret = avformat_write_header(ff->ofmtContext, NULL);
+    ret = avformat_write_header(ff->ofmtContext, &ffpack_encoder_params);
     if (ret < 0) {
         ff_printerr("failed: ", ret);
         return ret;

--- a/src/record/ffpack.h
+++ b/src/record/ffpack.h
@@ -1,68 +1,60 @@
-#ifndef __FFPACK_H_
-#define __FFPACK_H_
+#pragma once
 
-#include <stdbool.h>
 #include "ffmpeg.h"
+#include <stdbool.h>
 
 typedef enum AVMediaType FFMediaType_e;
-typedef enum AVCodecID   FFCodecID_e;
-typedef int (*CB_onData)(void* ffPtr, int streamIndex, uint8_t* pktData, int pktLen, void* context);
+typedef enum AVCodecID FFCodecID_e;
+typedef int (*CB_onData)(void *ffPtr, int streamIndex, uint8_t *pktData, int pktLen, void *context);
 
-typedef struct tagVideoParameters
-{
+typedef struct tagVideoParameters {
     int width;
     int height;
-    int fps;        //frame rate
+    int fps; // frame rate
 } FFVideoParameters_t;
 
-typedef struct tagAudioParameters
-{
+typedef struct tagAudioParameters {
     int channels;
     int sample_rate;
     int bits_per_sample;
 } FFAudioParameters_t;
 
-typedef struct tagDataParameters
-{
+typedef struct tagDataParameters {
     int encrypt_pos;
     int encrypt_len;
     int reserved;
 } FFDataParameters_t;
 
-typedef struct tagStreamParameters
-{
+typedef struct tagStreamParameters {
     FFMediaType_e mediaType;
-    FFCodecID_e   codecId;
-    uint8_t*      spsData;
-    uint32_t      spsLen;
+    FFCodecID_e codecId;
+    uint8_t *spsData;
+    uint32_t spsLen;
 
     union {
         FFVideoParameters_t video;
         FFAudioParameters_t audio;
-        FFDataParameters_t  data;
+        FFDataParameters_t data;
     };
 } FFStreamParameters_t;
 
-typedef struct tagFFPack
-{
-    AVFormatContext* ofmtContext;
-    CB_onData   cbOnData;
-    void*       cbContext;
-    uint64_t    nbTotalSize;
+typedef struct tagFFPack {
+    AVFormatContext *ofmtContext;
+    CB_onData cbOnData;
+    void *cbContext;
+    uint64_t nbTotalSize;
 } FFPack_t;
 
-FFPack_t* ffpack_openFile(char* sName, void* context);
-FFPack_t* ffpack_open(CB_onData fnOnData, void* context);
-int  ffpack_newProgram(FFPack_t* ff, char* sName);
-int  ffpack_newVideoStream(FFPack_t* ff, uint16_t programId, FFStreamParameters_t* param);
-int  ffpack_newAudioStream(FFPack_t* ff, uint16_t programId, FFStreamParameters_t* param);
-int  ffpack_newDataStream (FFPack_t* ff, uint16_t programId, FFStreamParameters_t* param);
-int  ffpack_start(FFPack_t* ff);
-int  ffpack_input(FFPack_t* ff, int streamIndex, uint8_t* frameData, int frameLen, bool keyFrame, uint64_t pts);
-void ffpack_close(FFPack_t* ff);
-int  ffpack_inputStream(FFPack_t* ff, int streamIndex, void* stream, void* pkt);
+FFPack_t *ffpack_openFile(char *sName, void *context);
+FFPack_t *ffpack_open(CB_onData fnOnData, void *context);
+int ffpack_newProgram(FFPack_t *ff, char *sName);
+int ffpack_newVideoStream(FFPack_t *ff, uint16_t programId, FFStreamParameters_t *param);
+int ffpack_newAudioStream(FFPack_t *ff, uint16_t programId, FFStreamParameters_t *param);
+int ffpack_newDataStream(FFPack_t *ff, uint16_t programId, FFStreamParameters_t *param);
+int ffpack_start(FFPack_t *ff);
+int ffpack_input(FFPack_t *ff, int streamIndex, uint8_t *frameData, int frameLen, bool keyFrame, uint64_t pts);
+void ffpack_close(FFPack_t *ff);
+int ffpack_inputStream(FFPack_t *ff, int streamIndex, void *stream, void *pkt);
 
-void ffpack_setParams(FFPack_t* ff, int streamIndex, void* param);
-int  ffpack_setExtradata(FFPack_t* ff, int streamIndex, void* extradata, int extradataSize);
-
-#endif //__FFPACK_H_
+void ffpack_setParams(FFPack_t *ff, int streamIndex, void *param);
+int ffpack_setExtradata(FFPack_t *ff, int streamIndex, void *extradata, int extradataSize);

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -56,16 +56,6 @@ static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_set_sel(&btn_group3, g_setting.record.audio ? 0 : 1);
     btn_group_set_sel(&btn_group4, g_setting.record.audio_source);
 
-    lv_obj_t *label2 = lv_label_create(cont);
-    lv_label_set_text(label2, "MP4 format requires properly closing files or the files will be corrupt. \nTS format is highly recommended.");
-    lv_obj_set_style_text_font(label2, &lv_font_montserrat_16, 0);
-    lv_obj_set_style_text_align(label2, LV_TEXT_ALIGN_LEFT, 0);
-    lv_obj_set_style_text_color(label2, lv_color_make(255, 255, 255), 0);
-    lv_obj_set_style_pad_top(label2, 12, 0);
-    lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
-    lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
-                         LV_GRID_ALIGN_START, 6, 3);
-
     return page;
 }
 


### PR DESCRIPTION
Moving forward we will utilize fragmented MP4.  Fragmented MP4 segments the mdat (Movie Data) to the mp4 file based on I-Frame detection.  This allows for the file to still be usable even though the last mdat was not written.  For more information I recommend this read as it explains the differences between Fragmented and Non-Fragmented:

https://stackoverflow.com/questions/35177797/what-exactly-is-fragmented-mp4fmp4-how-is-it-different-from-normal-mp4
