### PR TITLE
Docker update for Emulator development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,4 +2,4 @@ FROM --platform=linux/x86_64 mcr.microsoft.com/devcontainers/base:ubuntu
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
-    apt-get -y install --no-install-recommends cmake build-essential ninja-build
+    apt-get -y install --no-install-recommends cmake build-essential ninja-build libsdl2-dev


### PR DESCRIPTION
Simple addition of SDL2 development resources allows me to build the software on MacOS with the support of XQuartz.

MacOS Instructions:
brew install --cask xquartz

XQuartz.app Settings [Located in /Applications/Utilities/]:
Enable "Allow connections from network clients"

![Screenshot 2024-01-20 at 8 11 46 PM](https://github.com/hd-zero/hdzero-goggle/assets/1988793/ab2e26e2-46f9-430d-a71b-5b385075016f)

XQuartz Terminal Commands:
```
defaults write org.xquartz.X11 enable_iglx -bool YES
```
Verify configuration was successfully applied
```
defaults read org.xquartz.X11 enable_igl
1
```

Reboot Mac!!!!

Now you can run emulator via docker and be sure XQuartz is running first.
```
 ./HDZGOGGLE
```
![Screenshot 2024-01-20 at 8 07 21 PM](https://github.com/hd-zero/hdzero-goggle/assets/1988793/240e631b-ac16-4162-a322-f1d0d8cdefcb)
