### PR TITLE
Timestamp log entries with millisecond resolution

### DIFF
--- a/lib/log/src/log.c
+++ b/lib/log/src/log.c
@@ -6,6 +6,7 @@
 #include <stdatomic.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #define get_filename(file) (strrchr(file, '/') ? strrchr(file, '/') + 1 : file)
@@ -78,10 +79,19 @@ int log_printf(const char *file, const char *func, int line, const int level, co
     va_end(args2);
     static char buffer[1024];
 
-    int bytes =
+    // Timestamp
+    struct timeval now;
+    gettimeofday(&now, NULL);
+    int milli = now.tv_usec / 1000;
+    char timestamp[sizeof "YYYY-MM-DD HH:MM:SS.sss"];
+    int bytes = strftime(timestamp, sizeof timestamp, "%F %T.", gmtime(&now.tv_sec));
+    snprintf(&timestamp[bytes], sizeof(timestamp) - bytes, "%03d", milli);
+
+    bytes =
         snprintf(buffer,
                  sizeof(buffer),
-                 "[%s][%s:%s:%d] %s\r\n",
+                 "%s [%s][%s:%s:%d] %s\r\n",
+                 timestamp,
                  log_level_names[level + 2],
                  get_filename(file),
                  func,


### PR DESCRIPTION
Will help in debugging how frequently an event occurs such as the button presses and allow us to fine tune the input handling parameters as needed.

```
2024-01-31 00:46:41.945 [INFO][hardware.c:HDZero_open:210] HDZero: open
2024-01-31 00:46:42.130 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel0: valid:0, gain:61
2024-01-31 00:46:42.644 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel1: valid:0, gain:61
2024-01-31 00:46:43.227 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel2: valid:0, gain:61
2024-01-31 00:46:43.710 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel3: valid:0, gain:61
2024-01-31 00:46:43.921 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel4: valid:0, gain:61
2024-01-31 00:46:44.492 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel5: valid:0, gain:61
2024-01-31 00:46:45.044 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel6: valid:0, gain:61
2024-01-31 00:46:45.359 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel7: valid:0, gain:61
2024-01-31 00:46:45.914 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel8: valid:0, gain:61
2024-01-31 00:46:46.497 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel9: valid:0, gain:61
2024-01-31 00:46:47.061 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel10: valid:0, gain:61
2024-01-31 00:46:47.162 [INFO][page_scannow.c:scan_channel:309] Scan band:0, channel11: valid:0, gain:61
```