### PR TITLE
Quickswap sources using the Input menu options

### DIFF
--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -11,6 +11,7 @@ right_speed=3
 status=0
 last_source=1
 source=0
+toggle=0
 
 [power]
 voltage=35

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -30,6 +30,7 @@ const setting_t g_setting_defaults = {
         .status = SETTING_AUTOSCAN_STATUS_ON,
         .last_source = SETTING_AUTOSCAN_SOURCE_LAST,
         .source = SETTING_AUTOSCAN_SOURCE_HDZERO,
+        .toggle = SETTING_AUTOSCAN_TOGGLE_CYCLE,
     },
     .power = {
         .voltage = 35,

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -337,6 +337,7 @@ void settings_load(void) {
     g_setting.autoscan.status = ini_getl("autoscan", "status", g_setting_defaults.autoscan.status, SETTING_INI);
     g_setting.autoscan.source = ini_getl("autoscan", "source", g_setting_defaults.autoscan.source, SETTING_INI);
     g_setting.autoscan.last_source = ini_getl("autoscan", "last_source", g_setting_defaults.autoscan.last_source, SETTING_INI);
+    g_setting.autoscan.toggle = ini_getl("autoscan", "toggle", g_setting_defaults.autoscan.toggle, SETTING_INI);
 
     // osd
     g_setting.osd.orbit = ini_getl("osd", "orbit", g_setting_defaults.osd.orbit, SETTING_INI);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -32,10 +32,16 @@ typedef enum {
     SETTING_AUTOSCAN_SOURCE_HDMI_IN = 4
 } setting_autoscan_source_t;
 
+typedef enum {
+    SETTING_AUTOSCAN_TOGGLE_CYCLE = 0,
+    SETTING_AUTOSCAN_TOGGLE_RACE = 1,
+} setting_autoscan_toggle_t;
+
 typedef struct {
     setting_autoscan_status_t status;
     setting_autoscan_source_t last_source;
     setting_autoscan_source_t source;
+    setting_autoscan_toggle_t toggle;
 } setting_autoscan_t;
 
 typedef enum {

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -10,6 +10,7 @@ static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_T
 
 static btn_group_t btn_group0;
 static btn_group_t btn_group1;
+static btn_group_t btn_group2;
 
 static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
@@ -42,7 +43,8 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_t btn_group;
     create_btn_group_item(&btn_group0, cont, 3, "Auto Scan", "On", "Last", "Off", "", 0);
     create_btn_group_item2(&btn_group1, cont, 5, "Default", "Last", "HDZero", "Expansion", "AV In", "HDMI In", " ", 1); // 2 rows
-    create_label_item(cont, "< Back", 1, 3, 1);
+    create_btn_group_item(&btn_group2, cont, 2, "Toggle Mode", "Cycle", "Race", "", "", 3);
+    create_label_item(cont, "< Back", 1, 4, 1);
 
     lv_obj_t *label2 = lv_label_create(cont);
     lv_label_set_text(label2, "*if Auto Scan is 'Last', goggles will default to show last tuned channel");
@@ -52,10 +54,11 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_pad_top(label2, 12, 0);
     lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
     lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 3,
-                         LV_GRID_ALIGN_START, 4, 2);
+                         LV_GRID_ALIGN_START, 5, 2);
 
     btn_group_set_sel(&btn_group0, g_setting.autoscan.status);
     btn_group_set_sel(&btn_group1, g_setting.autoscan.source);
+    btn_group_set_sel(&btn_group2, g_setting.autoscan.toggle);
     return page;
 }
 
@@ -64,11 +67,14 @@ static void page_autoscan_on_click(uint8_t key, int sel) {
         btn_group_toggle_sel(&btn_group0);
         g_setting.autoscan.status = btn_group_get_sel(&btn_group0);
         ini_putl("autoscan", "status", g_setting.autoscan.status, SETTING_INI);
-    } else if (sel < 3) {
+    } else if (sel == 1) {
         btn_group_toggle_sel(&btn_group1);
         g_setting.autoscan.source = btn_group_get_sel(&btn_group1);
         ini_putl("autoscan", "source", g_setting.autoscan.source, SETTING_INI);
-    }
+    } else if (sel == 3) {
+        btn_group_toggle_sel(&btn_group2);
+        g_setting.autoscan.toggle = btn_group_get_sel(&btn_group2);
+        ini_putl("autoscan", "toggle", g_setting.autoscan.toggle, SETTING_INI);
 }
 
 page_pack_t pp_autoscan = {

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -4,6 +4,7 @@
 
 #include "core/settings.h"
 #include "ui/ui_style.h"
+#include "ui/page_source.h"
 
 static lv_coord_t col_dsc[] = {160, 150, 180, 220, 180, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
@@ -62,6 +63,51 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     return page;
 }
 
+static void source_race() {
+    switch(g_source_info.source) {
+    case SOURCE_HDZERO:
+        page_source_select_expansion();
+        break;
+    case SOURCE_EXPANSION:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_AV_IN:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_HDMI_IN:
+        page_source_select_hdzero();
+        break;
+    }
+}
+
+static void source_cycle() {
+    switch(g_source_info.source) {
+    case SOURCE_HDZERO: 
+        if (g_source_info.hdmi_in_status) {
+            page_source_select_hdmi();
+        } else {
+             page_source_select_av_in();
+        }
+        break;
+    case SOURCE_EXPANSION:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_AV_IN:
+        page_source_select_expansion();
+        break;
+    case SOURCE_HDMI_IN:
+        page_source_select_av_in();
+        break;
+    }
+}
+
+void source_toggle() {
+    if (g_setting.autoscan.toggle == 1) {
+        source_race();
+    } else {
+        source_cycle();
+    }
+
 static void page_autoscan_on_click(uint8_t key, int sel) {
     if (sel == 0) {
         btn_group_toggle_sel(&btn_group0);
@@ -80,7 +126,7 @@ static void page_autoscan_on_click(uint8_t key, int sel) {
 page_pack_t pp_autoscan = {
     .p_arr = {
         .cur = 0,
-        .max = 4,
+        .max = 5,
     },
     .name = "Auto Scan",
     .create = page_autoscan_create,

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -121,6 +121,7 @@ static void page_autoscan_on_click(uint8_t key, int sel) {
         btn_group_toggle_sel(&btn_group2);
         g_setting.autoscan.toggle = btn_group_get_sel(&btn_group2);
         ini_putl("autoscan", "toggle", g_setting.autoscan.toggle, SETTING_INI);
+    }
 }
 
 page_pack_t pp_autoscan = {

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -44,7 +44,7 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_t btn_group;
     create_btn_group_item(&btn_group0, cont, 3, "Auto Scan", "On", "Last", "Off", "", 0);
     create_btn_group_item2(&btn_group1, cont, 5, "Default", "Last", "HDZero", "Expansion", "AV In", "HDMI In", " ", 1); // 2 rows
-    create_btn_group_item(&btn_group2, cont, 2, "Toggle Mode", "Race", "Cycle", "", "", 3);
+    create_btn_group_item(&btn_group2, cont, 2, "Toggle Mode", "Cycle", "Race", "", "", 3);
     create_label_item(cont, "< Back", 1, 4, 1);
 
     lv_obj_t *label2 = lv_label_create(cont);

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -64,7 +64,7 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
 }
 
 void source_toggle() {
-    if (g_setting.autoscan.toggle == 1) {
+    if (g_setting.autoscan.toggle == SETTING_AUTOSCAN_TOGGLE_RACE) {
         source_race();
     } else {
         source_cycle();

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -44,7 +44,7 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_t btn_group;
     create_btn_group_item(&btn_group0, cont, 3, "Auto Scan", "On", "Last", "Off", "", 0);
     create_btn_group_item2(&btn_group1, cont, 5, "Default", "Last", "HDZero", "Expansion", "AV In", "HDMI In", " ", 1); // 2 rows
-    create_btn_group_item(&btn_group2, cont, 2, "Toggle Mode", "Cycle", "Race", "", "", 3);
+    create_btn_group_item(&btn_group2, cont, 2, "Toggle Mode", "Race", "Cycle", "", "", 3);
     create_label_item(cont, "< Back", 1, 4, 1);
 
     lv_obj_t *label2 = lv_label_create(cont);
@@ -61,44 +61,6 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_set_sel(&btn_group1, g_setting.autoscan.source);
     btn_group_set_sel(&btn_group2, g_setting.autoscan.toggle);
     return page;
-}
-
-static void source_race() {
-    switch(g_source_info.source) {
-    case SOURCE_HDZERO:
-        page_source_select_expansion();
-        break;
-    case SOURCE_EXPANSION:
-        page_source_select_hdzero();
-        break;
-    case SOURCE_AV_IN:
-        page_source_select_hdzero();
-        break;
-    case SOURCE_HDMI_IN:
-        page_source_select_hdzero();
-        break;
-    }
-}
-
-static void source_cycle() {
-    switch(g_source_info.source) {
-    case SOURCE_HDZERO: 
-        if (g_source_info.hdmi_in_status) {
-            page_source_select_hdmi();
-        } else {
-             page_source_select_av_in();
-        }
-        break;
-    case SOURCE_EXPANSION:
-        page_source_select_hdzero();
-        break;
-    case SOURCE_AV_IN:
-        page_source_select_expansion();
-        break;
-    case SOURCE_HDMI_IN:
-        page_source_select_av_in();
-        break;
-    }
 }
 
 void source_toggle() {

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -107,7 +107,7 @@ void source_toggle() {
     } else {
         source_cycle();
     }
-
+}
 static void page_autoscan_on_click(uint8_t key, int sel) {
     if (sel == 0) {
         btn_group_toggle_sel(&btn_group0);

--- a/src/ui/page_autoscan.h
+++ b/src/ui/page_autoscan.h
@@ -11,6 +11,8 @@ extern "C" {
 
 extern page_pack_t pp_autoscan;
 
+void source_toggle();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -12,6 +12,7 @@
 
 #include "ui/page_fans.h"
 #include "ui/ui_image_setting.h"
+#include "ui/page_autoscan.h"
 
 /**
  * Various enumerations and typedefs
@@ -36,8 +37,8 @@ typedef enum page_input_rows {
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 120, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
-const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed"};
-void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan};
+const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed", "Toggle source"};
+void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan, &source_toggle};
 
 const char *rollerOptions[] = {"Switch channel", "Change fan speed", "OLED Brightness"};
 void (* const rollerFunctionPointers[])(uint8_t) = {&tune_channel, &change_topfan, &change_oled_brightness};

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -124,7 +124,7 @@ void source_status_timer() {
     }
 }
 
-void page_source_select_hdzero() {
+static void page_source_select_hdzero() {
     progress_bar.start = 1;
     app_switch_to_hdzero(true);
     app_state_push(APP_STATE_VIDEO);
@@ -133,12 +133,12 @@ void page_source_select_hdzero() {
     dvr_enable_line_out(true);
 }
 
-void page_source_select_hdmi() {
+static void page_source_select_hdmi() {
     if (g_source_info.hdmi_in_status)
         app_switch_to_hdmi_in();
 }
 
-void page_source_select_av_in() {
+static void page_source_select_av_in() {
     app_switch_to_analog(0);
     app_state_push(APP_STATE_VIDEO);
     g_source_info.source = SOURCE_AV_IN;
@@ -146,12 +146,52 @@ void page_source_select_av_in() {
     dvr_enable_line_out(true);
 }
 
-void page_source_select_expansion() {
+static void page_source_select_expansion() {
     app_switch_to_analog(1);
     app_state_push(APP_STATE_VIDEO);
     g_source_info.source = SOURCE_EXPANSION;
     dvr_select_audio_source(2);
     dvr_enable_line_out(true);
+}
+
+void source_race() {
+    switch(g_source_info.source) {
+    case SOURCE_HDZERO:
+        page_source_select_expansion();
+        break;
+    case SOURCE_EXPANSION:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_AV_IN:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_HDMI_IN:
+        page_source_select_hdzero();
+        break;
+    }
+    Analog_Module_Power(0);
+}
+
+void source_cycle() {
+    switch(g_source_info.source) {
+    case SOURCE_HDZERO: 
+        if (g_source_info.hdmi_in_status) {
+            page_source_select_hdmi();
+        } else {
+             page_source_select_av_in();
+        }
+        break;
+    case SOURCE_EXPANSION:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_AV_IN:
+        page_source_select_expansion();
+        break;
+    case SOURCE_HDMI_IN:
+        page_source_select_av_in();
+        break;
+    }
+    Analog_Module_Power(0);
 }
 
 static void page_source_on_click(uint8_t key, int sel) {

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -124,36 +124,52 @@ void source_status_timer() {
     }
 }
 
+static void page_source_select_hdzero() {
+    progress_bar.start = 1;
+    app_switch_to_hdzero(true);
+    app_state_push(APP_STATE_VIDEO);
+    g_source_info.source = SOURCE_HDZERO;
+    dvr_select_audio_source(2);
+    dvr_enable_line_out(true);
+}
+
+static void page_source_select_hdmi() {
+    if (g_source_info.hdmi_in_status)
+        app_switch_to_hdmi_in();
+}
+
+static void page_source_select_av_in() {
+    app_switch_to_analog(0);
+    app_state_push(APP_STATE_VIDEO);
+    g_source_info.source = SOURCE_AV_IN;
+    dvr_select_audio_source(2);
+    dvr_enable_line_out(true);
+}
+
+static void page_source_select_expansion() {
+    app_switch_to_analog(1);
+    app_state_push(APP_STATE_VIDEO);
+    g_source_info.source = SOURCE_EXPANSION;
+    dvr_select_audio_source(2);
+    dvr_enable_line_out(true);
+}
+
 static void page_source_on_click(uint8_t key, int sel) {
     switch (sel) {
-    case 0:
-        progress_bar.start = 1;
-        app_switch_to_hdzero(true);
-        app_state_push(APP_STATE_VIDEO);
-        g_source_info.source = SOURCE_HDZERO;
-        dvr_select_audio_source(2);
-        dvr_enable_line_out(true);
+    case 0: // HDZero in
+        page_source_select_hdzero();
         break;
 
-    case 1:
-        if (g_source_info.hdmi_in_status)
-            app_switch_to_hdmi_in();
+    case 1: // HDMI in
+        page_source_select_hdmi();
         break;
 
     case 2: // AV in
-        app_switch_to_analog(0);
-        app_state_push(APP_STATE_VIDEO);
-        g_source_info.source = SOURCE_AV_IN;
-        dvr_select_audio_source(2);
-        dvr_enable_line_out(true);
+        page_source_select_av_in();
         break;
 
-    case 3: // Module in
-        app_switch_to_analog(1);
-        app_state_push(APP_STATE_VIDEO);
-        g_source_info.source = SOURCE_EXPANSION;
-        dvr_select_audio_source(2);
-        dvr_enable_line_out(true);
+    case 3: // Expansion module in
+        page_source_select_expansion();
         break;
 
     case 4: // Analog video format

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -124,7 +124,7 @@ void source_status_timer() {
     }
 }
 
-static void page_source_select_hdzero() {
+void page_source_select_hdzero() {
     progress_bar.start = 1;
     app_switch_to_hdzero(true);
     app_state_push(APP_STATE_VIDEO);
@@ -133,12 +133,12 @@ static void page_source_select_hdzero() {
     dvr_enable_line_out(true);
 }
 
-static void page_source_select_hdmi() {
+void page_source_select_hdmi() {
     if (g_source_info.hdmi_in_status)
         app_switch_to_hdmi_in();
 }
 
-static void page_source_select_av_in() {
+void page_source_select_av_in() {
     app_switch_to_analog(0);
     app_state_push(APP_STATE_VIDEO);
     g_source_info.source = SOURCE_AV_IN;
@@ -146,7 +146,7 @@ static void page_source_select_av_in() {
     dvr_enable_line_out(true);
 }
 
-static void page_source_select_expansion() {
+void page_source_select_expansion() {
     app_switch_to_analog(1);
     app_state_push(APP_STATE_VIDEO);
     g_source_info.source = SOURCE_EXPANSION;

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -11,10 +11,8 @@ extern "C" {
 extern page_pack_t pp_source;
 
 void source_status_timer();
-void page_source_select_hdzero();
-void page_source_select_expansion();
-void page_source_select_av_in();
-void page_source_select_hdmi();
+void source_race();
+void source_cycle();
 
 #ifdef __cplusplus
 }

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -11,6 +11,10 @@ extern "C" {
 extern page_pack_t pp_source;
 
 void source_status_timer();
+void page_source_select_hdzero();
+void page_source_select_expansion();
+void page_source_select_av_in();
+void page_source_select_hdmi();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
@Master92 did quite a lot of coding already, I took inspiration from his work which allows cycling through the source options.
On top of that I've added the option to choose to cycle only between HDZero and the expansion module, which is most useful on races where people use both systems, and for people flying lots of whoops with both systems.

![Added Toggle Mode](https://github.com/hd-zero/hdzero-goggle/assets/16467665/ecedeb35-b817-489c-bb12-6f7d9901ecda)
I've added `Toggle Mode` to the `Auto Scan` screen, because this seemed the most logical to me. Open to suggestions!
The `Cycle` setting does cycle through all source options, the `Race` setting switches between the expansion module and HDZero. In case `Race` is selected, and anything other than the expansion module or HDZero is active, it will switch to HDZero when the button is pressed to switch sources.

![Added Toggle source](https://github.com/hd-zero/hdzero-goggle/assets/16467665/78a620ae-12e9-4eb3-b2f2-af321b3f63fb)
The dropdown menu on the `Input` screen now has the option `Toggle source` added to the list, in this case I've set it on the `Right long:` button (not as default).

The code also takes into account that the expansion module can be switched off automatically, which is taken care of in the quickswap too.