### PR TITLE
Reduced font loading calls when decoding msp

### DIFF
--- a/src/core/msp_displayport.h
+++ b/src/core/msp_displayport.h
@@ -22,6 +22,7 @@ typedef enum {
 } osd_resolution_t;
 
 typedef enum {
+    VR_UNKNOWN = -1,
     VR_720P50 = 0,
     VR_720P60 = 1,
     VR_720P30 = 2,
@@ -51,8 +52,7 @@ void clear_screen();
 void write_string(uint8_t ch, uint8_t *line_buf, uint8_t col);
 void update_osd(uint16_t *line_buf, uint8_t raw);
 
-void camTypeDetect(uint8_t rData);
-void fcTypeDetect(uint8_t *rData);
+void vtxImageDetect(uint8_t *rData);
 void lqDetect(uint8_t rData);
 void lqStatistics();
 void vtxTempDetect(uint8_t rData);

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -829,7 +829,7 @@ void load_fc_osd_font(uint8_t fhd) {
 
     for (i = 0; i < 3; i++) {
         if (!load_fc_osd_font_bmp(fp[i], fhd)) {
-            LOGI(" succecss!");
+            LOGI(" success!");
             return;
         } else
             LOGE(" failed!");


### PR DESCRIPTION
Merged parsing of Camera type and FC variant detection in order to reduce the number of redundant calls in order to load the bitmap images from storage devices.

Previously:
```
[INFO][msp_displayport.c:camTypeDetect:245] Cam_mode changed:7
[INFO][osd.c:load_fc_osd_font_bmp:729] load_fc_osd_font_bmp: /mnt/extsd/resource/OSD/FC/BTFL_FHD_000.bmp...
[ERROR][osd.c:load_fc_osd_font:835]  failed!
[INFO][osd.c:load_fc_osd_font_bmp:729] load_fc_osd_font_bmp: /mnt/app/resource/OSD/FC/BTFL_FHD_000.bmp...
[INFO][osd.c:load_fc_osd_font:832]  succecss!
[INFO][osd.c:load_fc_osd_font_bmp:729] load_fc_osd_font_bmp: /mnt/extsd/resource/OSD/FC/INAV_FHD_000.bmp...
[INFO][osd.c:load_fc_osd_font:832]  succecss!
```

Currently:
```
[INFO][msp_displayport.c:camTypeDetect:233] camTypeDetect: Mode changed: -1 -> 1
[INFO][msp_displayport.c:fcTypeDetect:250] fcTypeDetect: Variant changed: BTFL -> INAV
[INFO][osd.c:load_fc_osd_font_bmp:729] load_fc_osd_font_bmp: /mnt/extsd/resource/OSD/FC/INAV_000.bmp...
[INFO][osd.c:load_fc_osd_font:832]  succecss!
```