### PR TITLE
Let pages handle roller interaction

### DIFF
--- a/src/core/app_state.h
+++ b/src/core/app_state.h
@@ -23,10 +23,6 @@ typedef enum {
     APP_STATE_WIFI = 13,
 
     APP_STATE_USER_INPUT_DISABLED = 20,
-
-    // TODO pages should set the on_roller callback and handle the input themselves
-    // instead of creating an app state. (use APP_STATE_SUBMENU_ITEM_FOCUSED)
-    PAGE_ANGLE_SLIDE = 101,
 } app_state_t;
 
 extern app_state_t g_app_state;

--- a/src/core/app_state.h
+++ b/src/core/app_state.h
@@ -28,9 +28,6 @@ typedef enum {
     // instead of creating an app state. (use APP_STATE_SUBMENU_ITEM_FOCUSED)
     PAGE_FAN_SLIDE = 100,
     PAGE_ANGLE_SLIDE = 101,
-    PAGE_POWER_SLIDE_CELL_COUNT = 102,
-    PAGE_POWER_SLIDE_WARNING_CELL_VOLTAGE = 103,
-    PAGE_POWER_SLIDE_CALIBRATION_OFFSET = 104,
 } app_state_t;
 
 extern app_state_t g_app_state;

--- a/src/core/app_state.h
+++ b/src/core/app_state.h
@@ -26,7 +26,6 @@ typedef enum {
 
     // TODO pages should set the on_roller callback and handle the input themselves
     // instead of creating an app state. (use APP_STATE_SUBMENU_ITEM_FOCUSED)
-    PAGE_FAN_SLIDE = 100,
     PAGE_ANGLE_SLIDE = 101,
 } app_state_t;
 

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -250,10 +250,7 @@ static void btn_click(void) // short press enter key
                g_app_state == APP_STATE_SUBMENU_ITEM_FOCUSED ||
                g_app_state == APP_STATE_WIFI ||
                g_app_state == PAGE_FAN_SLIDE ||
-               g_app_state == PAGE_ANGLE_SLIDE ||
-               g_app_state == PAGE_POWER_SLIDE_CELL_COUNT ||
-               g_app_state == PAGE_POWER_SLIDE_WARNING_CELL_VOLTAGE ||
-               g_app_state == PAGE_POWER_SLIDE_CALIBRATION_OFFSET) {
+               g_app_state == PAGE_ANGLE_SLIDE) {
         submenu_click();
     }
     pthread_mutex_unlock(&lvgl_mutex);
@@ -322,12 +319,6 @@ static void roller_up(void) {
         fans_speed_dec();
     } else if (g_app_state == PAGE_ANGLE_SLIDE) {
         ht_angle_dec();
-    } else if (g_app_state == PAGE_POWER_SLIDE_CELL_COUNT) {
-        power_cell_count_dec();
-    } else if (g_app_state == PAGE_POWER_SLIDE_WARNING_CELL_VOLTAGE) {
-        power_warning_voltage_dec();
-    } else if (g_app_state == PAGE_POWER_SLIDE_CALIBRATION_OFFSET) {
-        power_calibration_offset_dec();
     }
     pthread_mutex_unlock(&lvgl_mutex);
 }
@@ -365,12 +356,6 @@ static void roller_down(void) {
         fans_speed_inc();
     } else if (g_app_state == PAGE_ANGLE_SLIDE) {
         ht_angle_inc();
-    } else if (g_app_state == PAGE_POWER_SLIDE_CELL_COUNT) {
-        power_cell_count_inc();
-    } else if (g_app_state == PAGE_POWER_SLIDE_WARNING_CELL_VOLTAGE) {
-        power_warning_voltage_inc();
-    } else if (g_app_state == PAGE_POWER_SLIDE_CALIBRATION_OFFSET) {
-        power_calibration_offset_inc();
     }
 
     pthread_mutex_unlock(&lvgl_mutex);

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -249,7 +249,6 @@ static void btn_click(void) // short press enter key
                g_app_state == APP_STATE_PLAYBACK ||
                g_app_state == APP_STATE_SUBMENU_ITEM_FOCUSED ||
                g_app_state == APP_STATE_WIFI ||
-               g_app_state == PAGE_FAN_SLIDE ||
                g_app_state == PAGE_ANGLE_SLIDE) {
         submenu_click();
     }
@@ -315,8 +314,6 @@ static void roller_up(void) {
         ims_key(DIAL_KEY_UP);
     } else if (g_app_state == APP_STATE_OSD_ELEMENT_PREV) {
         ui_osd_element_pos_handle_input(DIAL_KEY_UP);
-    } else if (g_app_state == PAGE_FAN_SLIDE) {
-        fans_speed_dec();
     } else if (g_app_state == PAGE_ANGLE_SLIDE) {
         ht_angle_dec();
     }
@@ -352,8 +349,6 @@ static void roller_down(void) {
         ims_key(DIAL_KEY_DOWN);
     } else if (g_app_state == APP_STATE_OSD_ELEMENT_PREV) {
         ui_osd_element_pos_handle_input(DIAL_KEY_DOWN);
-    } else if (g_app_state == PAGE_FAN_SLIDE) {
-        fans_speed_inc();
     } else if (g_app_state == PAGE_ANGLE_SLIDE) {
         ht_angle_inc();
     }

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -248,8 +248,7 @@ static void btn_click(void) // short press enter key
     } else if (g_app_state == APP_STATE_SUBMENU ||
                g_app_state == APP_STATE_PLAYBACK ||
                g_app_state == APP_STATE_SUBMENU_ITEM_FOCUSED ||
-               g_app_state == APP_STATE_WIFI ||
-               g_app_state == PAGE_ANGLE_SLIDE) {
+               g_app_state == APP_STATE_WIFI) {
         submenu_click();
     }
     pthread_mutex_unlock(&lvgl_mutex);
@@ -314,8 +313,6 @@ static void roller_up(void) {
         ims_key(DIAL_KEY_UP);
     } else if (g_app_state == APP_STATE_OSD_ELEMENT_PREV) {
         ui_osd_element_pos_handle_input(DIAL_KEY_UP);
-    } else if (g_app_state == PAGE_ANGLE_SLIDE) {
-        ht_angle_dec();
     }
     pthread_mutex_unlock(&lvgl_mutex);
 }
@@ -349,8 +346,6 @@ static void roller_down(void) {
         ims_key(DIAL_KEY_DOWN);
     } else if (g_app_state == APP_STATE_OSD_ELEMENT_PREV) {
         ui_osd_element_pos_handle_input(DIAL_KEY_DOWN);
-    } else if (g_app_state == PAGE_ANGLE_SLIDE) {
-        ht_angle_inc();
     }
 
     pthread_mutex_unlock(&lvgl_mutex);

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -24,7 +24,7 @@ typedef enum {
 static lv_coord_t col_dsc[] = {160, 160, 160, 160, 140, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
-fans_mode_t fans_mode = FANS_MODE_TOP;
+static fans_mode_t fans_mode = FANS_MODE_NO_FAN;
 
 static btn_group_t btn_group_fans;
 

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -16,7 +16,8 @@
 #include "ui/ui_style.h"
 
 typedef enum {
-    FANS_MODE_TOP = 0,
+    FANS_MODE_NO_FAN = 0,
+    FANS_MODE_TOP,
     FANS_MODE_SIDE,
 } fans_mode_t;
 
@@ -76,72 +77,122 @@ static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     return page;
 }
 
-void fans_speed_inc(void) {
-    int32_t value = 0;
+static void fans_top_speed_inc() {
     char buf[5];
+    int32_t value = lv_slider_get_value(slider_group[0].slider);
 
+    if (value < MAX_FAN_TOP)
+        value += 1;
+
+    lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
+
+    sprintf(buf, "%d", value);
+    lv_label_set_text(slider_group[0].label, buf);
+
+    fans_top_setspeed(value);
+
+    g_setting.fans.top_speed = value;
+    ini_putl("fans", "top_speed", value, SETTING_INI);
+}
+
+static void fans_top_speed_dec() {
+    char buf[5];
+    int32_t value = lv_slider_get_value(slider_group[0].slider);
+
+    if (value > MIN_FAN_TOP)
+        value -= 1;
+
+    lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
+    sprintf(buf, "%d", value);
+    lv_label_set_text(slider_group[0].label, buf);
+
+    fans_top_setspeed(value);
+
+    g_setting.fans.top_speed = (uint8_t)value;
+    ini_putl("fans", "top_speed", value, SETTING_INI);
+}
+
+static void fans_side_speed_inc() {
+    char buf[5];
+    int32_t value = lv_slider_get_value(slider_group[1].slider);
+
+    if (value < MAX_FAN_SIDE)
+        value += 1;
+
+    lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
+
+    sprintf(buf, "%d", value);
+    lv_label_set_text(slider_group[1].label, buf);
+
+    g_setting.fans.left_speed = value;
+    ini_putl("fans", "left_speed", value, SETTING_INI);
+    g_setting.fans.right_speed = value;
+    ini_putl("fans", "right_speed", value, SETTING_INI);
+}
+
+static void fans_side_speed_dec() {
+    char buf[5];
+    int32_t value = lv_slider_get_value(slider_group[1].slider);
+
+    if (value > MIN_FAN_SIDE)
+        value -= 1;
+
+    lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
+    sprintf(buf, "%d", value);
+    lv_label_set_text(slider_group[1].label, buf);
+
+    g_setting.fans.left_speed = value;
+    ini_putl("fans", "left_speed", value, SETTING_INI);
+    g_setting.fans.right_speed = value;
+    ini_putl("fans", "right_speed", value, SETTING_INI);
+}
+
+static void fans_speed_inc(void) {
     if (fans_mode == FANS_MODE_TOP) {
-        value = lv_slider_get_value(slider_group[0].slider);
-        if (value < MAX_FAN_TOP)
-            value += 1;
-
-        lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
-
-        sprintf(buf, "%d", value);
-        lv_label_set_text(slider_group[0].label, buf);
-
-        fans_top_setspeed(value);
-
-        g_setting.fans.top_speed = value;
-        ini_putl("fans", "top_speed", value, SETTING_INI);
+        fans_top_speed_inc();
     } else if (fans_mode == FANS_MODE_SIDE) {
-        value = lv_slider_get_value(slider_group[1].slider);
-        if (value < MAX_FAN_SIDE)
-            value += 1;
-
-        lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
-
-        sprintf(buf, "%d", value);
-        lv_label_set_text(slider_group[1].label, buf);
-
-        g_setting.fans.left_speed = value;
-        ini_putl("fans", "left_speed", value, SETTING_INI);
-        g_setting.fans.right_speed = value;
-        ini_putl("fans", "right_speed", value, SETTING_INI);
+        fans_side_speed_inc();
     }
 }
-void fans_speed_dec(void) {
-    int32_t value = 0;
-    char buf[5];
 
+static void fans_speed_dec(void) {
     if (fans_mode == FANS_MODE_TOP) {
-        value = lv_slider_get_value(slider_group[0].slider);
-
-        if (value > MIN_FAN_TOP)
-            value -= 1;
-
-        lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
-        sprintf(buf, "%d", value);
-        lv_label_set_text(slider_group[0].label, buf);
-
-        fans_top_setspeed(value);
-
-        g_setting.fans.top_speed = (uint8_t)value;
-        ini_putl("fans", "top_speed", value, SETTING_INI);
+        fans_top_speed_dec();
     } else if (fans_mode == FANS_MODE_SIDE) {
-        value = lv_slider_get_value(slider_group[1].slider);
+        fans_side_speed_dec();
+    }
+}
 
-        if (value > MIN_FAN_SIDE)
-            value -= 1;
+static void page_fans_exit_slider() {
+    lv_obj_t *slider;
+    if (fans_mode == FANS_MODE_TOP) {
+        slider = slider_group[0].slider;
+    } else if (fans_mode == FANS_MODE_SIDE) {
+        slider = slider_group[1].slider;
+    } else {
+        return;
+    }
 
-        lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
-        sprintf(buf, "%d", value);
-        lv_label_set_text(slider_group[1].label, buf);
+    app_state_push(APP_STATE_SUBMENU);
+    lv_obj_add_style(slider, &style_silder_main, LV_PART_MAIN);
+    fans_mode = FANS_MODE_NO_FAN;
+}
 
-        g_setting.fans.left_speed = value;
-        ini_putl("fans", "left_speed", value, SETTING_INI);
-        g_setting.fans.right_speed = value;
-        ini_putl("fans", "right_speed", value, SETTING_INI);
+static void page_fans_mode_exit() {
+    if (fans_mode != FANS_MODE_NO_FAN) {
+        page_fans_exit_slider();
+    }
+}
+
+static void page_fans_mode_on_roller(uint8_t key) {
+    if (g_app_state != APP_STATE_SUBMENU_ITEM_FOCUSED) {
+        return;
+    }
+
+    if (key == DIAL_KEY_UP) {
+        fans_speed_dec();
+    } else if (key == DIAL_KEY_DOWN) {
+        fans_speed_inc();
     }
 }
 
@@ -163,11 +214,10 @@ static void page_fans_mode_on_click(uint8_t key, int sel) {
         return;
     }
 
-    if (g_app_state == PAGE_FAN_SLIDE) {
-        app_state_push(APP_STATE_SUBMENU);
-        lv_obj_add_style(slider, &style_silder_main, LV_PART_MAIN);
+    if (g_app_state == APP_STATE_SUBMENU_ITEM_FOCUSED) {
+        page_fans_exit_slider();
     } else {
-        app_state_push(PAGE_FAN_SLIDE);
+        app_state_push(APP_STATE_SUBMENU_ITEM_FOCUSED);
         lv_obj_add_style(slider, &style_silder_select, LV_PART_MAIN);
     }
 }
@@ -343,8 +393,8 @@ page_pack_t pp_fans = {
     .name = "Fans",
     .create = page_fans_create,
     .enter = NULL,
-    .exit = NULL,
-    .on_roller = NULL,
+    .exit = page_fans_mode_exit,
+    .on_roller = page_fans_mode_on_roller,
     .on_click = page_fans_mode_on_click,
     .on_right_button = NULL,
 };

--- a/src/ui/page_fans.h
+++ b/src/ui/page_fans.h
@@ -20,8 +20,6 @@
 
 extern page_pack_t pp_fans;
 
-void fans_speed_dec(void);
-void fans_speed_inc(void);
 void step_topfan();
 void fans_auto_ctrl();
 

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -198,7 +198,9 @@ static void page_headtracker_enter() {
 }
 
 static void page_headtracker_exit() {
-    page_headtracker_exit_slider();
+    if (angle_slider_selected) {
+        page_headtracker_exit_slider();
+    }
     lv_timer_del(timer);
 }
 

--- a/src/ui/page_headtracker.h
+++ b/src/ui/page_headtracker.h
@@ -7,7 +7,4 @@
 
 extern page_pack_t pp_headtracker;
 
-void ht_angle_dec(void);
-void ht_angle_inc(void);
-
 #endif

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -42,6 +42,8 @@ static btn_group_t btn_group_osd_display_mode;
 static btn_group_t btn_group_warn_type;
 static btn_group_t btn_group_power_ana;
 
+static slider_group_t* selected_slider_group = NULL;
+
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 120, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 lv_obj_t *label_cell_count;
@@ -160,7 +162,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     return page;
 }
 
-void power_cell_count_inc(void) {
+static void power_cell_count_inc(void) {
     int32_t value = 0;
 
     value = lv_slider_get_value(slider_group_cell_count.slider);
@@ -171,7 +173,7 @@ void power_cell_count_inc(void) {
     page_power_update_cell_count();
 }
 
-void power_cell_count_dec(void) {
+static void power_cell_count_dec(void) {
     int32_t value = 0;
 
     value = lv_slider_get_value(slider_group_cell_count.slider);
@@ -183,7 +185,7 @@ void power_cell_count_dec(void) {
     page_power_update_cell_count();
 }
 
-void power_warning_voltage_inc(void) {
+static void power_warning_voltage_inc(void) {
     int32_t value = 0;
 
     value = lv_slider_get_value(slider_group_cell_voltage.slider);
@@ -201,7 +203,7 @@ void power_warning_voltage_inc(void) {
     ini_putl("power", "voltage", g_setting.power.voltage, SETTING_INI);
 }
 
-void power_warning_voltage_dec(void) {
+static void power_warning_voltage_dec(void) {
     int32_t value = 0;
 
     value = lv_slider_get_value(slider_group_cell_voltage.slider);
@@ -218,7 +220,7 @@ void power_warning_voltage_dec(void) {
     ini_putl("power", "voltage", g_setting.power.voltage, SETTING_INI);
 }
 
-void power_calibration_offset_inc(void) {
+static void power_calibration_offset_inc(void) {
     int32_t value = 0;
 
     value = lv_slider_get_value(slider_group_calibration_offset.slider);
@@ -230,7 +232,7 @@ void power_calibration_offset_inc(void) {
     page_power_update_calibration_offset();
 }
 
-void power_calibration_offset_dec(void) {
+static void power_calibration_offset_dec(void) {
     int32_t value = 0;
 
     value = lv_slider_get_value(slider_group_calibration_offset.slider);
@@ -242,7 +244,48 @@ void power_calibration_offset_dec(void) {
     page_power_update_calibration_offset();
 }
 
+static void page_power_exit_slider() {
+    lv_obj_add_style(selected_slider_group->slider, &style_silder_main, LV_PART_MAIN);
+    app_state_push(APP_STATE_SUBMENU);
+    selected_slider_group = NULL;
+}
+
+static void page_power_exit() {
+    if (selected_slider_group != NULL) {
+        page_power_exit_slider();
+    }
+}
+
+static void page_power_on_roller(uint8_t key) {
+    if (selected_slider_group == NULL) {
+        return;
+    }
+
+    if (key == DIAL_KEY_UP) {
+        if (selected_slider_group == &slider_group_cell_voltage) {
+            power_warning_voltage_dec();
+        } else if (selected_slider_group == &slider_group_cell_count) {
+            power_cell_count_dec();
+        } else if (selected_slider_group == &slider_group_calibration_offset) {
+            power_calibration_offset_dec();
+        }
+    } else if (key == DIAL_KEY_DOWN) {
+        if (selected_slider_group == &slider_group_cell_voltage) {
+            power_warning_voltage_inc();
+        } else if (selected_slider_group == &slider_group_cell_count) {
+            power_cell_count_inc();
+        } else if (selected_slider_group == &slider_group_calibration_offset) {
+            power_calibration_offset_inc();
+        }
+    }
+}
+
 static void page_power_on_click(uint8_t key, int sel) {
+
+    if (selected_slider_group != NULL) {
+        page_power_exit_slider();
+        return;
+    }
 
     switch (sel) {
 
@@ -256,34 +299,22 @@ static void page_power_on_click(uint8_t key, int sel) {
 
     case ROW_CELL_COUNT:
         if (g_setting.power.cell_count_mode == SETTING_POWER_CELL_COUNT_MODE_AUTO)
-            ;
-        else if (g_app_state == PAGE_POWER_SLIDE_CELL_COUNT) {
-            app_state_push(APP_STATE_SUBMENU);
-            lv_obj_add_style(slider_group_cell_count.slider, &style_silder_main, LV_PART_MAIN);
-        } else {
-            app_state_push(PAGE_POWER_SLIDE_CELL_COUNT);
-            lv_obj_add_style(slider_group_cell_count.slider, &style_silder_select, LV_PART_MAIN);
-        }
+            break;
+        app_state_push(APP_STATE_SUBMENU_ITEM_FOCUSED);
+        lv_obj_add_style(slider_group_cell_count.slider, &style_silder_select, LV_PART_MAIN);
+        selected_slider_group = &slider_group_cell_count;
         break;
 
     case ROW_WARNING_CELL_VOLTAGE:
-        if (g_app_state == PAGE_POWER_SLIDE_WARNING_CELL_VOLTAGE) {
-            app_state_push(APP_STATE_SUBMENU);
-            lv_obj_add_style(slider_group_cell_voltage.slider, &style_silder_main, LV_PART_MAIN);
-        } else {
-            app_state_push(PAGE_POWER_SLIDE_WARNING_CELL_VOLTAGE);
-            lv_obj_add_style(slider_group_cell_voltage.slider, &style_silder_select, LV_PART_MAIN);
-        }
+        app_state_push(APP_STATE_SUBMENU_ITEM_FOCUSED);
+        lv_obj_add_style(slider_group_cell_voltage.slider, &style_silder_select, LV_PART_MAIN);
+        selected_slider_group = &slider_group_cell_voltage;
         break;
 
     case ROW_CALIBRATION_OFFSET:
-        if (g_app_state == PAGE_POWER_SLIDE_CALIBRATION_OFFSET) {
-            app_state_push(APP_STATE_SUBMENU);
-            lv_obj_add_style(slider_group_calibration_offset.slider, &style_silder_main, LV_PART_MAIN);
-        } else {
-            app_state_push(PAGE_POWER_SLIDE_CALIBRATION_OFFSET);
-            lv_obj_add_style(slider_group_calibration_offset.slider, &style_silder_select, LV_PART_MAIN);
-        }
+        app_state_push(APP_STATE_SUBMENU_ITEM_FOCUSED);
+        lv_obj_add_style(slider_group_calibration_offset.slider, &style_silder_select, LV_PART_MAIN);
+        selected_slider_group = &slider_group_calibration_offset;
         break;
 
     case ROW_OSD_DISPLAY_MODE:
@@ -321,8 +352,8 @@ page_pack_t pp_power = {
     .name = "Power",
     .create = page_power_create,
     .enter = NULL,
-    .exit = NULL,
-    .on_roller = NULL,
+    .exit = page_power_exit,
+    .on_roller = page_power_on_roller,
     .on_click = page_power_on_click,
     .on_right_button = NULL,
 };

--- a/src/ui/page_power.h
+++ b/src/ui/page_power.h
@@ -5,11 +5,4 @@
 
 extern page_pack_t pp_power;
 
-void power_cell_count_inc(void);
-void power_cell_count_dec(void);
-void power_warning_voltage_inc(void);
-void power_warning_voltage_dec(void);
-void power_calibration_offset_inc(void);
-void power_calibration_offset_dec(void);
-
 #endif


### PR DESCRIPTION
As stated in [app_state.h:27](https://github.com/hd-zero/hdzero-goggle/blob/b1c7d90f0dc3db1aa27b2d7cb3bc7051a45df158/src/core/app_state.h#L27), "pages should set the on_roller callback and handle the input themselves [...]".

This PR updates the corresponding pages' compile units to do that and removes the enum entries from the app_state header. It should be purely cosmetical and shouldn't change any behavior.

Tested my changes with a set of batch 2 goggles and couldn't find any unexpected behavior - however another one testing it would be appreciated.