### PR TITLE
Update top fan slider when changing speed from video

### DIFF
--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -280,7 +280,9 @@ void rbtn_click(right_button_t click_type) {
         if (click_type == RIGHT_CLICK) {
             dvr_cmd(DVR_TOGGLE);
         } else if (click_type == RIGHT_LONG_PRESS) {
+            pthread_mutex_lock(&lvgl_mutex);
             step_topfan();
+            pthread_mutex_unlock(&lvgl_mutex);
         } else if (click_type == RIGHT_DOUBLE_CLICK) {
             ht_set_center_position();
         }

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -182,6 +182,10 @@ void step_topfan() {
 
     fans_top_setspeed(g_setting.fans.top_speed);
     ini_putl("fans", "top_speed", g_setting.fans.top_speed, SETTING_INI);
+
+    lv_slider_set_value(slider_group[0].slider, g_setting.fans.top_speed, LV_ANIM_OFF);
+    sprintf(str, "%d", g_setting.fans.top_speed);
+    lv_label_set_text(slider_group[0].label, str);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Updates the menu UI when stepping the top fan value via the right button long press method as described in the issue.

Closes #352 