### PR TITLE
Follow DCF for DVR storage

### DIFF
--- a/src/record/record_definitions.h
+++ b/src/record/record_definitions.h
@@ -89,7 +89,7 @@ extern "C" {
 #define REC_packTypesNUM    2
 
 #define REC_filePathGet(BUFF, PATH, PREFIX, INDEX, FILEFMT) \
-    sprintf((BUFF), "%s%s%03d.%s", (PATH), (PREFIX), (INDEX), (FILEFMT));
+    sprintf((BUFF), "%s%s%04d.%s", (PATH), (PREFIX), (INDEX), (FILEFMT));
 
 #define ZeroMemory(p, size) memset(p, 0, size)
 

--- a/src/record/record_definitions.h
+++ b/src/record/record_definitions.h
@@ -71,7 +71,7 @@ extern "C" {
 #define REC_packSIZE        1024                //MB
 #define REC_minSIZE         50                  //MB
 #define REC_maxSIZE         (2 * 1024)          //MB
-#define REC_packPATH        "/movies/" //REC_diskPATH "/movies/"
+#define REC_packPATH        "/DCIM/100HDZRO/" //REC_diskPATH "/DCIM/100HDZRO/"
 #define REC_packPREFIX      "hdz_"
 #define REC_hotPREFIX       "hot_"
 #define REC_packHotPREFIX   REC_hotPREFIX REC_packPREFIX
@@ -82,7 +82,7 @@ extern "C" {
 #define REC_packPGN         "png"
 #define REC_packTYPE        REC_packTS
 #define REC_packSnapTYPE    REC_packJPG
-#define REC_packIndexLEN    3
+#define REC_packIndexLEN    4
 #define REC_packTYPES       {REC_packMP4,REC_packTS}
 #define DOT                 "."
 #define REC_packEXTS        {DOT REC_packMP4, DOT REC_packTS}


### PR DESCRIPTION
- Store DVR files in folder /DCIM/100HDZRO/
- Extend index length to 4 (hdz_xxx to hdz_xxxx)

[Design rule for Camera File system (DCF)](https://en.wikipedia.org/wiki/Design_rule_for_Camera_File_system#Directory_and_file_structure)