### PR TITLE
Analog disable color kill feature on TP2825

### DIFF
--- a/src/driver/TP2825.c
+++ b/src/driver/TP2825.c
@@ -72,7 +72,7 @@ void TP2825_Config(int ch_sel, int is_pal) // ch_sel: 0=AV in; 1=Module bay
         I2C_Write(ADDR_TP2825, 0x27, 0x2D);
         I2C_Write(ADDR_TP2825, 0x28, 0xC5); //---
         I2C_Write(ADDR_TP2825, 0x29, 0x18); //---
-        I2C_Write(ADDR_TP2825, 0x2A, 0x30); //---
+        I2C_Write(ADDR_TP2825, 0x2A, 0xB0); //---
         I2C_Write(ADDR_TP2825, 0x2B, 0x70);
         I2C_Write(ADDR_TP2825, 0x2C, 0x1A);
         I2C_Write(ADDR_TP2825, 0x2D, 0x60);
@@ -144,7 +144,7 @@ void TP2825_Config(int ch_sel, int is_pal) // ch_sel: 0=AV in; 1=Module bay
         I2C_Write(ADDR_TP2825, 0x27, 0x2D);
         I2C_Write(ADDR_TP2825, 0x28, 0xC5); //---
         I2C_Write(ADDR_TP2825, 0x29, 0x18); //---
-        I2C_Write(ADDR_TP2825, 0x2A, 0x30); //---
+        I2C_Write(ADDR_TP2825, 0x2A, 0xB0); //---
         I2C_Write(ADDR_TP2825, 0x2B, 0x70);
         I2C_Write(ADDR_TP2825, 0x2C, 0x1A);
         I2C_Write(ADDR_TP2825, 0x2D, 0x68);


### PR DESCRIPTION
Disabling back color killer feature on analog, that lead to smoother analog experience: no suddens loss of colors