### PR TITLE
Mark as Hot Clip from live view

### DIFF
--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -18,6 +18,9 @@ bool dvr_is_recording = false;
 
 static pthread_mutex_t dvr_mutex;
 
+int walk_sdcard();
+void mark_video_file(int const seq);
+
 ///////////////////////////////////////////////////////////////////
 //-1=error;
 // 0=idle,1=recording,2=stopped,3=No SD card,4=recorf file path error,
@@ -180,4 +183,19 @@ void dvr_cmd(osd_dvr_cmd_t cmd) {
     }
 
     pthread_mutex_unlock(&dvr_mutex);
+}
+
+void live_mark_video_file() {
+    bool dvr_was_recording = dvr_is_recording;
+    if (dvr_is_recording) {
+        dvr_cmd(DVR_STOP);
+    }
+    int cnt = walk_sdcard();
+    LOGI("dvr_was_recording=%d, count=%d", dvr_was_recording, cnt);
+    if (cnt > 0) {
+        mark_video_file(0);
+    }
+    if (dvr_was_recording) {
+        dvr_cmd(DVR_START);
+    }
 }

--- a/src/core/dvr.h
+++ b/src/core/dvr.h
@@ -23,6 +23,7 @@ void dvr_enable_line_out(bool enable);
 void dvr_cmd(osd_dvr_cmd_t cmd);
 void dvr_update_vi_conf(video_resolution_t fmt);
 void dvr_toggle();
+void live_mark_video_file();
 
 #ifdef __cplusplus
 }

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -36,8 +36,8 @@ typedef enum page_input_rows {
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 120, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
-const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed"};
-void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan};
+const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed", "Mark Hot Clip"};
+void (*const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan, &live_mark_video_file};
 
 const char *rollerOptions[] = {"Switch channel", "Change fan speed", "OLED Brightness"};
 void (* const rollerFunctionPointers[])(uint8_t) = {&tune_channel, &change_topfan, &change_oled_brightness};

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -163,7 +163,9 @@ int hot_alphasort(const struct dirent **a, const struct dirent **b) {
     return strcoll((*a)->d_name, (*b)->d_name);
 }
 
-static int walk_sdcard() {
+// ToDo: This used to be static - did it need to be?
+// static int walk_sdcard() {
+int walk_sdcard() {
     char fname[512];
 
     media_db.count = 0;
@@ -309,7 +311,9 @@ static void update_item(uint8_t cur_pos, uint8_t lst_pos) {
     lv_obj_add_style(pb_ui[lst_pos]._img, &style_pb_dark, LV_PART_MAIN);
 }
 
-static void mark_video_file(int const seq) {
+// ToDo: Used to be static - does it need to be?
+// static void mark_video_file(int const seq) {
+void mark_video_file(int const seq) {
     media_file_node_t const *const pnode = get_list(seq);
     if (!pnode) {
         return;

--- a/src/ui/page_playback.h
+++ b/src/ui/page_playback.h
@@ -53,6 +53,8 @@ void pb_key(uint8_t key);
 
 int get_videofile_cnt();
 void clear_videofile_cnt();
+int walk_sdcard();
+void mark_video_file(int const seq);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #341
This feature allows the user to set a shortcut via the Input menu (Called "Mark Hot Clip") that when pressed, will:
1. Stop recording if currently recording
2. Mark the last clip as a Hot Clip
3. Restart recording if we were originally recording