### PR TITLE
Improve configuration user experience

### DIFF
--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -35,6 +35,9 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
     create_select_item(arr, cont);
+    lv_obj_set_grid_cell(pp_autoscan.p_arr.panel[1], LV_GRID_ALIGN_STRETCH, 0, 6,
+                         LV_GRID_ALIGN_STRETCH, 1, 2);
+    lv_obj_clear_flag(pp_autoscan.p_arr.panel[2], FLAG_SELECTABLE);
 
     btn_group_t btn_group;
     create_btn_group_item(&btn_group0, cont, 3, "Auto Scan", "On", "Last", "Off", "", 0);

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -99,6 +99,7 @@ lv_obj_t *create_label_item_compact(lv_obj_t *parent, const char *name, int col,
     lv_obj_set_size(label, 120 * cols, height);
 
     lv_label_set_recolor(label, true);
+    lv_obj_set_style_text_color(label, COLOR_DISABLED, STATE_DISABLED);
 
     lv_obj_set_grid_cell(label, col_align, col, cols,
                          LV_GRID_ALIGN_CENTER, row, 1);
@@ -115,6 +116,7 @@ lv_obj_t *create_label_item(lv_obj_t *parent, const char *name, int col, int row
     lv_obj_set_size(label, 320 * cols, 60);
 
     lv_label_set_recolor(label, true);
+    lv_obj_set_style_text_color(label, COLOR_DISABLED, STATE_DISABLED);
 
     lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, col, cols,
                          LV_GRID_ALIGN_CENTER, row, 1);
@@ -147,16 +149,22 @@ void create_slider_item_compact(slider_group_t *slider_group, lv_obj_t *parent, 
     lv_obj_set_size(slider_group->name, 200, 40);
     lv_obj_set_grid_cell(slider_group->name, LV_GRID_ALIGN_START, 1, 1,
                          LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_style_text_color(slider_group->name, COLOR_DISABLED, STATE_DISABLED);
 
     slider_group->slider = lv_slider_create(parent);
 
     lv_obj_remove_style_all(slider_group->slider);
     lv_obj_add_style(slider_group->slider, &style_silder_main, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(slider_group->slider, COLOR_DISABLED, LV_PART_MAIN | STATE_DISABLED);
+
     lv_obj_add_style(slider_group->slider, &style_silder_indicator, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_color(slider_group->slider, COLOR_DISABLED, LV_PART_INDICATOR | STATE_DISABLED);
     lv_obj_add_style(slider_group->slider, &style_silder_pressed_color, LV_PART_INDICATOR | LV_STATE_PRESSED);
+
     lv_obj_set_style_bg_opa(slider_group->slider, LV_OPA_COVER, LV_PART_KNOB);
     lv_obj_set_style_pad_ver(slider_group->slider, 10, LV_PART_KNOB);
     lv_obj_set_style_pad_hor(slider_group->slider, 2, LV_PART_KNOB);
+    lv_obj_set_style_bg_color(slider_group->slider, COLOR_DISABLED, LV_PART_KNOB | STATE_DISABLED);
     lv_obj_add_style(slider_group->slider, &style_silder_pressed_color, LV_PART_KNOB | LV_STATE_PRESSED);
 
     lv_obj_set_size(slider_group->slider, 0, 2);
@@ -177,6 +185,7 @@ void create_slider_item_compact(slider_group_t *slider_group, lv_obj_t *parent, 
     lv_obj_set_size(slider_group->label, 160, 40);
     lv_obj_set_grid_cell(slider_group->label, LV_GRID_ALIGN_START, 4, 1,
                          LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_style_text_color(slider_group->label, COLOR_DISABLED, STATE_DISABLED);
 }
 
 void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const char *name, int range, int default_value, int row) {
@@ -189,14 +198,20 @@ void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const ch
     lv_obj_set_size(slider_group->name, 320, 60);
     lv_obj_set_grid_cell(slider_group->name, LV_GRID_ALIGN_START, 1, 2,
                          LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_style_text_color(slider_group->name, COLOR_DISABLED, STATE_DISABLED);
 
     slider_group->slider = lv_slider_create(parent);
 
     lv_obj_remove_style_all(slider_group->slider);
     lv_obj_add_style(slider_group->slider, &style_silder_main, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(slider_group->slider, COLOR_DISABLED, LV_PART_MAIN | STATE_DISABLED);
+    
     lv_obj_add_style(slider_group->slider, &style_silder_indicator, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_color(slider_group->slider, COLOR_DISABLED, LV_PART_INDICATOR | STATE_DISABLED);
     lv_obj_add_style(slider_group->slider, &style_silder_pressed_color, LV_PART_INDICATOR | LV_STATE_PRESSED);
+
     lv_obj_add_style(slider_group->slider, &style_silder_knob, LV_PART_KNOB);
+    lv_obj_set_style_bg_color(slider_group->slider, COLOR_DISABLED, LV_PART_KNOB | STATE_DISABLED);
     lv_obj_add_style(slider_group->slider, &style_silder_pressed_color, LV_PART_KNOB | LV_STATE_PRESSED);
 
     lv_obj_set_size(slider_group->slider, 320, 3);
@@ -217,6 +232,7 @@ void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const ch
     lv_obj_set_size(slider_group->label, 160, 60);
     lv_obj_set_grid_cell(slider_group->label, LV_GRID_ALIGN_START, 5, 1,
                          LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_style_text_color(slider_group->label, COLOR_DISABLED, STATE_DISABLED);
 }
 
 void update_slider_item_with_value(slider_group_t *slider_group, int value) {
@@ -237,6 +253,7 @@ void create_btn_item(lv_obj_t *parent, const char *name, int col, int row) {
     lv_obj_set_style_text_font(btn, &lv_font_montserrat_26, 0);
     lv_obj_set_style_text_align(btn, LV_TEXT_ALIGN_LEFT, 0);
     lv_obj_set_style_bg_color(btn, lv_color_make(19, 19, 19), 0);
+    lv_obj_set_style_bg_color(btn, COLOR_DISABLED, STATE_DISABLED);
     lv_obj_set_style_bg_opa(btn, 0x0, 0);
     lv_obj_set_style_shadow_width(btn, 0, 0);
     lv_obj_set_style_pad_top(btn, 0, 0);
@@ -253,6 +270,7 @@ lv_obj_t *create_dropdown_item(lv_obj_t *parent, const char *options, int col, i
     lv_obj_set_style_shadow_width(obj, 0, 0);
     lv_obj_set_style_pad_top(obj, pad_top, 0);
     lv_obj_set_size(obj, width, height);
+    lv_obj_set_style_text_color(obj, COLOR_DISABLED, STATE_DISABLED);
 
     lv_obj_set_grid_cell(obj, column_align, col, col_span, LV_GRID_ALIGN_CENTER, row, 1);
 
@@ -294,6 +312,7 @@ static void create_btn_with_arrow(lv_obj_t *parent, btn_with_arr_t *btn_a, const
     lv_obj_set_size(btn_a->btn, 160, 60);
     lv_obj_set_grid_cell(btn_a->btn, LV_GRID_ALIGN_START, 1, 1,
                          LV_GRID_ALIGN_CENTER, 0, 1);
+    lv_obj_set_style_text_color(btn_a->label, COLOR_DISABLED, STATE_DISABLED);
 
     lv_obj_set_style_pad_column(btn_a->container, 0, 0);
 }
@@ -361,6 +380,7 @@ static void create_btn_with_arrow_compact(lv_obj_t *parent, btn_with_arr_t *btn_
     lv_obj_set_style_bg_color(btn_a->btn, lv_color_make(19, 19, 19), 0);
     lv_obj_set_style_bg_opa(btn_a->btn, 0x0, 0);
     lv_obj_set_style_shadow_width(btn_a->btn, 0, 0);
+    lv_obj_set_style_text_color(btn_a->label, COLOR_DISABLED, STATE_DISABLED);
 
     lv_obj_set_style_pad_top(btn_a->btn, 0, 0);
     lv_obj_set_style_pad_bottom(btn_a->btn, 0, 0);
@@ -415,6 +435,7 @@ void create_btn_group_item(btn_group_t *btn_group, lv_obj_t *parent, int count, 
     lv_obj_set_size(btn_group->label, 320, 60);
     lv_obj_set_grid_cell(btn_group->label, LV_GRID_ALIGN_START, 1, 2,
                          LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_style_text_color(btn_group->label, COLOR_DISABLED, STATE_DISABLED);
 
     create_btn_with_arrow(parent, &btn_group->btn_a[0], name0, row, 2);
     if (count >= 2) {
@@ -444,6 +465,7 @@ void create_btn_group_item2(btn_group_t *btn_group, lv_obj_t *parent, int count,
     lv_obj_set_size(label, 320, 60);
     lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2,
                          LV_GRID_ALIGN_CENTER, row, 1);
+    lv_obj_set_style_text_color(label, COLOR_DISABLED, STATE_DISABLED);
 
     create_btn_with_arrow(parent, &btn_group->btn_a[0], name0, row, 2);
     if (count >= 2) {
@@ -481,6 +503,18 @@ void slider_show(slider_group_t *slider_group, bool visible) {
     }
 }
 
+void slider_enable(slider_group_t *slider_group, bool enable) {
+    if (enable) {
+        lv_obj_clear_state(slider_group->slider, STATE_DISABLED);
+        lv_obj_clear_state(slider_group->label, STATE_DISABLED);
+        lv_obj_clear_state(slider_group->name, STATE_DISABLED);
+    } else {
+        lv_obj_add_state(slider_group->slider, STATE_DISABLED);
+        lv_obj_add_state(slider_group->label, STATE_DISABLED);
+        lv_obj_add_state(slider_group->name, STATE_DISABLED);
+    }
+}
+
 void btn_group_show(btn_group_t *btn_group, bool visible) {
     for (int i = 0; i < btn_group->valid; ++i) {
         if (visible) {
@@ -499,5 +533,24 @@ void btn_group_show(btn_group_t *btn_group, bool visible) {
         lv_obj_add_flag(btn_group->btn_a[sel].arrow, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(btn_group->btn_a[sel].label, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(btn_group->label, LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+void btn_group_enable(btn_group_t *btn_group, bool enable) {
+    for (int i = 0; i < btn_group->valid; ++i) {
+        if (enable) {
+            lv_obj_clear_state(btn_group->btn_a[i].label, STATE_DISABLED);
+        } else {
+            lv_obj_add_state(btn_group->btn_a[i].label, STATE_DISABLED);
+        }
+    }
+
+    const int sel = btn_group_get_sel(btn_group);
+    if (enable) {
+        lv_obj_clear_state(btn_group->label, STATE_DISABLED);
+        lv_obj_clear_flag(btn_group->btn_a[sel].arrow, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_obj_add_state(btn_group->label, STATE_DISABLED);
+        lv_obj_add_flag(btn_group->btn_a[sel].arrow, LV_OBJ_FLAG_HIDDEN);
     }
 }

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -56,6 +56,7 @@ void create_select_item(panel_arr_t *arr, lv_obj_t *parent) {
         arr->panel[i] = lv_obj_create(parent);
         lv_obj_clear_flag(arr->panel[i], LV_OBJ_FLAG_SCROLLABLE);
         lv_obj_add_flag(arr->panel[i], LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(arr->panel[i], FLAG_SELECTABLE);
         lv_obj_add_style(arr->panel[i], &style_select, LV_PART_MAIN);
         lv_obj_set_grid_cell(arr->panel[i], LV_GRID_ALIGN_STRETCH, 0, 6,
                              LV_GRID_ALIGN_STRETCH, i, 1);

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -71,6 +71,8 @@
 
 #define MAX_PANELS 9
 
+#define FLAG_SELECTABLE LV_OBJ_FLAG_USER_1
+
 typedef enum {
     SOURCE_HDZERO = 0,
     SOURCE_HDMI_IN = 1,

--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -72,6 +72,8 @@
 #define MAX_PANELS 9
 
 #define FLAG_SELECTABLE LV_OBJ_FLAG_USER_1
+#define STATE_DISABLED LV_STATE_USER_1
+#define COLOR_DISABLED (lv_color_darken(lv_color_white(), 127))
 
 typedef enum {
     SOURCE_HDZERO = 0,
@@ -168,6 +170,8 @@ void create_select_item(panel_arr_t *arr, lv_obj_t *parent);
 void set_select_item(const panel_arr_t *arr, int row);
 
 void slider_show(slider_group_t *slider_group, bool visible);
+void slider_enable(slider_group_t *slider_group, bool enable);
 void btn_group_show(btn_group_t *btn_group, bool visible);
+void btn_group_enable(btn_group_t *btn_group, bool enable);
 
 #endif

--- a/src/ui/page_elrs.c
+++ b/src/ui/page_elrs.c
@@ -45,23 +45,23 @@ static void update_visibility() {
     const bool backpackIsActive = elrs_group.current == 0;
 
     if (backpackIsActive) {
-        lv_obj_clear_flag(btn_wifi, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(btn_bind, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(label_bind_status, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(btn_vtx_send, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_state(btn_wifi, STATE_DISABLED);
+        lv_obj_clear_state(label_wifi_status, STATE_DISABLED);
+        lv_obj_clear_state(label_wifi_status, STATE_DISABLED);
+        lv_obj_clear_state(btn_bind, STATE_DISABLED);
+        lv_obj_clear_state(label_bind_status, STATE_DISABLED);
+        lv_obj_clear_state(btn_vtx_send, STATE_DISABLED);
 
         lv_obj_add_flag(pp_elrs.p_arr.panel[0], FLAG_SELECTABLE);
         lv_obj_add_flag(pp_elrs.p_arr.panel[2], FLAG_SELECTABLE);
         lv_obj_add_flag(pp_elrs.p_arr.panel[3], FLAG_SELECTABLE);
     } else {
-        lv_obj_add_flag(btn_wifi, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(btn_bind, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(label_bind_status, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_add_flag(btn_vtx_send, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_state(btn_wifi, STATE_DISABLED);
+        lv_obj_add_state(label_wifi_status, STATE_DISABLED);
+        lv_obj_add_state(label_wifi_status, STATE_DISABLED);
+        lv_obj_add_state(btn_bind, STATE_DISABLED);
+        lv_obj_add_state(label_bind_status, STATE_DISABLED);
+        lv_obj_add_state(btn_vtx_send, STATE_DISABLED);
 
         lv_obj_clear_flag(pp_elrs.p_arr.panel[0], FLAG_SELECTABLE);
         lv_obj_clear_flag(pp_elrs.p_arr.panel[2], FLAG_SELECTABLE);

--- a/src/ui/page_elrs.c
+++ b/src/ui/page_elrs.c
@@ -41,6 +41,34 @@ static lv_obj_t *btn_vtx_send;
 static btn_group_t elrs_group;
 static bool binding = false;
 
+static void update_visibility() {
+    const bool backpackIsActive = elrs_group.current == 0;
+
+    if (backpackIsActive) {
+        lv_obj_clear_flag(btn_wifi, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(btn_bind, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(label_bind_status, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(btn_vtx_send, LV_OBJ_FLAG_HIDDEN);
+
+        lv_obj_add_flag(pp_elrs.p_arr.panel[0], FLAG_SELECTABLE);
+        lv_obj_add_flag(pp_elrs.p_arr.panel[2], FLAG_SELECTABLE);
+        lv_obj_add_flag(pp_elrs.p_arr.panel[3], FLAG_SELECTABLE);
+    } else {
+        lv_obj_add_flag(btn_wifi, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(label_wifi_status, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(btn_bind, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(label_bind_status, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(btn_vtx_send, LV_OBJ_FLAG_HIDDEN);
+
+        lv_obj_clear_flag(pp_elrs.p_arr.panel[0], FLAG_SELECTABLE);
+        lv_obj_clear_flag(pp_elrs.p_arr.panel[2], FLAG_SELECTABLE);
+        lv_obj_clear_flag(pp_elrs.p_arr.panel[3], FLAG_SELECTABLE);
+    }
+}
+
 static lv_obj_t *page_elrs_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
@@ -84,6 +112,8 @@ static lv_obj_t *page_elrs_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_pad_top(cancel_label, 12, 0);
     lv_label_set_long_mode(cancel_label, LV_LABEL_LONG_WRAP);
     lv_obj_set_grid_cell(cancel_label, LV_GRID_ALIGN_START, 1, 3, LV_GRID_ALIGN_START, POS_MAX, 2);
+
+    update_visibility();
 
     return page;
 }
@@ -130,7 +160,11 @@ static void elrs_enable_timer(struct _lv_timer_t *timer) {
 static void page_elrs_enter() {
     lv_label_set_text(label_wifi_status, "Click to start");
     lv_label_set_text(label_bind_status, "Click to start");
-    request_uid();
+    if (elrs_group.current == 0) {
+        request_uid();
+    } else {
+        pp_elrs.p_arr.cur = 1;
+    }
 }
 
 static void page_elrs_on_click(uint8_t key, int sel) {
@@ -143,6 +177,8 @@ static void page_elrs_on_click(uint8_t key, int sel) {
             enable_esp32();
         else
             disable_esp32();
+
+        update_visibility();
     } else if (sel == POS_VTX) // Send VTX freq
     {
         msp_channel_update();

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -31,7 +31,7 @@ static btn_group_t btn_group_fans;
 static slider_group_t slider_group[2];
 
 static void update_visibility() {
-    slider_show(&slider_group[1], btn_group_fans.current != 0);
+    slider_enable(&slider_group[1], btn_group_fans.current != 0);
 
     if (btn_group_fans.current == 0) {
         lv_obj_clear_flag(pp_fans.p_arr.panel[2], FLAG_SELECTABLE);

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -30,6 +30,16 @@ static btn_group_t btn_group_fans;
 
 static slider_group_t slider_group[2];
 
+static void update_visibility() {
+    slider_show(&slider_group[1], btn_group_fans.current != 0);
+
+    if (btn_group_fans.current == 0) {
+        lv_obj_clear_flag(pp_fans.p_arr.panel[2], FLAG_SELECTABLE);
+    } else {
+        lv_obj_add_flag(pp_fans.p_arr.panel[2], FLAG_SELECTABLE);
+    }
+}
+
 static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
@@ -73,6 +83,8 @@ static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_label_set_text(slider_group[0].label, buf);
     sprintf(buf, "%d", g_setting.fans.left_speed);
     lv_label_set_text(slider_group[1].label, buf);
+
+    update_visibility();
 
     return page;
 }
@@ -203,6 +215,7 @@ static void page_fans_mode_on_click(uint8_t key, int sel) {
         btn_group_toggle_sel(&btn_group_fans);
         g_setting.fans.auto_mode = btn_group_get_sel(&btn_group_fans) == 0;
         settings_put_bool("fans", "auto", g_setting.fans.auto_mode);
+        update_visibility();
         return;
     } else if (sel == 1) {
         slider = slider_group[0].slider;

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -14,12 +14,33 @@ static btn_group_t btn_group;
 static lv_coord_t col_dsc[] = {160, 160, 160, 160, 160, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 40, 40, 40, 60, LV_GRID_TEMPLATE_LAST};
 static lv_obj_t *label_cali;
+static lv_obj_t *label_center;
 static lv_timer_t *timer;
 static lv_obj_t *pan;
 static lv_obj_t *tilt;
 static lv_obj_t *roll;
 static slider_group_t slider_group;
 bool angle_slider_selected;
+
+static void update_visibility() {
+    slider_enable(&slider_group, g_setting.ht.enable);
+
+    if (g_setting.ht.enable) {
+        lv_obj_clear_state(label_cali, STATE_DISABLED);
+        lv_obj_clear_state(label_center, STATE_DISABLED);
+
+        lv_obj_add_flag(pp_headtracker.p_arr.panel[1], FLAG_SELECTABLE);
+        lv_obj_add_flag(pp_headtracker.p_arr.panel[2], FLAG_SELECTABLE);
+        lv_obj_add_flag(pp_headtracker.p_arr.panel[3], FLAG_SELECTABLE);
+    } else {
+        lv_obj_add_state(label_cali, STATE_DISABLED);
+        lv_obj_add_state(label_center, STATE_DISABLED);
+
+        lv_obj_clear_flag(pp_headtracker.p_arr.panel[1], FLAG_SELECTABLE);
+        lv_obj_clear_flag(pp_headtracker.p_arr.panel[2], FLAG_SELECTABLE);
+        lv_obj_clear_flag(pp_headtracker.p_arr.panel[3], FLAG_SELECTABLE);
+    }
+}
 
 static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
@@ -50,7 +71,7 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     label_cali = create_label_item(cont, "Calibrate", 1, 1, 1);
 
-    create_label_item(cont, "Set Center", 1, 2, 1);
+    label_center = create_label_item(cont, "Set Center", 1, 2, 1);
 
     create_slider_item(&slider_group, cont, "Max Angle", 360, g_setting.ht.max_angle, 3);
     lv_slider_set_range(slider_group.slider, 0, 360);
@@ -97,6 +118,8 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_radius(roll, 0, LV_PART_INDICATOR);
     lv_obj_set_grid_cell(roll, LV_GRID_ALIGN_START, 2, 1,
                          LV_GRID_ALIGN_CENTER, 8, 1);
+
+    update_visibility();
     return page;
 }
 
@@ -164,6 +187,8 @@ static void page_headtracker_on_click(uint8_t key, int sel) {
             ht_enable();
         else
             ht_disable();
+
+        update_visibility();
     } else if (sel == 1) {
         lv_label_set_text(label_cali, "Calibrating...");
         lv_timer_handler();

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -111,6 +111,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_grid_row_dsc_array(cont, row_dsc, 0);
 
     create_select_item(arr, cont);
+    lv_obj_clear_flag(pp_power.p_arr.panel[0], FLAG_SELECTABLE);
 
     // create menu entries
     create_label_item(cont, "Battery", 1, ROW_BATT_C_LABEL, 1);

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -66,7 +66,7 @@ static void page_power_update_cell_count() {
     lv_label_set_text(slider_group_cell_count.label, buf);
 
     const bool isAutoCellCount = btn_group_cell_count_mode.current == 0;
-    slider_show(&slider_group_cell_count, !isAutoCellCount);
+    slider_enable(&slider_group_cell_count, !isAutoCellCount);
     if (isAutoCellCount) {
         lv_obj_clear_flag(pp_power.p_arr.panel[2], FLAG_SELECTABLE);
     } else {

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -157,17 +157,6 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     page_power_update_cell_count();
     page_power_update_calibration_offset();
 
-    lv_obj_t *label = lv_label_create(cont);
-    lv_label_set_text(label, "*Cell count setting is disabled in auto mode");
-    lv_obj_set_style_text_font(label, &lv_font_montserrat_16, 0);
-    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
-    lv_obj_set_style_text_color(label, lv_color_make(255, 255, 255), 0);
-    lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_style_pad_top(label, 12, 0);
-    lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
-    lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 4,
-                         LV_GRID_ALIGN_START, pp_power.p_arr.max, 3);
-
     return page;
 }
 

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -64,6 +64,14 @@ static void page_power_update_cell_count() {
     char buf[5];
     sprintf(buf, "%d", g_battery.type);
     lv_label_set_text(slider_group_cell_count.label, buf);
+
+    const bool isAutoCellCount = btn_group_cell_count_mode.current == 0;
+    slider_show(&slider_group_cell_count, !isAutoCellCount);
+    if (isAutoCellCount) {
+        lv_obj_clear_flag(pp_power.p_arr.panel[2], FLAG_SELECTABLE);
+    } else {
+        lv_obj_add_flag(pp_power.p_arr.panel[2], FLAG_SELECTABLE);
+    }
 }
 
 static void page_power_update_calibration_offset() {

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -18,6 +18,16 @@ static btn_group_t btn_group4;
 static lv_coord_t col_dsc[] = {160, 200, 200, 160, 120, 120, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
+static void update_visibility() {
+    btn_group_show(&btn_group4, btn_group3.current == 0);
+
+    if (btn_group3.current == 0) {
+        lv_obj_add_flag(pp_record.p_arr.panel[4], FLAG_SELECTABLE);
+    } else {
+        lv_obj_clear_flag(pp_record.p_arr.panel[4], FLAG_SELECTABLE);
+    }
+}
+
 static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
@@ -66,6 +76,8 @@ static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
                          LV_GRID_ALIGN_START, 6, 3);
 
+    update_visibility();
+
     return page;
 }
 
@@ -90,6 +102,7 @@ static void page_record_on_click(uint8_t key, int sel) {
         btn_group_toggle_sel(&btn_group3);
         g_setting.record.audio = !btn_group_get_sel(&btn_group3);
         settings_put_bool("record", "audio", g_setting.record.audio);
+        update_visibility();
     } else if (sel == 4) {
         btn_group_toggle_sel(&btn_group4);
         g_setting.record.audio_source = btn_group_get_sel(&btn_group4);

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -19,7 +19,7 @@ static lv_coord_t col_dsc[] = {160, 200, 200, 160, 120, 120, LV_GRID_TEMPLATE_LA
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
 static void update_visibility() {
-    btn_group_show(&btn_group4, btn_group3.current == 0);
+    btn_group_enable(&btn_group4, btn_group3.current == 0);
 
     if (btn_group3.current == 0) {
         lv_obj_add_flag(pp_record.p_arr.panel[4], FLAG_SELECTABLE);

--- a/src/ui/page_storage.c
+++ b/src/ui/page_storage.c
@@ -70,6 +70,28 @@ static page_options_t page_storage;
 static lv_timer_t *page_storage_format_sd_timer = NULL;
 static lv_timer_t *page_storage_repair_sd_timer = NULL;
 
+static void disable_controls() {
+    page_storage.disable_controls = true;
+
+    for (int i = 0; i < ITEM_LIST_TOTAL - 1; i++) {
+        lv_obj_clear_flag(pp_storage.p_arr.panel[i], FLAG_SELECTABLE);
+    }
+    btn_group_enable(&page_storage.logging, !page_storage.disable_controls);
+    lv_obj_add_state(page_storage.format_sd, STATE_DISABLED);
+    lv_obj_add_state(page_storage.repair_sd, STATE_DISABLED);
+}
+
+static void enable_controls() {
+    page_storage.disable_controls = false;
+
+    for (int i = 0; i < ITEM_LIST_TOTAL - 1; i++) {
+        lv_obj_add_flag(pp_storage.p_arr.panel[i], FLAG_SELECTABLE);
+    }
+    btn_group_enable(&page_storage.logging, !page_storage.disable_controls);
+    lv_obj_clear_state(page_storage.format_sd, STATE_DISABLED);
+    lv_obj_clear_state(page_storage.repair_sd, STATE_DISABLED);
+}
+
 /**
  * Cancel operation.
  */
@@ -371,14 +393,14 @@ static lv_obj_t *page_storage_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     if (g_setting.storage.selftest) {
         lv_label_set_text(page_storage.note, "Self-Test is enabled, All storage options are disabled.");
-        page_storage.disable_controls = true;
+        disable_controls();
     } else {
         if (file_exists(DEVELOP_SCRIPT) || file_exists(APP_BIN_FILE)) {
             char text[256];
             snprintf(text, sizeof(text), "Detected files being accessed by SD Card, All storage options are disabled.\n"
                                          "Remove the following files from the SD Card and try again:\n" DEVELOP_SCRIPT "\n" APP_BIN_FILE);
             lv_label_set_text(page_storage.note, text);
-            page_storage.disable_controls = true;
+            disable_controls();
         }
     }
 
@@ -503,10 +525,10 @@ page_pack_t pp_storage = {
 static void *page_storage_repair_thread(void *arg) {
     if (!page_storage.disable_controls) {
         page_storage.is_auto_sd_repair_active = true;
-        page_storage.disable_controls = true;
+        disable_controls();
         lv_label_set_text(page_storage.note, "SD Card integrity check is active, controls are disabled until process has completed.");
         page_storage_repair_sd();
-        page_storage.disable_controls = false;
+        enable_controls();
         lv_label_set_text(page_storage.note, "");
         page_storage.is_auto_sd_repair_active = false;
     }

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -458,35 +458,56 @@ static void page_wifi_update_current_page(int which) {
         break;
     case 1:
         pp_wifi.p_arr.max = page_wifi.page_2.row_count;
-        if (page_wifi.page_1.mode.button.current == WIFI_MODE_STA) {
-            btn_group_show(&page_wifi.page_2.dhcp.button, true);
-        } else {
+        btn_group_show(&page_wifi.page_2.dhcp.button, true);
+        btn_group_enable(&page_wifi.page_2.dhcp.button, page_wifi.page_1.mode.button.current == WIFI_MODE_STA);
+        if (page_wifi.page_1.mode.button.current != WIFI_MODE_STA) {
             lv_obj_clear_flag(pp_wifi.p_arr.panel[1], FLAG_SELECTABLE);
         }
+
+        lv_obj_clear_flag(page_wifi.page_2.ip_addr.label, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(page_wifi.page_2.ip_addr.input, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(page_wifi.page_2.netmask.label, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(page_wifi.page_2.netmask.input, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(page_wifi.page_2.gateway.label, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(page_wifi.page_2.gateway.input, LV_OBJ_FLAG_HIDDEN);
+
         if (page_wifi.page_1.mode.button.current == WIFI_MODE_AP ||
                 (page_wifi.page_1.mode.button.current == WIFI_MODE_STA &&
                 page_wifi.page_2.dhcp.button.current == 1)) {
-            lv_obj_clear_flag(page_wifi.page_2.ip_addr.label, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(page_wifi.page_2.ip_addr.input, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(page_wifi.page_2.netmask.label, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(page_wifi.page_2.netmask.input, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(page_wifi.page_2.gateway.label, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(page_wifi.page_2.gateway.input, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_state(page_wifi.page_2.ip_addr.label, STATE_DISABLED);
+            lv_obj_clear_state(page_wifi.page_2.ip_addr.input, STATE_DISABLED);
+            lv_obj_clear_state(page_wifi.page_2.netmask.label, STATE_DISABLED);
+            lv_obj_clear_state(page_wifi.page_2.netmask.input, STATE_DISABLED);
+            lv_obj_clear_state(page_wifi.page_2.gateway.label, STATE_DISABLED);
+            lv_obj_clear_state(page_wifi.page_2.gateway.input, STATE_DISABLED);
         } else {
+            lv_obj_add_state(page_wifi.page_2.ip_addr.label, STATE_DISABLED);
+            lv_obj_add_state(page_wifi.page_2.ip_addr.input, STATE_DISABLED);
+            lv_obj_add_state(page_wifi.page_2.netmask.label, STATE_DISABLED);
+            lv_obj_add_state(page_wifi.page_2.netmask.input, STATE_DISABLED);
+            lv_obj_add_state(page_wifi.page_2.gateway.label, STATE_DISABLED);
+            lv_obj_add_state(page_wifi.page_2.gateway.input, STATE_DISABLED);
             lv_obj_clear_flag(pp_wifi.p_arr.panel[2], FLAG_SELECTABLE);
             lv_obj_clear_flag(pp_wifi.p_arr.panel[3], FLAG_SELECTABLE);
             lv_obj_clear_flag(pp_wifi.p_arr.panel[4], FLAG_SELECTABLE);
         }
+
+        lv_obj_clear_flag(page_wifi.page_2.dns.label, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(page_wifi.page_2.dns.input, LV_OBJ_FLAG_HIDDEN);
+
         if (page_wifi.page_1.mode.button.current == WIFI_MODE_STA &&
             page_wifi.page_2.dhcp.button.current == 1) {
-            lv_obj_clear_flag(page_wifi.page_2.dns.label, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(page_wifi.page_2.dns.input, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_state(page_wifi.page_2.dns.label, STATE_DISABLED);
+            lv_obj_clear_state(page_wifi.page_2.dns.input, STATE_DISABLED);
         } else {
+            lv_obj_add_state(page_wifi.page_2.dns.label, STATE_DISABLED);
+            lv_obj_add_state(page_wifi.page_2.dns.input, STATE_DISABLED);
             lv_obj_clear_flag(pp_wifi.p_arr.panel[5], FLAG_SELECTABLE);
         }
-        if (page_wifi.page_1.mode.button.current == WIFI_MODE_AP) {
-            slider_show(&page_wifi.page_2.rf_channel.input, true);
-        } else {
+
+        slider_show(&page_wifi.page_2.rf_channel.input, true);
+        slider_enable(&page_wifi.page_2.rf_channel.input, page_wifi.page_1.mode.button.current == WIFI_MODE_AP);
+        if (page_wifi.page_1.mode.button.current != WIFI_MODE_AP) {
             lv_obj_clear_flag(pp_wifi.p_arr.panel[6], FLAG_SELECTABLE);
         }
         break;

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -474,20 +474,15 @@ static void page_wifi_update_current_page(int which) {
         if (page_wifi.page_1.mode.button.current == WIFI_MODE_AP ||
                 (page_wifi.page_1.mode.button.current == WIFI_MODE_STA &&
                 page_wifi.page_2.dhcp.button.current == 1)) {
-            lv_obj_clear_state(page_wifi.page_2.ip_addr.label, STATE_DISABLED);
-            lv_obj_clear_state(page_wifi.page_2.ip_addr.input, STATE_DISABLED);
             lv_obj_clear_state(page_wifi.page_2.netmask.label, STATE_DISABLED);
             lv_obj_clear_state(page_wifi.page_2.netmask.input, STATE_DISABLED);
             lv_obj_clear_state(page_wifi.page_2.gateway.label, STATE_DISABLED);
             lv_obj_clear_state(page_wifi.page_2.gateway.input, STATE_DISABLED);
         } else {
-            lv_obj_add_state(page_wifi.page_2.ip_addr.label, STATE_DISABLED);
-            lv_obj_add_state(page_wifi.page_2.ip_addr.input, STATE_DISABLED);
             lv_obj_add_state(page_wifi.page_2.netmask.label, STATE_DISABLED);
             lv_obj_add_state(page_wifi.page_2.netmask.input, STATE_DISABLED);
             lv_obj_add_state(page_wifi.page_2.gateway.label, STATE_DISABLED);
             lv_obj_add_state(page_wifi.page_2.gateway.input, STATE_DISABLED);
-            lv_obj_clear_flag(pp_wifi.p_arr.panel[2], FLAG_SELECTABLE);
             lv_obj_clear_flag(pp_wifi.p_arr.panel[3], FLAG_SELECTABLE);
             lv_obj_clear_flag(pp_wifi.p_arr.panel[4], FLAG_SELECTABLE);
         }

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -406,6 +406,10 @@ static int page_wifi_get_current_page_max() {
  * Update UI to reflect current wifi page options.
  */
 static void page_wifi_update_current_page(int which) {
+    for (size_t i = 0; i < MAX_PANELS; i++) {
+        lv_obj_add_flag(pp_wifi.p_arr.panel[i], FLAG_SELECTABLE);
+    }
+
     // Page 1
     btn_group_show(&page_wifi.page_1.enable.button, false);
     btn_group_show(&page_wifi.page_1.mode.button, false);
@@ -454,16 +458,37 @@ static void page_wifi_update_current_page(int which) {
         break;
     case 1:
         pp_wifi.p_arr.max = page_wifi.page_2.row_count;
-        btn_group_show(&page_wifi.page_2.dhcp.button, true);
-        lv_obj_clear_flag(page_wifi.page_2.ip_addr.label, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(page_wifi.page_2.ip_addr.input, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(page_wifi.page_2.netmask.label, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(page_wifi.page_2.netmask.input, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(page_wifi.page_2.gateway.label, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(page_wifi.page_2.gateway.input, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(page_wifi.page_2.dns.label, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_clear_flag(page_wifi.page_2.dns.input, LV_OBJ_FLAG_HIDDEN);
-        slider_show(&page_wifi.page_2.rf_channel.input, true);
+        if (page_wifi.page_1.mode.button.current == WIFI_MODE_STA) {
+            btn_group_show(&page_wifi.page_2.dhcp.button, true);
+        } else {
+            lv_obj_clear_flag(pp_wifi.p_arr.panel[1], FLAG_SELECTABLE);
+        }
+        if (page_wifi.page_1.mode.button.current == WIFI_MODE_AP ||
+                (page_wifi.page_1.mode.button.current == WIFI_MODE_STA &&
+                page_wifi.page_2.dhcp.button.current == 1)) {
+            lv_obj_clear_flag(page_wifi.page_2.ip_addr.label, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(page_wifi.page_2.ip_addr.input, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(page_wifi.page_2.netmask.label, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(page_wifi.page_2.netmask.input, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(page_wifi.page_2.gateway.label, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(page_wifi.page_2.gateway.input, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_clear_flag(pp_wifi.p_arr.panel[2], FLAG_SELECTABLE);
+            lv_obj_clear_flag(pp_wifi.p_arr.panel[3], FLAG_SELECTABLE);
+            lv_obj_clear_flag(pp_wifi.p_arr.panel[4], FLAG_SELECTABLE);
+        }
+        if (page_wifi.page_1.mode.button.current == WIFI_MODE_STA &&
+            page_wifi.page_2.dhcp.button.current == 1) {
+            lv_obj_clear_flag(page_wifi.page_2.dns.label, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(page_wifi.page_2.dns.input, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_clear_flag(pp_wifi.p_arr.panel[5], FLAG_SELECTABLE);
+        }
+        if (page_wifi.page_1.mode.button.current == WIFI_MODE_AP) {
+            slider_show(&page_wifi.page_2.rf_channel.input, true);
+        } else {
+            lv_obj_clear_flag(pp_wifi.p_arr.panel[6], FLAG_SELECTABLE);
+        }
         break;
     case 2:
         pp_wifi.p_arr.max = page_wifi.page_3.row_count;
@@ -791,6 +816,7 @@ static void page_wifi_on_click(uint8_t key, int sel) {
             btn_group_toggle_sel(&page_wifi.page_2.dhcp.button);
             page_wifi.page_2.dhcp.dirty =
                 (btn_group_get_sel(&page_wifi.page_2.dhcp.button) != !g_setting.wifi.dhcp);
+            page_wifi_update_current_page(page_wifi.page_select.button.current);
             break;
         case 2:
             if (!keyboard_active()) {

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -96,8 +96,9 @@ void submenu_enter(void) {
     }
 
     if (pp->p_arr.max) {
-        // if we have selectable entries, select the first one
-        pp->p_arr.cur = 0;
+        // if we have selectable entries, select the first selectable one
+        pp->p_arr.cur = -1;
+        while (!lv_obj_has_flag(pp->p_arr.panel[++pp->p_arr.cur], FLAG_SELECTABLE));
         set_select_item(&pp->p_arr, pp->p_arr.cur);
     }
 

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -97,8 +97,7 @@ void submenu_enter(void) {
 
     if (pp->p_arr.max) {
         // if we have selectable entries, select the first selectable one
-        pp->p_arr.cur = -1;
-        while (!lv_obj_has_flag(pp->p_arr.panel[++pp->p_arr.cur], FLAG_SELECTABLE));
+        for (pp->p_arr.cur = 0; !lv_obj_has_flag(pp->p_arr.panel[pp->p_arr.cur], FLAG_SELECTABLE); ++pp->p_arr.cur);
         set_select_item(&pp->p_arr, pp->p_arr.cur);
     }
 

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -133,15 +133,19 @@ void submenu_roller(uint8_t key) {
     if (pp->p_arr.max) {
         // if we have selectable entries, move selection
         if (key == DIAL_KEY_UP) {
-            if (pp->p_arr.cur < pp->p_arr.max - 1)
-                pp->p_arr.cur++;
-            else
-                pp->p_arr.cur = 0;
+            do {
+                if (pp->p_arr.cur < pp->p_arr.max - 1)
+                    pp->p_arr.cur++;
+                else
+                    pp->p_arr.cur = 0;
+            } while (!lv_obj_has_flag(pp->p_arr.panel[pp->p_arr.cur], FLAG_SELECTABLE));
         } else if (key == DIAL_KEY_DOWN) {
-            if (pp->p_arr.cur > 0)
-                pp->p_arr.cur--;
-            else
-                pp->p_arr.cur = pp->p_arr.max - 1;
+            do {
+                if (pp->p_arr.cur > 0)
+                    pp->p_arr.cur--;
+                else
+                    pp->p_arr.cur = pp->p_arr.max - 1;
+            } while (!lv_obj_has_flag(pp->p_arr.panel[pp->p_arr.cur], FLAG_SELECTABLE));
         }
         set_select_item(&pp->p_arr, pp->p_arr.cur);
     }


### PR DESCRIPTION
## Description

This PR improves the user experience when configuring the goggles. It adds kind of an `enabled` state for configuration items. That means, when an item is configured to be disabled, navigation skips this item and its text is displayed in a darker shade.
Further, when the first item in a page is disabled or only a label (for which the selection item should be set to disabled), it is skipped when entering that page.

## What pages have been changed

In detail the following pages' configuration items are affected:

- Power
	- `Battery` cell label is not selectable
	- `Cell Count` slider can only be modified if `Cell Count Mode` is `Manual`
- Fans
	- `Side Fans` slider can only be modified if `Auto Control` is `Off`
- Record Option
	- `Audio Source` can only be switched if `Record Audio` is `On`
- Auto Scan
	- `Default` selection spans two rows. They are now both highlighted as if they were one
- ELRS
	- When `Backpack` is `Off`, no action can be taken in this page except for turning it on
- Wifi Module
	- When in `AP` mode, `DHCP` and `DNS` cannot be switched
	- When in `Client` mode, `RF Channel` can never be modified and ~~`IP`-related~~ `Netmask` and `Gateway` settings can only be changed if `DHCP` is `Off`
- Head Tracker
	- When `Tracking` is `Off`, no action can be taken in this page except for tuning it on

### Edit 2023-11-30:
- Storage
	- When `develop.sh` or `HDZGOGGLE` files are detected on sd card, all options are disabled

	
## Example

The Fans page as an example:

![Disabled](https://github.com/hd-zero/hdzero-goggle/assets/8737970/f7f98c32-7dc4-49a0-94e1-751f3b986cc0)
*Disabled `Side Fans` slider*

![Enabled](https://github.com/hd-zero/hdzero-goggle/assets/8737970/47d904a8-7c75-4740-bc55-0161320dabe0)
*Enabled `Side Fans` slider*