### PR TITLE
Fixing emulator bug #391

### DIFF
--- a/src/core/SDLaccess.h
+++ b/src/core/SDLaccess.h
@@ -1,0 +1,8 @@
+#ifndef _SDLaccess_H
+#define _SDLaccess_H
+
+#include <SDL2/SDL.h>
+
+extern SDL_mutex *global_sdl_mutex;
+
+#endif

--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -15,7 +15,6 @@
 
 #ifdef EMULATOR_BUILD
 #include "SDLaccess.h"
-#include <SDL2/SDL.h>
 #endif
 
 #include "defines.h"

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -13,7 +13,6 @@
 
 #ifdef EMULATOR_BUILD
 #include "SDLaccess.h"
-#include <SDL2/SDL.h>
 SDL_mutex *global_sdl_mutex;
 #endif
 
@@ -150,7 +149,7 @@ int main(int argc, char *argv[]) {
 #ifdef EMULATOR_BUILD
     global_sdl_mutex = SDL_CreateMutex();
     if (global_sdl_mutex == NULL) {
-        // Handle error: SDL_CreateMutex failed
+        LOGE("Failed to create an SDL mutex!");
     }
 #endif
 

--- a/src/ui/ui_porting.c
+++ b/src/ui/ui_porting.c
@@ -11,7 +11,6 @@
 
 #ifdef EMULATOR_BUILD
 #include "SDLaccess.h"
-#include <SDL2/SDL.h>
 static void *fb1, *fb2;
 SDL_Window *window = NULL;
 SDL_Renderer *renderer = NULL;
@@ -132,6 +131,8 @@ int lvgl_init_porting() {
 #else
     if (SDL_WasInit(SDL_INIT_VIDEO) == 0) {
         SDL_InitSubSystem(SDL_INIT_VIDEO);
+    } else {
+        LOGI("SDL already initialised.");
     }
 
     SDL_LockMutex(global_sdl_mutex);

--- a/src/ui/ui_porting.c
+++ b/src/ui/ui_porting.c
@@ -10,6 +10,7 @@
 #include "lvgl/lvgl.h"
 
 #ifdef EMULATOR_BUILD
+#include "SDLaccess.h"
 #include <SDL2/SDL.h>
 static void *fb1, *fb2;
 SDL_Window *window = NULL;
@@ -55,6 +56,7 @@ static void hdz_disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_
 
     fb_sync(&fbdev);
 #else
+    SDL_LockMutex(global_sdl_mutex);
     SDL_Rect
         src = {
             .x = 0,
@@ -76,6 +78,7 @@ static void hdz_disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_
     src.h = dst.h;
     SDL_RenderCopy(renderer, texture, &src, &dst);
     SDL_RenderPresent(renderer);
+    SDL_UnlockMutex(global_sdl_mutex);
 #endif
 
     if (disp_orbit_state & ORBIT_FLUSH) {
@@ -127,8 +130,11 @@ int lvgl_init_porting() {
 
     lv_disp_drv_init(&disp_drv);
 #else
-    SDL_InitSubSystem(SDL_INIT_VIDEO);
+    if (SDL_WasInit(SDL_INIT_VIDEO) == 0) {
+        SDL_InitSubSystem(SDL_INIT_VIDEO);
+    }
 
+    SDL_LockMutex(global_sdl_mutex);
     window = SDL_CreateWindow(WINDOW_NAME,
                               SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
                               DISP_HOR_RES_FHD, DISP_VER_RES_FHD, 0);
@@ -140,6 +146,7 @@ int lvgl_init_porting() {
                                 SDL_TEXTUREACCESS_STREAMING,
                                 DRAW_HOR_RES_FHD,
                                 DRAW_VER_RES_FHD);
+    SDL_UnlockMutex(global_sdl_mutex);
 
     fb1 = malloc(DRAW_HOR_RES_FHD * DRAW_VER_RES_FHD * ((LV_COLOR_DEPTH + 7) / 8));
     fb2 = malloc(DRAW_HOR_RES_FHD * DRAW_VER_RES_FHD * ((LV_COLOR_DEPTH + 7) / 8));


### PR DESCRIPTION
The emulator would crash for me. This is either because SDL was not initialised before SDL_WaitEvent was called, or more likely because anothe thread was trying to use SDL at the same time. This fixes both by initialising SDL earlier and by setting up a mutex that locks access to SDL when the input thread works. 

**This affects the emulator only, it has no impact on running on the goggles**