### PR TITLE
Add option to disable random MAC address in client mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.cache
 /build
 /build_emu
 linux-4.9

--- a/mkapp/app/script/wlan_stop.sh
+++ b/mkapp/app/script/wlan_stop.sh
@@ -2,6 +2,7 @@
 /mnt/app/app/record/gogglecmd -live quit
 sleep 1
 killall rtspLive
+killall wpa_supplicant
 killall hostapd
 killall udhcpd
 killall dropbear

--- a/src/core/defines.h
+++ b/src/core/defines.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define DIAL_SENSITIVITY 1    // number of clicks before dial event is triggered
+#define DIAL_SENSITIVITY           1    // number of clicks before dial event is triggered
 #define DIAL_SENSITIVTY_TIMEOUT_MS 1000 // ms
-#define CHANNEL_SHOWTIME 30 // must <= 127
+#define CHANNEL_SHOWTIME           30   // must <= 127
 
 #define GPIO_BEEP 131
 
@@ -20,8 +20,9 @@
 #define DEV_SPI_VRX_L     "/dev/mtd9"
 #define DEV_SPI_VA        "/dev/mtd10"
 
-#define SELF_TEST_FILE "/mnt/extsd/self_test.txt"
-#define NO_DIAL_FILE   "/mnt/extsd/no_dial.txt"
-#define APP_LOG_FILE   "/mnt/extsd/HDZGOGGLE.log"
-#define APP_BIN_FILE   "/mnt/extsd/HDZGOGGLE"
-#define DEVELOP_SCRIPT "/mnt/extsd/develop.sh"
+#define SELF_TEST_FILE    "/mnt/extsd/self_test.txt"
+#define NO_DIAL_FILE      "/mnt/extsd/no_dial.txt"
+#define APP_LOG_FILE      "/mnt/extsd/HDZGOGGLE.log"
+#define APP_BIN_FILE      "/mnt/extsd/HDZGOGGLE"
+#define DEVELOP_SCRIPT    "/mnt/extsd/develop.sh"
+#define MAC_OVERRIDE_FILE "/mnt/extsd/macaddr.txt"

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -1,5 +1,6 @@
 #include "settings.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -208,6 +209,7 @@ const setting_t g_setting_defaults = {
         .rf_channel = 6,
         .root_pw = "divimath",
         .ssh = false,
+        .macRandom = true,
     },
     .storage = {
         .logging = false,
@@ -448,6 +450,7 @@ void settings_load(void) {
     g_setting.wifi.rf_channel = ini_getl("wifi", "rf_channel", g_setting_defaults.wifi.rf_channel, SETTING_INI);
     ini_gets("wifi", "root_pw", g_setting_defaults.wifi.root_pw, g_setting.wifi.root_pw, WIFI_PASSWD_MAX, SETTING_INI);
     g_setting.wifi.ssh = settings_get_bool("wifi", "ssh", g_setting_defaults.wifi.ssh);
+    g_setting.wifi.macRandom = settings_get_bool("wifi", "macRandom", g_setting_defaults.wifi.macRandom);
 
     //  no dial under video mode
     g_setting.ease.no_dial = fs_file_exists(NO_DIAL_FILE);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -220,6 +220,7 @@ typedef struct {
     uint8_t rf_channel;
     char root_pw[WIFI_SSID_MAX];
     bool ssh;
+    bool macRandom;
 } wifi_t;
 
 typedef struct {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -221,6 +221,7 @@ typedef struct {
     char root_pw[WIFI_SSID_MAX];
     bool ssh;
     bool macRandom;
+    char mac[18];
 } wifi_t;
 
 typedef struct {
@@ -291,6 +292,8 @@ int settings_put_osd_element(const setting_osd_goggle_element_t *element, char *
 int settings_put_osd_element_pos_y(const setting_osd_goggle_element_positions_t *pos, char *config_name);
 int settings_put_osd_element_pos_x(const setting_osd_goggle_element_positions_t *pos, char *config_name);
 int settings_put_osd_element_shown(bool show, char *config_name);
+
+static bool is_valid_mac_address(const char mac_address[]);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
To allow for easier access via WIFI, the changing mac address of the goggle will result in different IP's every boot, thanks to the dhcp on the network not recognizing the device by it's MAC.
This PR introduces a (semi) permanent MAC that can be used as a fixed address, if so desired.
The first address of the device is generated randomly from system time and saved to the settings_ini.
Changing of the address is also supported by placing a file named macaddr.txt in the SD-card root.
Validation is in place, and only valid mac's will be accepted.

Please validate this a bit more cautiously, my C skills are rusty.
