### PR TITLE
Increase goggle battery voltage precision to 2 decimal places

### DIFF
--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -109,9 +109,9 @@ element_battery_voltage_pos_16_9_y=0
 
 # channel
 element_channel_show=true
-element_channel_pos_4_3_x=540
+element_channel_pos_4_3_x=580
 element_channel_pos_4_3_y=0
-element_channel_pos_16_9_x=540
+element_channel_pos_16_9_x=580
 element_channel_pos_16_9_y=0
 
 # sd rec

--- a/mkapp/app/setting.ini
+++ b/mkapp/app/setting.ini
@@ -13,7 +13,7 @@ last_source=1
 source=0
 
 [power]
-voltage=35
+voltage=3500
 warning_type=2
 cell_count_mode=0
 cell_count = 2

--- a/src/core/battery.c
+++ b/src/core/battery.c
@@ -52,19 +52,19 @@ void battery_get_voltage_str(char *buf) {
     default:
     case SETTING_POWER_OSD_DISPLAY_MODE_TOTAL: {
         int bat_mv = battery_get_millivolts(false);
-        sprintf(buf, "%dS %d.%dV",
+        sprintf(buf, "%dS %d.%02dV",
                 g_battery.type,
                 bat_mv / 1000,
-                bat_mv % 1000 / 100);
+                bat_mv % 1000 / 10);
         break;
     }
 
     case SETTING_POWER_OSD_DISPLAY_MODE_CELL: {
         int bat_mv = battery_get_millivolts(true);
-        sprintf(buf, "%dS %d.%dV/C",
+        sprintf(buf, "%dS %d.%02dV/C",
                 g_battery.type,
                 bat_mv / 1000,
-                bat_mv % 1000 / 100);
+                bat_mv % 1000 / 10);
         break;
     }
     }

--- a/src/core/battery.c
+++ b/src/core/battery.c
@@ -36,14 +36,14 @@ bool battery_is_low() {
         return true;
     }
     int cell_volt = battery_get_millivolts(true);
-    return cell_volt <= g_setting.power.voltage * 100;
+    return cell_volt <= g_setting.power.voltage;
 }
 
 int battery_get_millivolts(bool per_cell) {
     if (per_cell && g_battery.type > 0) {
-        return (g_battery.voltage + g_battery.offset * 100) / g_battery.type;
+        return (g_battery.voltage + g_battery.offset) / g_battery.type;
     }
-    return g_battery.voltage + g_battery.offset * 100;
+    return g_battery.voltage + g_battery.offset;
 }
 
 void battery_get_voltage_str(char *buf) {

--- a/src/core/battery.h
+++ b/src/core/battery.h
@@ -13,7 +13,7 @@ extern "C" {
 typedef struct {
     int type; // cell count
     int voltage;
-    int offset; // in 100mV
+    int offset; // in mV
 } sys_battery_t;
 
 extern sys_battery_t g_battery;
@@ -23,7 +23,7 @@ void battery_update();
 
 bool battery_is_low();
 int battery_get_millivolts(bool per_cell);
-void battery_get_voltage_str(char* buf);
+void battery_get_voltage_str(char *buf);
 
 #ifdef __cplusplus
 }

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -127,7 +127,7 @@ const setting_t g_setting_defaults = {
             // OSD_GOGGLE_CHANNEL
             {
                 .show = true,
-                .position = {.mode_4_3 = {.x = 540, .y = 0}, .mode_16_9 = {.x = 540, .y = 0}},
+                .position = {.mode_4_3 = {.x = 580, .y = 0}, .mode_16_9 = {.x = 580, .y = 0}},
             },
             // OSD_GOGGLE_SD_REC
             {

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -32,7 +32,7 @@ const setting_t g_setting_defaults = {
         .source = SETTING_AUTOSCAN_SOURCE_HDZERO,
     },
     .power = {
-        .voltage = 35,
+        .voltage = 3500,
         .display_voltage = true,
         .warning_type = SETTING_POWER_WARNING_TYPE_BOTH,
         .cell_count_mode = SETTING_POWER_CELL_COUNT_MODE_AUTO,

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -15,10 +15,10 @@
 #include "page_common.h"
 #include "ui/ui_style.h"
 
-#define WARNING_CELL_VOLTAGE_MIN 28
-#define WARNING_CELL_VOLTAGE_MAX 42
-#define CALIBRATION_OFFSET_MIN   -25
-#define CALIBRATION_OFFSET_MAX   25
+#define WARNING_CELL_VOLTAGE_MIN 2800
+#define WARNING_CELL_VOLTAGE_MAX 4200
+#define CALIBRATION_OFFSET_MIN   -2500
+#define CALIBRATION_OFFSET_MAX   2500
 
 enum {
     ROW_BATT_C_LABEL = 0,
@@ -42,7 +42,7 @@ static btn_group_t btn_group_osd_display_mode;
 static btn_group_t btn_group_warn_type;
 static btn_group_t btn_group_power_ana;
 
-static slider_group_t* selected_slider_group = NULL;
+static slider_group_t *selected_slider_group = NULL;
 
 static lv_coord_t col_dsc[] = {160, 200, 160, 160, 120, 160, LV_GRID_TEMPLATE_LAST};
 static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 60, 60, LV_GRID_TEMPLATE_LAST};
@@ -79,8 +79,8 @@ static void page_power_update_calibration_offset() {
     ini_putl("power", "calibration_offset", g_battery.offset, SETTING_INI);
 
     lv_slider_set_value(slider_group_calibration_offset.slider, g_battery.offset, LV_ANIM_OFF);
-    char buf[6];
-    sprintf(buf, "%.1fV", g_battery.offset / 10.f);
+    char buf[7];
+    sprintf(buf, "%.2fV", g_battery.offset / 1000.0);
     lv_label_set_text(slider_group_calibration_offset.label, buf);
 }
 
@@ -132,8 +132,8 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_label_item(cont, "< Back", 1, pp_power.p_arr.max - 1, 1);
 
     // set menu entry min/max values and labels
-    char str[5];
-    sprintf(str, "%d.%d", g_setting.power.voltage / 10, g_setting.power.voltage % 10);
+    char str[6];
+    sprintf(str, "%.2f", g_setting.power.voltage / 1000.0);
     lv_slider_set_range(slider_group_cell_voltage.slider, WARNING_CELL_VOLTAGE_MIN, WARNING_CELL_VOLTAGE_MAX);
     lv_label_set_text(slider_group_cell_voltage.label, str);
 
@@ -141,7 +141,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_slider_set_range(slider_group_cell_count.slider, CELL_MIN_COUNT, CELL_MAX_COUNT);
     lv_label_set_text(slider_group_cell_count.label, str);
 
-    sprintf(str, "%.1fV", g_setting.power.calibration_offset / 10.f);
+    sprintf(str, "%.2fV", g_setting.power.calibration_offset / 1000.0);
     lv_slider_set_range(slider_group_calibration_offset.slider, CALIBRATION_OFFSET_MIN, CALIBRATION_OFFSET_MAX);
     lv_label_set_text(slider_group_calibration_offset.label, str);
 
@@ -188,12 +188,12 @@ static void power_warning_voltage_inc(void) {
 
     value = lv_slider_get_value(slider_group_cell_voltage.slider);
     if (value < WARNING_CELL_VOLTAGE_MAX)
-        value += 1;
+        value += 10;
 
     lv_slider_set_value(slider_group_cell_voltage.slider, value, LV_ANIM_OFF);
 
-    char buf[5];
-    sprintf(buf, "%d.%d", value / 10, value % 10);
+    char buf[6];
+    sprintf(buf, "%.2f", value / 1000.0);
     lv_label_set_text(slider_group_cell_voltage.label, buf);
 
     g_setting.power.voltage = value;
@@ -206,11 +206,11 @@ static void power_warning_voltage_dec(void) {
 
     value = lv_slider_get_value(slider_group_cell_voltage.slider);
     if (value > WARNING_CELL_VOLTAGE_MIN)
-        value -= 1;
+        value -= 10;
 
     lv_slider_set_value(slider_group_cell_voltage.slider, value, LV_ANIM_OFF);
-    char buf[5];
-    sprintf(buf, "%d.%d", value / 10, value % 10);
+    char buf[6];
+    sprintf(buf, "%.2f", value / 1000.0);
     lv_label_set_text(slider_group_cell_voltage.label, buf);
 
     g_setting.power.voltage = value;
@@ -223,7 +223,7 @@ static void power_calibration_offset_inc(void) {
 
     value = lv_slider_get_value(slider_group_calibration_offset.slider);
     if (value < CALIBRATION_OFFSET_MAX)
-        value += 1;
+        value += 10;
 
     g_setting.power.calibration_offset = value;
 
@@ -235,7 +235,7 @@ static void power_calibration_offset_dec(void) {
 
     value = lv_slider_get_value(slider_group_calibration_offset.slider);
     if (value > CALIBRATION_OFFSET_MIN)
-        value -= 1;
+        value -= 10;
 
     g_setting.power.calibration_offset = value;
 


### PR DESCRIPTION
## Changes
- Show voltage as 0.00V/C instead of 0.0V/C. Also moved channel OSD to the right to accommodate longer voltage text

  Emulator image (in goggles gap is smaller):
  ![image](https://github.com/user-attachments/assets/4c5c159c-4a91-458d-9d7d-82b28fc19cbc)

- Battery voltage warning and offset precision increased to 0.01V.
![image](https://github.com/user-attachments/assets/c06e4bd0-00e4-4527-8727-777e0c7017e6)

- To make code more consistent now variable `g_setting.power.voltage`, `g_battery.offset`, `WARNING_CELL_VOLTAGE_MIN` `WARNING_CELL_VOLTAGE_MAX`, `CALIBRATION_OFFSET_MIN`, `CALIBRATION_OFFSET_MAX` are in mV

## Before merging
I'm not sure how changing voltage units from 100mV to 1mV would effect user settings so before merging someone else should try this firmware and check if their saved warning and offset value was not corrupted after update