### PR TITLE
Add quickswap input options to inputs menu

### DIFF
--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -11,6 +11,7 @@
 #include "core/osd.h"
 
 #include "ui/page_fans.h"
+#include "ui/page_source.h"
 #include "ui/ui_image_setting.h"
 
 /**
@@ -36,8 +37,8 @@ typedef enum page_input_rows {
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 120, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
 
-const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed", "Star DVR"};
-void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan, &dvr_star};
+const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed", "Star DVR", "Toggle source", "Cycle source"};
+void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan, &dvr_star, &source_toggle, &source_cycle};
 
 const char *rollerOptions[] = {"Switch channel", "Change fan speed", "OLED Brightness"};
 void (* const rollerFunctionPointers[])(uint8_t) = {&tune_channel, &change_topfan, &change_oled_brightness};

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -35,7 +35,7 @@ typedef enum page_input_rows {
  * Compile-unit local variables, constants and fields
  */
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 160, 120, LV_GRID_TEMPLATE_LAST};
-static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
+static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 80, LV_GRID_TEMPLATE_LAST};
 
 const char *btnOptions[] = {"Toggle OSD", "Main menu", "Toggle DVR", "Center HT", "Calibrate HT", "Go Sleep!", "Toggle fan speed", "Star DVR", "Toggle source", "Cycle source"};
 void (* const btnFunctionPointers[])() = {&osd_toggle, &app_switch_to_menu, &dvr_toggle, &ht_set_center_position, &ht_calibrate, &go_sleep, &step_topfan, &dvr_star, &source_toggle, &source_cycle};
@@ -211,7 +211,8 @@ static lv_obj_t *page_input_create(lv_obj_t *parent, panel_arr_t *arr) {
     pageItems[BACK_BTN] = create_label_item(content, "< Back", 1, BACK_BTN, 1);
 
     lv_obj_t *label = lv_label_create(content);
-    lv_label_set_text(label, "*Settings apply to video mode only");
+    lv_label_set_text(label, "*Settings apply to video mode only\n"
+                             "'Toggle source' will switch between HDZero and Expansion module");
     lv_obj_set_style_text_font(label, &lv_font_montserrat_16, 0);
     lv_obj_set_style_pad_top(label, 12, 0);
     lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 1, 2, LV_GRID_ALIGN_START, pp_input.p_arr.max, 1);

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -124,37 +124,89 @@ void source_status_timer() {
     }
 }
 
+static void page_source_select_hdzero() {
+    progress_bar.start = 1;
+    app_switch_to_hdzero(true);
+    app_state_push(APP_STATE_VIDEO);
+    g_source_info.source = SOURCE_HDZERO;
+    dvr_select_audio_source(2);
+    dvr_enable_line_out(true);
+}
+
+static void page_source_select_hdmi() {
+    if (g_source_info.hdmi_in_status)
+        app_switch_to_hdmi_in();
+}
+
+static void page_source_select_av_in() {
+    app_switch_to_analog(0);
+    app_state_push(APP_STATE_VIDEO);
+    g_source_info.source = SOURCE_AV_IN;
+    dvr_select_audio_source(2);
+    dvr_enable_line_out(true);
+}
+
+static void page_source_select_expansion() {
+    app_switch_to_analog(1);
+    app_state_push(APP_STATE_VIDEO);
+    g_source_info.source = SOURCE_EXPANSION;
+    dvr_select_audio_source(2);
+    dvr_enable_line_out(true);
+}
+
+void source_toggle() {
+    switch(g_source_info.source) {
+    case SOURCE_HDZERO:
+        page_source_select_expansion();
+        break;
+    case SOURCE_EXPANSION:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_AV_IN:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_HDMI_IN:
+        page_source_select_hdzero();
+        break;
+    }
+    Analog_Module_Power(0);
+}
+
+void source_cycle() {
+    switch(g_source_info.source) {
+    case SOURCE_HDZERO: 
+        if (g_source_info.hdmi_in_status) {
+            page_source_select_hdmi();
+        } else {
+             page_source_select_av_in();
+        }
+        break;
+    case SOURCE_EXPANSION:
+        page_source_select_hdzero();
+        break;
+    case SOURCE_AV_IN:
+        page_source_select_expansion();
+        break;
+    case SOURCE_HDMI_IN:
+        page_source_select_av_in();
+        break;
+    }
+    Analog_Module_Power(0);
+}
+
 static void page_source_on_click(uint8_t key, int sel) {
     switch (sel) {
-    case 0:
-        progress_bar.start = 1;
-        app_switch_to_hdzero(true);
-        app_state_push(APP_STATE_VIDEO);
-        g_source_info.source = SOURCE_HDZERO;
-        dvr_select_audio_source(2);
-        dvr_enable_line_out(true);
-        break;
+    case 0: // HDZero in
+        page_source_select_hdzero();
 
-    case 1:
-        if (g_source_info.hdmi_in_status)
-            app_switch_to_hdmi_in();
-        break;
+    case 1: // HDMI in
+        page_source_select_hdmi();
 
     case 2: // AV in
-        app_switch_to_analog(0);
-        app_state_push(APP_STATE_VIDEO);
-        g_source_info.source = SOURCE_AV_IN;
-        dvr_select_audio_source(2);
-        dvr_enable_line_out(true);
-        break;
+        page_source_select_av_in();
 
-    case 3: // Module in
-        app_switch_to_analog(1);
-        app_state_push(APP_STATE_VIDEO);
-        g_source_info.source = SOURCE_EXPANSION;
-        dvr_select_audio_source(2);
-        dvr_enable_line_out(true);
-        break;
+    case 3: // Expansion module in
+        page_source_select_expansion();
 
     case 4: // Analog video format
         btn_group_toggle_sel(&btn_group0);

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -11,6 +11,7 @@
 #include "core/dvr.h"
 #include "core/osd.h"
 #include "core/settings.h"
+#include "driver/beep.h"
 #include "driver/hardware.h"
 #include "driver/it66121.h"
 #include "driver/oled.h"
@@ -155,6 +156,7 @@ static void page_source_select_expansion() {
 }
 
 void source_toggle() {
+    beep_dur(BEEP_SHORT);
     switch(g_source_info.source) {
     case SOURCE_HDZERO:
         page_source_select_expansion();
@@ -173,6 +175,7 @@ void source_toggle() {
 }
 
 void source_cycle() {
+    beep_dur(BEEP_SHORT);
     switch(g_source_info.source) {
     case SOURCE_HDZERO: 
         if (g_source_info.hdmi_in_status) {

--- a/src/ui/page_source.h
+++ b/src/ui/page_source.h
@@ -11,6 +11,8 @@ extern "C" {
 extern page_pack_t pp_source;
 
 void source_status_timer();
+void source_toggle();
+void source_cycle();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Simplified version of the quickswap input PR, this PR replaces the old #423. 

Added 2 options to the dropdown menu on the inputs page: `Toggle source` and `Cycle source`
Added the remark 'Toggle source' will switch between HDZero and Expansion module
Everything can be set on the inputs page, without the need of defining which option you want to use on a separate page.

See `Right short:` and `Right long:` in the below example:
![Screenshot 2024-08-05 174353](https://github.com/user-attachments/assets/3ffc953e-e5f9-4e06-a10e-842f02bbb668)


