### PR TITLE
Make button and roller actions configurable for video mode

### DIFF
--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -45,6 +45,14 @@ enable=false
 [elrs]
 enable=false
 
+[inputs]
+roller=0
+left_click=0
+left_press=1
+right_click=2
+right_press=5
+right_double_click=3
+
 [wifi]
 enable=false
 ap_ssid=HDZero

--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -50,7 +50,7 @@ roller=0
 left_click=0
 left_press=1
 right_click=2
-right_press=5
+right_press=6
 right_double_click=3
 
 [wifi]

--- a/src/core/common.hh
+++ b/src/core/common.hh
@@ -30,6 +30,8 @@ hw_revision_t getHwRevision();
 #define RIGHT_KEY_CLICK 5
 #define RIGHT_KEY_PRESS 6
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+
 extern atomic_int g_key;
 extern atomic_int g_init_done;
 extern pthread_mutex_t lvgl_mutex;

--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -87,6 +87,10 @@ void dvr_update_vi_conf(video_resolution_t fmt) {
     LOGI("update_record_vi_conf: fmt=%d", fmt);
 }
 
+void dvr_toggle() {
+    dvr_cmd(DVR_TOGGLE);
+}
+
 static void dvr_update_record_conf() {
     LOGI("CAM_MODE=%d", CAM_MODE);
     if (g_setting.record.format_ts)

--- a/src/core/dvr.h
+++ b/src/core/dvr.h
@@ -22,6 +22,7 @@ void dvr_select_audio_source(uint8_t audio_source);
 void dvr_enable_line_out(bool enable);
 void dvr_cmd(osd_dvr_cmd_t cmd);
 void dvr_update_vi_conf(video_resolution_t fmt);
+void dvr_toggle();
 
 #ifdef __cplusplus
 }

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -161,6 +161,8 @@ void (*rbtn_click_callback)() = &dvr_toggle;
 void (*rbtn_press_callback)() = &step_topfan;
 void (*rbtn_double_click_callback)() = &ht_set_center_position;
 
+void (*roller_callback)(uint8_t key) = &tune_channel;
+
 static void btn_press(void) // long press left key
 {
     LOGI("btn_press (%d)", g_app_state);
@@ -305,8 +307,7 @@ static void roller_up(void) {
     } else if ((g_app_state == APP_STATE_SUBMENU_ITEM_FOCUSED)) {
         submenu_roller_no_selection_change(DIAL_KEY_UP);
     } else if (g_app_state == APP_STATE_VIDEO) {
-        if (g_source_info.source == SOURCE_HDZERO)
-            tune_channel(DIAL_KEY_UP);
+        (*roller_callback)(DIAL_KEY_UP);
     } else if (g_app_state == APP_STATE_IMS) {
         ims_key(DIAL_KEY_UP);
     } else if (g_app_state == APP_STATE_OSD_ELEMENT_PREV) {
@@ -340,8 +341,7 @@ static void roller_down(void) {
     } else if ((g_app_state == APP_STATE_SUBMENU_ITEM_FOCUSED)) {
         submenu_roller_no_selection_change(DIAL_KEY_DOWN);
     } else if (g_app_state == APP_STATE_VIDEO) {
-        if (g_source_info.source == SOURCE_HDZERO)
-            tune_channel(DIAL_KEY_DOWN);
+        (*roller_callback)(DIAL_KEY_DOWN);
     } else if (g_app_state == APP_STATE_IMS) {
         ims_key(DIAL_KEY_DOWN);
     } else if (g_app_state == APP_STATE_OSD_ELEMENT_PREV) {

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -157,6 +157,10 @@ void tune_channel_timer() {
 static int roller_up_acc = 0;
 static int roller_down_acc = 0;
 
+void (*rbtn_click_callback)() = &dvr_toggle;
+void (*rbtn_press_callback)() = &step_topfan;
+void (*rbtn_double_click_callback)() = &ht_set_center_position;
+
 static void btn_press(void) // long press left key
 {
     LOGI("btn_press (%d)", g_app_state);
@@ -264,17 +268,11 @@ void rbtn_click(right_button_t click_type) {
         break;
     case APP_STATE_VIDEO:
         if (click_type == RIGHT_CLICK) {
-            dvr_cmd(DVR_TOGGLE);
+            (*rbtn_click_callback)();
         } else if (click_type == RIGHT_LONG_PRESS) {
-            pthread_mutex_lock(&lvgl_mutex);
-            step_topfan();
-            pthread_mutex_unlock(&lvgl_mutex);
+            (*rbtn_press_callback)();
         } else if (click_type == RIGHT_DOUBLE_CLICK) {
-            if (g_setting.ht.enable == true) {
-                ht_set_center_position();
-            } else {
-                go_sleep();
-            }
+            (*rbtn_double_click_callback)();
         }
         break;
     case APP_STATE_SLEEP:

--- a/src/core/input_device.h
+++ b/src/core/input_device.h
@@ -15,8 +15,12 @@ typedef enum {
 void input_device_init();
 void tune_channel(uint8_t key);
 void tune_channel_timer();
+void tune_channel_confirm();
 void exit_tune_channel();
 void rbtn_click(right_button_t click_type);
+
+extern void (*btn_click_callback)();
+extern void (*btn_press_callback)();
 
 extern void (*rbtn_click_callback)();
 extern void (*rbtn_press_callback)();

--- a/src/core/input_device.h
+++ b/src/core/input_device.h
@@ -13,6 +13,7 @@ typedef enum {
 } right_button_t;
 
 void input_device_init();
+void tune_channel(uint8_t key);
 void tune_channel_timer();
 void exit_tune_channel();
 void rbtn_click(right_button_t click_type);
@@ -20,6 +21,9 @@ void rbtn_click(right_button_t click_type);
 extern void (*rbtn_click_callback)();
 extern void (*rbtn_press_callback)();
 extern void (*rbtn_double_click_callback)();
+
+
+extern void (*roller_callback)(uint8_t key);
 
 #ifdef __cplusplus
 }

--- a/src/core/input_device.h
+++ b/src/core/input_device.h
@@ -17,6 +17,10 @@ void tune_channel_timer();
 void exit_tune_channel();
 void rbtn_click(right_button_t click_type);
 
+extern void (*rbtn_click_callback)();
+extern void (*rbtn_press_callback)();
+extern void (*rbtn_double_click_callback)();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -93,6 +93,15 @@ void osd_resource_path(char *buf, const char *fmt, osd_resource_t osd_resource_t
     buf[1] = ':';
 }
 
+void osd_toggle() {
+    g_setting.osd.is_visible = !g_setting.osd.is_visible;
+    if (g_setting.osd.is_visible) {
+        channel_osd_mode = CHANNEL_SHOWTIME;
+    }
+
+    settings_put_bool("osd", "is_visible", g_setting.osd.is_visible);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // these are local for OSD controlling
 static osd_hdzero_t g_osd_hdzero;

--- a/src/core/osd.h
+++ b/src/core/osd.h
@@ -100,6 +100,7 @@ char *channel2str(uint8_t band, uint8_t channel);
 void load_fc_osd_font(uint8_t);
 void *thread_osd(void *ptr);
 void osd_resource_path(char *buf, const char *fmt, osd_resource_t osd_resource_type, ...);
+void osd_toggle();
 
 #ifdef __cplusplus
 }

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -178,6 +178,15 @@ const setting_t g_setting_defaults = {
         .sec = 30,
         .format = 0,
     },
+    // Refer to `page_input.c`'s arrays `rollerFunctionPointers` and `btnFunctionPointers`
+    .inputs = {
+        .roller = 0,
+        .left_click = 0,
+        .left_press = 1,
+        .right_click = 2,
+        .right_press = 5,
+        .right_double_click = 3,
+    },
     .wifi = {
         .enable = false,
         .mode = 0,
@@ -404,6 +413,14 @@ void settings_load(void) {
     g_setting.clock.min = ini_getl("clock", "min", g_setting_defaults.clock.min, SETTING_INI);
     g_setting.clock.sec = ini_getl("clock", "sec", g_setting_defaults.clock.sec, SETTING_INI);
     g_setting.clock.format = ini_getl("clock", "format", g_setting_defaults.clock.format, SETTING_INI);
+
+    // inputs
+    g_setting.inputs.roller = ini_getl("inputs", "roller", g_setting_defaults.inputs.roller, SETTING_INI);
+    g_setting.inputs.left_click = ini_getl("inputs", "left_click", g_setting_defaults.inputs.left_click, SETTING_INI);
+    g_setting.inputs.left_press = ini_getl("inputs", "left_press", g_setting_defaults.inputs.left_press, SETTING_INI);
+    g_setting.inputs.right_click = ini_getl("inputs", "right_click", g_setting_defaults.inputs.right_click, SETTING_INI);
+    g_setting.inputs.right_press = ini_getl("inputs", "right_press", g_setting_defaults.inputs.right_press, SETTING_INI);
+    g_setting.inputs.right_double_click = ini_getl("inputs", "right_double_click", g_setting_defaults.inputs.right_double_click, SETTING_INI);
 
     // wifi
     g_setting.wifi.enable = settings_get_bool("wifi", "enable", g_setting_defaults.wifi.enable);

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -184,7 +184,7 @@ const setting_t g_setting_defaults = {
         .left_click = 0,
         .left_press = 1,
         .right_click = 2,
-        .right_press = 5,
+        .right_press = 6,
         .right_double_click = 3,
     },
     .wifi = {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -222,6 +222,15 @@ typedef struct {
 } setting_sources_t;
 
 typedef struct {
+    uint16_t roller;
+    uint16_t left_click;
+    uint16_t left_press;
+    uint16_t right_click;
+    uint16_t right_press;
+    uint16_t right_double_click;
+} setting_inputs_t;
+
+typedef struct {
     bool logging;
     bool selftest;
 } setting_storage_t;
@@ -239,6 +248,7 @@ typedef struct {
     wifi_t wifi;
     setting_osd_t osd;
     setting_clock_t clock;
+    setting_inputs_t inputs;
     ease_use_t ease;
     setting_storage_t storage;
 } setting_t;

--- a/src/driver/oled.h
+++ b/src/driver/oled.h
@@ -7,6 +7,9 @@ extern "C" {
 #include "defines.h"
 #include <stdint.h>
 
+#define MIN_OLED_BRIGHTNESS 0
+#define MAX_OLED_BRIGHTNESS 12
+
 void OLED_write(uint16_t addr, uint16_t wdat, uint8_t sel);
 uint16_t OLED_read(uint16_t addr, uint8_t sel);
 

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -224,7 +224,6 @@ static void page_fans_mode_on_click(uint8_t key, int sel) {
 
 void step_topfan() {
     char str[10];
-    pthread_mutex_lock(&lvgl_mutex);
 
     if (g_setting.fans.top_speed == MAX_FAN_TOP)
         g_setting.fans.top_speed = MIN_FAN_TOP;
@@ -237,8 +236,6 @@ void step_topfan() {
     lv_slider_set_value(slider_group[0].slider, g_setting.fans.top_speed, LV_ANIM_OFF);
     sprintf(str, "%d", g_setting.fans.top_speed);
     lv_label_set_text(slider_group[0].label, str);
-
-    pthread_mutex_unlock(&lvgl_mutex);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -224,6 +224,7 @@ static void page_fans_mode_on_click(uint8_t key, int sel) {
 
 void step_topfan() {
     char str[10];
+    pthread_mutex_lock(&lvgl_mutex);
 
     if (g_setting.fans.top_speed == MAX_FAN_TOP)
         g_setting.fans.top_speed = MIN_FAN_TOP;
@@ -236,6 +237,8 @@ void step_topfan() {
     lv_slider_set_value(slider_group[0].slider, g_setting.fans.top_speed, LV_ANIM_OFF);
     sprintf(str, "%d", g_setting.fans.top_speed);
     lv_label_set_text(slider_group[0].label, str);
+
+    pthread_mutex_unlock(&lvgl_mutex);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -392,6 +392,14 @@ void fans_auto_ctrl() {
     }
 }
 
+void change_topfan(uint8_t key) {
+    if (key == DIAL_KEY_UP) {
+        fans_top_speed_inc();
+    } else if (key == DIAL_KEY_DOWN) {
+        fans_top_speed_dec();
+    }
+}
+
 page_pack_t pp_fans = {
     .p_arr = {
         .cur = 0,

--- a/src/ui/page_fans.h
+++ b/src/ui/page_fans.h
@@ -25,6 +25,7 @@ extern page_pack_t pp_fans;
 
 void step_topfan();
 void fans_auto_ctrl();
+void change_topfan(uint8_t key);
 
 #ifdef __cplusplus
 }

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -1,0 +1,248 @@
+#include "page_input.h"
+
+#include "core/app_state.h"
+#include "core/common.hh"
+#include "core/dvr.h"
+#include "core/ht.h"
+#include "core/input_device.h"
+#include "core/sleep_mode.h"
+
+#include "ui/page_fans.h"
+
+/**
+ * Various enumerations and typedefs
+ */
+typedef enum page_input_rows {
+    RIGHT_SHORT,
+    RIGHT_LONG,
+    RIGHT_DOUBLE,
+    BACK_BTN,
+
+    ROW_COUNT
+} rowType_t;
+
+/**
+ * Compile-unit local variables, constants and fields
+ */
+static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 120, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
+
+const char *options[] = {"Toggle DVR", "Center HT", "Go Sleep!", "Toggle fan speed"};
+void (* const functionPointers[])() = {&dvr_toggle, &ht_set_center_position, &go_sleep, &step_topfan};
+const uint16_t defaultOptions[] = {0, 3, 1};
+
+static rowType_t selectedRow = ROW_COUNT;
+static lv_obj_t *pageItems[ROW_COUNT];
+static int currentHighlight;
+static uint16_t previousSelection;
+
+/**
+ * Build a '\n'-separated list of all available options for the dropdown element
+ */
+static void build_options_string(char* output) {
+    const size_t nOptions = ARRAY_SIZE(options);
+    output[0] = 0;
+    for (size_t i = 0; i < nOptions; i++) {
+        strcat(output, options[i]);
+        if (i < nOptions - 1) {
+            strcat(output, "\n");
+        }
+    }
+}
+
+/**
+ * Update the UI elements as the user navigates the page
+ */
+static void reset_dropdown_styles() {
+    for (rowType_t i = 0; i < BACK_BTN; i++) {
+        lv_obj_remove_style(pageItems[i], &style_dropdown, LV_PART_MAIN);
+    }
+}
+
+/**
+ * Accept the current selection and write the associated function pointer to
+ * the global target variable.
+ */
+static void accept_dropdown(lv_obj_t *obj) {
+    const uint16_t selectedOption = lv_dropdown_get_selected(obj);
+    void (* const funcPointer) = functionPointers[selectedOption];
+
+    switch (selectedRow) {
+    case RIGHT_SHORT:
+        rbtn_click_callback = funcPointer;
+        break;
+    case RIGHT_LONG:
+        rbtn_press_callback = funcPointer;
+        break;
+    case RIGHT_DOUBLE:
+        rbtn_double_click_callback = funcPointer;
+        break;
+    default:
+        break;
+    }
+
+    lv_event_send(obj, LV_EVENT_RELEASED, NULL);
+    lv_dropdown_close(obj);
+    selectedRow = ROW_COUNT;
+    app_state_push(APP_STATE_SUBMENU);
+}
+
+/**
+ * Revert the currently selected dropdown option to the previously set value
+ */
+static void cancel_dropdown(lv_obj_t *obj) {
+    lv_dropdown_set_selected(obj, previousSelection);
+    accept_dropdown(obj);
+}
+
+static bool is_any_dropdown_open() {
+    return selectedRow < BACK_BTN;
+}
+
+/**
+ * Main allocation routine for this page
+ */
+static lv_obj_t *page_input_create(lv_obj_t *parent, panel_arr_t *arr) {
+    int contentHeight = 0;
+    for (size_t i = 0; i < (ARRAY_SIZE(row_dsc) - 1); i++) {
+        contentHeight += row_dsc[i];
+    }
+    int contentWidth = 0;
+    for (size_t i = 0; i < (ARRAY_SIZE(col_dsc) - 1); i++) {
+        contentWidth += col_dsc[i];
+    }
+
+    char optionsStr[128];
+    build_options_string(optionsStr);
+
+    lv_obj_t *page = lv_menu_page_create(parent, NULL);
+    lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_size(page, contentWidth + 93, contentHeight + 300);
+    lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(page, 94, 0);
+
+    lv_obj_t *section = lv_menu_section_create(page);
+    lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
+    lv_obj_set_size(section, contentWidth + 93, contentHeight + 294);
+
+    create_text(NULL, section, false, "Inputs:", LV_MENU_ITEM_BUILDER_VARIANT_2);
+
+    lv_obj_t *content = lv_obj_create(section);
+    lv_obj_set_size(content, contentWidth, contentHeight);
+    lv_obj_set_pos(content, 0, 0);
+    lv_obj_set_layout(content, LV_LAYOUT_GRID);
+    lv_obj_clear_flag(content, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_style(content, &style_context, LV_PART_MAIN);
+
+    lv_obj_set_style_grid_column_dsc_array(content, col_dsc, 0);
+    lv_obj_set_style_grid_row_dsc_array(content, row_dsc, 0);
+
+    create_select_item(arr, content);
+
+    create_label_item(content, "Right short:", 1, RIGHT_SHORT, 1);
+    pageItems[RIGHT_SHORT] = create_dropdown_item(content, optionsStr, 2, RIGHT_SHORT, 320, row_dsc[RIGHT_SHORT], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
+    lv_dropdown_set_selected(pageItems[RIGHT_SHORT], defaultOptions[RIGHT_SHORT]);
+
+    create_label_item(content, "Right long:", 1, RIGHT_LONG, 1);
+    pageItems[RIGHT_LONG] = create_dropdown_item(content, optionsStr, 2, RIGHT_LONG, 320, row_dsc[RIGHT_LONG], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
+    lv_dropdown_set_selected(pageItems[RIGHT_LONG], defaultOptions[RIGHT_LONG]);
+
+    create_label_item(content, "Right double:", 1, RIGHT_DOUBLE, 1);
+    pageItems[RIGHT_DOUBLE] = create_dropdown_item(content, optionsStr, 2, RIGHT_DOUBLE, 320, row_dsc[RIGHT_DOUBLE], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
+    lv_dropdown_set_selected(pageItems[RIGHT_DOUBLE], defaultOptions[RIGHT_DOUBLE]);
+
+    pageItems[BACK_BTN] = create_label_item(content, "< Back", 1, BACK_BTN, 1);
+
+    return page;
+}
+
+/**
+ * Main entry routine for this page
+ */
+static void page_input_enter() {
+    currentHighlight = 0;
+    pp_input.p_arr.cur = currentHighlight;
+    reset_dropdown_styles();
+    lv_obj_add_style(pageItems[currentHighlight], &style_dropdown, LV_PART_MAIN);
+}
+
+/**
+ * Main exit routine for this page
+ */
+static void page_input_exit() {
+    if (is_any_dropdown_open()) {
+        cancel_dropdown(pageItems[selectedRow]);
+    }
+
+    reset_dropdown_styles();
+}
+
+/**
+ * Main navigation routine for this page
+ */
+static void page_input_on_roller(uint8_t key) {
+    if (is_any_dropdown_open()) {
+        lv_obj_t * const targetItem = pageItems[selectedRow];
+        uint32_t evt = (key == DIAL_KEY_DOWN) ? LV_KEY_UP : LV_KEY_DOWN;
+
+        lv_event_send(targetItem, LV_EVENT_KEY, &evt);
+    } else {
+        reset_dropdown_styles();
+
+        if (key == DIAL_KEY_UP) {
+            if (++currentHighlight == ROW_COUNT) {
+                currentHighlight = 0;
+            }
+        } else if (key == DIAL_KEY_DOWN) {
+            if (--currentHighlight < 0) {
+                currentHighlight = BACK_BTN;
+            }
+        }
+
+        if (pageItems[currentHighlight]->class_p == &lv_dropdown_class) {
+            lv_obj_add_style(pageItems[currentHighlight], &style_dropdown, LV_PART_MAIN);
+        }
+    }
+}
+
+/**
+ * Main input selection routine for this page
+ */
+static void page_input_on_click(uint8_t key, int sel) {
+    LV_UNUSED(key);
+
+    if ((rowType_t) sel >= BACK_BTN) {
+        return;
+    }
+
+    if (is_any_dropdown_open()) {
+        accept_dropdown(pageItems[selectedRow]);
+    } else {
+        selectedRow = (rowType_t)sel;
+        lv_obj_t * const currentItem = pageItems[selectedRow];
+
+        lv_dropdown_open(currentItem);
+        lv_obj_t * const list = lv_dropdown_get_list(currentItem);
+        lv_obj_add_style(list, &style_dropdown, LV_PART_MAIN);
+        lv_obj_set_style_text_color(list, lv_color_make(0, 0, 0), LV_PART_SELECTED | LV_STATE_CHECKED);
+        previousSelection = lv_dropdown_get_selected(currentItem);
+        app_state_push(APP_STATE_SUBMENU_ITEM_FOCUSED);
+    }
+}
+
+/**
+ * Main menu page data structure
+ */
+page_pack_t pp_input = {
+    .p_arr = {
+        .cur = 0,
+        .max = ROW_COUNT,
+    },
+    .name = "Input",
+    .create = page_input_create,
+    .enter = page_input_enter,
+    .exit = page_input_exit,
+    .on_roller = page_input_on_roller,
+    .on_click = page_input_on_click,
+    .on_right_button = NULL,
+};

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -36,8 +36,8 @@ typedef enum page_input_rows {
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 120, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
-const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Go Sleep!", "Toggle fan speed"};
-void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &go_sleep, &step_topfan};
+const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed"};
+void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan};
 
 const char *rollerOptions[] = {"Switch channel", "Change fan speed", "OLED Brightness"};
 void (* const rollerFunctionPointers[])(uint8_t) = {&tune_channel, &change_topfan, &change_oled_brightness};

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -34,7 +34,7 @@ typedef enum page_input_rows {
  * Compile-unit local variables, constants and fields
  */
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 120, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed"};
 void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan};
@@ -208,6 +208,12 @@ static lv_obj_t *page_input_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_dropdown_set_selected(pageItems[RIGHT_DOUBLE], g_setting.inputs.right_double_click);
 
     pageItems[BACK_BTN] = create_label_item(content, "< Back", 1, BACK_BTN, 1);
+
+    lv_obj_t *label = lv_label_create(content);
+    lv_label_set_text(label, "*Settings apply to video mode only");
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_pad_top(label, 12, 0);
+    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2, LV_GRID_ALIGN_START, pp_input.p_arr.max, 1);
 
     update_inputs();
 

--- a/src/ui/page_input.h
+++ b/src/ui/page_input.h
@@ -1,0 +1,8 @@
+#ifndef _PAGE_INPUT_H
+#define _PAGE_INPUT_H
+
+#include "ui_main_menu.h"
+
+extern page_pack_t pp_input;
+
+#endif // _PAGE_INPUT_H

--- a/src/ui/page_sleep.c
+++ b/src/ui/page_sleep.c
@@ -22,9 +22,7 @@ lv_obj_t *page_sleep_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *cont = lv_menu_cont_create(section);
     lv_obj_t *desc_label = lv_label_create(cont);
     lv_label_set_text(desc_label, "Click the Enter Button to go sleep.\n"
-                                  "Click any button to exit sleep mode.\n\n"
-                                  "Double-click the right button to go sleep from video mode.\n"
-                                  "(Only when Head Tracker is disabled!)");
+                                  "Click any button to exit sleep mode.");
     lv_obj_set_style_text_font(desc_label, &lv_font_montserrat_26, 0);
     lv_obj_set_style_text_color(desc_label, lv_color_make(255, 255, 255), 0);
     lv_obj_set_style_pad_top(desc_label, 12, 0);

--- a/src/ui/ui_image_setting.c
+++ b/src/ui/ui_image_setting.c
@@ -203,6 +203,25 @@ void ims_save() {
     osd_update_element_positions();
 }
 
+void change_oled_brightness(uint8_t key) {
+    if (key == DIAL_KEY_UP) {
+        if (g_setting.image.oled != MAX_OLED_BRIGHTNESS) {
+            g_setting.image.oled += 1;
+        } else {
+            return;
+        }
+    } else if (key == DIAL_KEY_DOWN) {
+        if (g_setting.image.oled != MIN_OLED_BRIGHTNESS) {
+            g_setting.image.oled -= 1;
+        } else {
+            return;
+        }
+    }
+
+    ini_putl("image", "oled", g_setting.image.oled, SETTING_INI);
+    OLED_Brightness(g_setting.image.oled);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // key:
 //   1 = dial up

--- a/src/ui/ui_image_setting.h
+++ b/src/ui/ui_image_setting.h
@@ -45,6 +45,8 @@ uint8_t ims_key(uint8_t key);
 void ims_update();
 void ims_save();
 
+void change_oled_brightness(uint8_t key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -18,6 +18,7 @@
 #include "ui/page_focus_chart.h"
 #include "ui/page_headtracker.h"
 #include "ui/page_imagesettings.h"
+#include "ui/page_input.h"
 #include "ui/page_osd.h"
 #include "ui/page_playback.h"
 #include "ui/page_power.h"
@@ -60,6 +61,7 @@ static page_pack_t *page_packs[] = {
     &pp_version,
     &pp_focus_chart,
     &pp_clock,
+    &pp_input,
     &pp_sleep,
 };
 


### PR DESCRIPTION
This adds a page in the settings where one can freely assign the actions that are executed when a button or the roller is operated in video mode.
I also added the ability to change the top fan speed and the OLED brightness level with the roller.

When changing a channel is requested, the left short button acts as the "Enter" button, regardless of which action is configured for it.

**Note:** This changes the behavior introduced with #348 where I double-assigned the double right click for either HT Center or Go Sleep! mode. However, as this PR is not yet in the release candidate, I think, this shouldn't do much harm. Closes #357 

The available actions are for the roller:

- Switch channel
- Change fan speed
- OLED brightness

and for the buttons:

- Toggle OSD
- Main menu
- Toggle DVR
- Center HT
- Calibrate HT
- Go Sleep!
- Toggle fan speed

![Setting](https://github.com/hd-zero/hdzero-goggle/assets/8737970/a896af4b-c1ae-4a52-9661-51a659e3882e)

![Roller](https://github.com/hd-zero/hdzero-goggle/assets/8737970/1047740a-5697-455c-bfca-9efadd4722cd)

![Button](https://github.com/hd-zero/hdzero-goggle/assets/8737970/c95b6f0e-638a-4925-8090-5e344999403d)
