### PR TITLE
Make a beep once goggles are up and running.

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -193,6 +193,7 @@ int main(int argc, char *argv[]) {
 
     // 10. Execute main loop
     g_init_done = 1;
+    beep_dur(BEEP_SHORT);
     for (;;) {
         pthread_mutex_lock(&lvgl_mutex);
         main_menu_update();


### PR DESCRIPTION
HDZero Goggle take around 20 seconds to start up.
This PR makes goggles beep once they started up, so user doesn't have to check visually.