### PR TITLE
Fix disappearing navigation box when only one DVR is present

### DIFF
--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -325,6 +325,10 @@ static void update_page() {
 }
 
 static void update_item(uint8_t cur_pos, uint8_t lst_pos) {
+    if (cur_pos == lst_pos) {
+        return;
+    }
+
     lv_obj_clear_flag(pb_ui[cur_pos]._arrow, LV_OBJ_FLAG_HIDDEN);
     lv_obj_remove_style(pb_ui[cur_pos]._img, &style_pb_dark, LV_PART_MAIN);
     lv_obj_add_style(pb_ui[cur_pos]._img, &style_pb, LV_PART_MAIN);


### PR DESCRIPTION
When using the roller in the playback page when it has only one DVR file, the highlight of that file would disappear. The reason for it was that the visibility flags were set on the new item before clearing them on the old item.

This change introduces an early return if both items in update_item are the same and wouldn't need a change in their visibility flags anyway.