### PR TITLE
Prevent possible invalid memory accesses by sprintf

### DIFF
--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -44,14 +44,14 @@ void dvr_update_status() {
 void dvr_enable_line_out(bool enable) {
     char buf[128];
     if (enable) {
-        sprintf(buf, "%s out_on", AUDIO_SEL_SH);
+        snprintf(buf, sizeof(buf), "%s out_on", AUDIO_SEL_SH);
         system_exec(buf);
-        sprintf(buf, "%s out_linein_on", AUDIO_SEL_SH);
+        snprintf(buf, sizeof(buf), "%s out_linein_on", AUDIO_SEL_SH);
         system_exec(buf);
-        sprintf(buf, "%s out_dac_off", AUDIO_SEL_SH);
+        snprintf(buf, sizeof(buf), "%s out_dac_off", AUDIO_SEL_SH);
         system_exec(buf);
     } else {
-        sprintf(buf, "%s out_off", AUDIO_SEL_SH);
+        snprintf(buf, sizeof(buf), "%s out_off", AUDIO_SEL_SH);
         system_exec(buf);
     }
 }
@@ -65,7 +65,7 @@ void dvr_select_audio_source(uint8_t source) {
 
     if (source > 2)
         source = 2;
-    sprintf(buf, "%s %s", AUDIO_SEL_SH, audio_source[source]);
+    snprintf(buf, sizeof(buf), "%s %s", AUDIO_SEL_SH, audio_source[source]);
     system_exec(buf);
 }
 

--- a/src/core/osd.c
+++ b/src/core/osd.c
@@ -70,7 +70,7 @@ void osd_resource_path(char *buf, const char *fmt, osd_resource_t osd_resource_t
 
     va_list args;
     va_start(args, osd_resource_type);
-    vsprintf(filename, fmt, args);
+    vsnprintf(filename, sizeof(filename), fmt, args);
     va_end(args);
     strcpy(buf2, buf);
     strcpy(buf, RESOURCE_PATH_SDCARD);
@@ -292,12 +292,12 @@ void osd_channel_show(bool bShow) {
     if (channel_osd_mode & 0x80) {
         ch = channel_osd_mode & 0x7F;
         color = lv_color_make(0xFF, 0x20, 0x20);
-        sprintf(buf, "  To %s?  ", channel2str(g_setting.source.hdzero_band, ch));
+        snprintf(buf, sizeof(buf), "  To %s?  ", channel2str(g_setting.source.hdzero_band, ch));
         lv_obj_set_style_bg_opa(g_osd_hdzero.channel[is_fhd], LV_OPA_100, 0);
     } else {
         ch = g_setting.scan.channel & 0x7F;
         color = lv_color_make(0xFF, 0xFF, 0xFF);
-        sprintf(buf, "CH:%s", channel2str(g_setting.source.hdzero_band, ch));
+        snprintf(buf, sizeof(buf), "CH:%s", channel2str(g_setting.source.hdzero_band, ch));
         lv_obj_set_style_bg_opa(g_osd_hdzero.channel[is_fhd], 0, 0);
     }
 
@@ -644,13 +644,13 @@ void osd_hdzero_update(void) {
         lv_obj_add_flag(g_osd_hdzero.ant3[is_fhd], LV_OBJ_FLAG_HIDDEN);
 
     if (g_setting.storage.selftest) {
-        sprintf(buf, "T:%d-%d", fan_speed.top, g_temperature.top / 10);
+        snprintf(buf, sizeof(buf), "T:%d-%d", fan_speed.top, g_temperature.top / 10);
         lv_label_set_text(g_osd_hdzero.osd_tempe[is_fhd][0], buf);
 
-        sprintf(buf, "L:%d-%d", fan_speed.left, g_temperature.left / 10);
+        snprintf(buf, sizeof(buf), "L:%d-%d", fan_speed.left, g_temperature.left / 10);
         lv_label_set_text(g_osd_hdzero.osd_tempe[is_fhd][1], buf);
 
-        sprintf(buf, "R:%d-%d", fan_speed.right, g_temperature.right / 10);
+        snprintf(buf, sizeof(buf), "R:%d-%d", fan_speed.right, g_temperature.right / 10);
         lv_label_set_text(g_osd_hdzero.osd_tempe[is_fhd][2], buf);
     }
 }
@@ -929,13 +929,13 @@ void load_fc_osd_font(uint8_t fhd) {
     int i;
 
     if (fhd) {
-        sprintf(fp[0], "%s%s_FHD_000.bmp", FC_OSD_SDCARD_PATH, fc_variant);
-        sprintf(fp[1], "%s%s_FHD_000.bmp", FC_OSD_LOCAL_PATH, fc_variant);
-        sprintf(fp[2], "%sBTFL_FHD_000.bmp", FC_OSD_LOCAL_PATH);
+        snprintf(fp[0], sizeof(fp[0]), "%s%s_FHD_000.bmp", FC_OSD_SDCARD_PATH, fc_variant);
+        snprintf(fp[1], sizeof(fp[1]), "%s%s_FHD_000.bmp", FC_OSD_LOCAL_PATH, fc_variant);
+        snprintf(fp[2], sizeof(fp[2]), "%sBTFL_FHD_000.bmp", FC_OSD_LOCAL_PATH);
     } else {
-        sprintf(fp[0], "%s%s_000.bmp", FC_OSD_SDCARD_PATH, fc_variant);
-        sprintf(fp[1], "%s%s_000.bmp", FC_OSD_LOCAL_PATH, fc_variant);
-        sprintf(fp[2], "%sBTFL_000.bmp", FC_OSD_LOCAL_PATH);
+        snprintf(fp[0], sizeof(fp[0]), "%s%s_000.bmp", FC_OSD_SDCARD_PATH, fc_variant);
+        snprintf(fp[1], sizeof(fp[1]), "%s%s_000.bmp", FC_OSD_LOCAL_PATH, fc_variant);
+        snprintf(fp[2], sizeof(fp[2]), "%sBTFL_000.bmp", FC_OSD_LOCAL_PATH);
     }
 
     // Optimized for runtime execution

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -227,7 +227,7 @@ const setting_t g_setting_defaults = {
 int settings_put_osd_element_shown(bool show, char *config_name) {
     char setting_key[128];
 
-    sprintf(setting_key, "element_%s_show", config_name);
+    snprintf(setting_key, sizeof(setting_key), "element_%s_show", config_name);
     return settings_put_bool("osd", setting_key, show);
 }
 
@@ -235,9 +235,9 @@ int settings_put_osd_element_pos_x(const setting_osd_goggle_element_positions_t 
     char setting_key[128];
     int ret = 0;
 
-    sprintf(setting_key, "element_%s_pos_4_3_x", config_name);
+    snprintf(setting_key, sizeof(setting_key), "element_%s_pos_4_3_x", config_name);
     ret = ini_putl("osd", setting_key, pos->mode_4_3.x, SETTING_INI);
-    sprintf(setting_key, "element_%s_pos_16_9_x", config_name);
+    snprintf(setting_key, sizeof(setting_key), "element_%s_pos_16_9_x", config_name);
     ret &= ini_putl("osd", setting_key, pos->mode_16_9.x, SETTING_INI);
     return ret;
 }
@@ -246,9 +246,9 @@ int settings_put_osd_element_pos_y(const setting_osd_goggle_element_positions_t 
     char setting_key[128];
     int ret = 0;
 
-    sprintf(setting_key, "element_%s_pos_4_3_y", config_name);
+    snprintf(setting_key, sizeof(setting_key), "element_%s_pos_4_3_y", config_name);
     ret = ini_putl("osd", setting_key, pos->mode_4_3.y, SETTING_INI);
-    sprintf(setting_key, "element_%s_pos_16_9_y", config_name);
+    snprintf(setting_key, sizeof(setting_key), "element_%s_pos_16_9_y", config_name);
     ret &= ini_putl("osd", setting_key, pos->mode_16_9.y, SETTING_INI);
     return ret;
 }
@@ -265,19 +265,19 @@ int settings_put_osd_element(const setting_osd_goggle_element_t *element, char *
 static void settings_load_osd_element(setting_osd_goggle_element_t *element, char *config_name, const setting_osd_goggle_element_t *defaults) {
     char buf[128];
 
-    sprintf(buf, "element_%s_show", config_name);
+    snprintf(buf, sizeof(buf), "element_%s_show", config_name);
     element->show = settings_get_bool("osd", buf, defaults->show);
 
-    sprintf(buf, "element_%s_pos_4_3_x", config_name);
+    snprintf(buf, sizeof(buf), "element_%s_pos_4_3_x", config_name);
     element->position.mode_4_3.x = ini_getl("osd", buf, defaults->position.mode_4_3.x, SETTING_INI);
 
-    sprintf(buf, "element_%s_pos_4_3_y", config_name);
+    snprintf(buf, sizeof(buf), "element_%s_pos_4_3_y", config_name);
     element->position.mode_4_3.y = ini_getl("osd", buf, defaults->position.mode_4_3.y, SETTING_INI);
 
-    sprintf(buf, "element_%s_pos_16_9_x", config_name);
+    snprintf(buf, sizeof(buf), "element_%s_pos_16_9_x", config_name);
     element->position.mode_16_9.x = ini_getl("osd", buf, defaults->position.mode_16_9.x, SETTING_INI);
 
-    sprintf(buf, "element_%s_pos_16_9_y", config_name);
+    snprintf(buf, sizeof(buf), "element_%s_pos_16_9_y", config_name);
     element->position.mode_16_9.y = ini_getl("osd", buf, defaults->position.mode_16_9.y, SETTING_INI);
 }
 
@@ -295,11 +295,11 @@ int settings_put_bool(char *section, char *key, bool value) {
 void settings_reset(void) {
     char buf[256];
 
-    sprintf(buf, "rm -f %s", SETTING_INI);
+    snprintf(buf, sizeof(buf), "rm -f %s", SETTING_INI);
     system_exec(buf);
     usleep(50);
 
-    sprintf(buf, "touch %s", SETTING_INI);
+    snprintf(buf, sizeof(buf), "touch %s", SETTING_INI);
     system_exec(buf);
     usleep(50);
 
@@ -310,7 +310,7 @@ void settings_init(void) {
     // check if backup of old settings file exists after goggle update
     if (fs_file_exists("/mnt/UDISK/setting.ini")) {
         char buf[256];
-        sprintf(buf, "cp -f /mnt/UDISK/setting.ini %s", SETTING_INI);
+        snprintf(buf, sizeof(buf), "cp -f /mnt/UDISK/setting.ini %s", SETTING_INI);
         system_exec(buf);
         usleep(10);
         system_exec("rm /mnt/UDISK/setting.ini");

--- a/src/driver/gpio.c
+++ b/src/driver/gpio.c
@@ -36,7 +36,7 @@ void gpio_open(int port_num) {
     }
 
     char buf[64];
-    sprintf(buf, "/sys/class/gpio/gpio%d/direction", port_num);
+    snprintf(buf, sizeof(buf), "/sys/class/gpio/gpio%d/direction", port_num);
 
     if (!fs_printf(buf, "out")) {
         return;
@@ -45,6 +45,6 @@ void gpio_open(int port_num) {
 
 void gpio_set(int port_num, bool val) {
     char buf[64];
-    sprintf(buf, "/sys/class/gpio/gpio%d/value", port_num);
+    snprintf(buf, sizeof(buf), "/sys/class/gpio/gpio%d/value", port_num);
     fs_printf(buf, "%d", val ? 1 : 0);
 }

--- a/src/driver/nct75.c
+++ b/src/driver/nct75.c
@@ -27,7 +27,7 @@ int nct_read_temperature(nct_type_t type) {
 
     int dev_id = type + (getHwRevision() == HW_REV_1 ? 1 : 0);
 
-    sprintf(buf, "/sys/bus/iio/devices/iio:device%d/in_voltage0_raw", dev_id);
+    snprintf(buf, sizeof(buf), "/sys/bus/iio/devices/iio:device%d/in_voltage0_raw", dev_id);
     fp = fopen(buf, "r");
     if (!fp) {
         static bool bFirst = true;

--- a/src/lang/language.c
+++ b/src/lang/language.c
@@ -59,7 +59,7 @@ bool language_config() {
     int i = 0;
 
     for (i = 0; i < LANG_END; i++) {
-        sprintf(buf, "/mnt/extsd/%s", language_config_file[i]);
+        snprintf(buf, sizeof(buf), "/mnt/extsd/%s", language_config_file[i]);
         if (access(buf, F_OK) == 0) {
             LOGI("%s found", language_config_file[i]);
             ini_putl("language", "lang", i, SETTING_INI);

--- a/src/record/confparser.c
+++ b/src/record/confparser.c
@@ -404,7 +404,7 @@ void conf_loadRecordParams(char* confFile, RecordParams_t* para)
         memset(para->diskPath, 0, sizeof(para->packPath));
         strcpy(para->diskPath, sTemp);
         memset(para->packPath, 0, sizeof(para->packPath));
-        sprintf(para->packPath, "%s%s", para->diskPath, REC_packPATH);
+        snprintf(para->packPath, MAX_pathLEN, "%s%s", para->diskPath, REC_packPATH);
     }
 
     lValue = ini_gets(SEC_RECORD, KEY_TYPE, REC_packTYPE, sTemp, sizearray(sTemp), confFile);

--- a/src/record/main.c
+++ b/src/record/main.c
@@ -121,7 +121,7 @@ int already_running(void)
         exit(1);
     }
     ftruncate(fd, 0);
-    sprintf(buf, "%ld", (long)getpid());
+    snprintf(buf, sizeof(buf), "%ld", (long)getpid());
     write(fd, buf, strlen(buf)+1);
     return(0);
 }
@@ -203,7 +203,7 @@ void record_saveStatus(RecordContext_t* recCtx, RecordStatus_e recStatus)
         LOGE( "can't lock %s: %s", REC_dataFILE, strerror(errno));
     }
     ftruncate(fd, 0);
-    sprintf(buf, "%d", recCtx->status);
+    snprintf(buf, sizeof(buf), "%d", recCtx->status);
     write(fd, buf, strlen(buf)+1);
     close(fd);
 
@@ -354,13 +354,13 @@ int record_start(RecordContext_t* recCtx)
     char sFile[256];
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
-        REC_filePathGet(sFile, recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
+        REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
         break;
     case NAMING_DATE: {
         const time_t t = time(0);
         const struct tm* date = localtime(&t);
-        sprintf(dateString, "%04d%02d%02d-%02d%02d%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec);
-        sprintf(sFile, "%s%s.%s", recCtx->params.packPath, dateString, recCtx->params.packType);
+        snprintf(dateString, sizeof(dateString), "%04d%02d%02d-%02d%02d%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec);
+        snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, recCtx->params.packType);
         break;
     }
     }
@@ -429,7 +429,7 @@ int record_start(RecordContext_t* recCtx)
         strcpy(fileName, strrchr(sFile, '/') + 1);
         av_dict_set(&ff->ofmtContext->metadata, "title", fileName, 0);
 
-        sprintf(localDateString, "%04d-%02d-%02d %02d:%02d:%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec);
+        snprintf(localDateString, sizeof(localDateString), "%04d-%02d-%02d %02d:%02d:%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec);
         av_dict_set(&ff->ofmtContext->metadata, "date", localDateString, 0);
     }
 
@@ -462,10 +462,10 @@ int record_start(RecordContext_t* recCtx)
 
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
-        REC_filePathGet(sFile, recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
+        REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
         break;
     case NAMING_DATE:
-        sprintf(sFile, "%s%s.%s", recCtx->params.packPath, dateString, REC_packSnapTYPE);
+        snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, REC_packSnapTYPE);
         break;
     }
     ret = record_takePicture(recCtx, sFile);
@@ -519,7 +519,7 @@ bool record_pack(RecordContext_t* recCtx)
     VencSpspps_t veHeader = { NULL, 0 };
     int  nbFileIndex = recCtx->nbFileIndex;
     char sFile[256];
-    REC_filePathGet(sFile, recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
+    REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
 
     FFPack_t* ff = ffpack_openFile(sFile, NULL);
     if( ff == NULL ) {
@@ -577,7 +577,7 @@ bool record_pack(RecordContext_t* recCtx)
 
     pthread_mutex_unlock(&recCtx->mutex);
 
-    REC_filePathGet(sFile, recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
+    REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
     record_takePicture(recCtx, sFile);
 
     return true;
@@ -888,7 +888,7 @@ void record_checkConf(RecordContext_t* recCtx, char* confSet)
         readlink("/proc/self/exe", sTemp, MAX_pathLEN);
         p = strrchr(sTemp,'/');
         *p = '\0';
-        sprintf(recCtx->confFile, "%s/%s", sTemp, REC_confFILE);
+        snprintf(recCtx->confFile, MAX_pathLEN, "%s/%s", sTemp, REC_confFILE);
     }
 }
 

--- a/src/record/record_definitions.h
+++ b/src/record/record_definitions.h
@@ -91,8 +91,8 @@ extern "C" {
 #define REC_packTypesNUM    2
 #define REC_starFORMAT      "%u:%02u star\n"
 
-#define REC_filePathGet(BUFF, PATH, PREFIX, INDEX, FILEFMT) \
-    sprintf((BUFF), "%s%s%04d.%s", (PATH), (PREFIX), (INDEX), (FILEFMT));
+#define REC_filePathGet(BUFF, MAXLEN, PATH, PREFIX, INDEX, FILEFMT) \
+    snprintf((BUFF), (MAXLEN), "%s%s%04d.%s", (PATH), (PREFIX), (INDEX), (FILEFMT));
 
 #define ZeroMemory(p, size) memset(p, 0, size)
 

--- a/src/rtspLive/main.cpp
+++ b/src/rtspLive/main.cpp
@@ -129,7 +129,7 @@ static int already_running(void)
         exit(1);
     }
     ftruncate(fd, 0);
-    sprintf(buf, "%ld", (long)getpid());
+    snprintf(buf, sizeof(buf), "%ld", (long)getpid());
     write(fd, buf, strlen(buf)+1);
     return(0);
 }
@@ -179,7 +179,7 @@ void live_checkConf(LiveContext_t* liveCtx, char* confSet)
         readlink("/proc/self/exe", sTemp, MAX_pathLEN);
         p = strrchr(sTemp,'/');
         *p = '\0';
-        sprintf(liveCtx->confFile, "%s/%s", sTemp, REC_confFILE);
+        snprintf(liveCtx->confFile, MAX_pathLEN, "%s/%s", sTemp, REC_confFILE);
     }
 }
 

--- a/src/ui/page_autoscan.c
+++ b/src/ui/page_autoscan.c
@@ -24,7 +24,7 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Auto Scan"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Auto Scan"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -45,7 +45,7 @@ static lv_obj_t *page_autoscan_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_t btn_group;
     create_btn_group_item(&btn_group0, cont, 3, _lang("Auto Scan"), _lang("On"), _lang("Last"), _lang("Off"), "", 0);
     create_btn_group_item2(&btn_group1, cont, 5, _lang("Default"), _lang("Last"), _lang("HDZero"), _lang("Expansion"), _lang("AV In"), _lang("HDMI In"), " ", 1); // 2 rows
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, 3, 1);
 
     lv_obj_t *label2 = lv_label_create(cont);

--- a/src/ui/page_clock.c
+++ b/src/ui/page_clock.c
@@ -356,7 +356,7 @@ static lv_obj_t *page_clock_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Clock"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Clock"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -379,7 +379,7 @@ static lv_obj_t *page_clock_create(lv_obj_t *parent, panel_arr_t *arr) {
     page_clock_create_dropdown(cont, ITEM_MINUTE, page_clock_rtc_date.min, 2, 1);
     page_clock_create_dropdown(cont, ITEM_SECOND, page_clock_rtc_date.sec, 3, 1);
 
-    sprintf(buf, "%s/%s", _lang("AM"), _lang("PM"));
+    snprintf(buf, sizeof(buf), "%s/%s", _lang("AM"), _lang("PM"));
     create_btn_group_item(&page_clock_items[ITEM_FORMAT].data.btn, cont, 2, _lang("Format"), buf, _lang("24 Hour"), "", "", 2);
     page_clock_items[ITEM_FORMAT].type = ITEM_TYPE_BTN;
     page_clock_items[ITEM_FORMAT].panel = arr->panel[2];
@@ -389,7 +389,7 @@ static lv_obj_t *page_clock_create(lv_obj_t *parent, panel_arr_t *arr) {
     page_clock_items[ITEM_SET_CLOCK].type = ITEM_TYPE_OBJ;
     page_clock_items[ITEM_SET_CLOCK].panel = arr->panel[3];
 
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     page_clock_items[ITEM_BACK].data.obj = create_label_item(cont, buf, 1, 4, 1);
     page_clock_items[ITEM_BACK].type = ITEM_TYPE_OBJ;
     page_clock_items[ITEM_BACK].panel = arr->panel[4];
@@ -398,7 +398,7 @@ static lv_obj_t *page_clock_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     if (rtc_has_battery() != 0) {
         lv_obj_t *note = lv_label_create(cont);
-        sprintf(buf, "*%s.", _lang("Battery not installed or clock not configured"));
+        snprintf(buf, sizeof(buf), "*%s.", _lang("Battery not installed or clock not configured"));
         lv_label_set_text(note, buf);
         lv_obj_set_style_text_font(note, &lv_font_montserrat_16, 0);
         lv_obj_set_style_text_align(note, LV_TEXT_ALIGN_LEFT, 0);
@@ -520,13 +520,13 @@ static void page_clock_on_click(uint8_t key, int sel) {
         break;
     case ITEM_SET_CLOCK:
         if (page_clock_set_clock_confirm) {
-            sprintf(buf, "#FF0000 %s %s...#", _lang("Updating"), _lang("Clock"));
+            snprintf(buf, sizeof(buf), "#FF0000 %s %s...#", _lang("Updating"), _lang("Clock"));
             lv_label_set_text(page_clock_items[ITEM_SET_CLOCK].data.obj, buf);
             page_clock_set_clock_timer = lv_timer_create(page_clock_set_clock_timer_cb, 1000, NULL);
             lv_timer_set_repeat_count(page_clock_set_clock_timer, 1);
             page_clock_set_clock_confirm = 2;
         } else {
-            sprintf(buf, "#FFFF00 %s...#", _lang("Click to confirm or Scroll to cancel"));
+            snprintf(buf, sizeof(buf), "#FFFF00 %s...#", _lang("Click to confirm or Scroll to cancel"));
             lv_label_set_text(page_clock_items[ITEM_SET_CLOCK].data.obj, buf);
             page_clock_set_clock_confirm = 1;
         }

--- a/src/ui/page_common.c
+++ b/src/ui/page_common.c
@@ -177,7 +177,7 @@ void create_slider_item_compact(slider_group_t *slider_group, lv_obj_t *parent, 
     slider_group->label = lv_label_create(parent);
     char buf[25];
     memset(buf, 0, sizeof(buf));
-    sprintf(buf, "%d", default_value);
+    snprintf(buf, sizeof(buf), "%d", default_value);
     lv_label_set_text(slider_group->label, buf);
     lv_obj_set_style_text_font(slider_group->label, font, 0);
     lv_obj_set_style_text_align(slider_group->label, LV_TEXT_ALIGN_LEFT, 0);
@@ -224,7 +224,7 @@ void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const ch
     slider_group->label = lv_label_create(parent);
     char buf[25];
     memset(buf, 0, sizeof(buf));
-    sprintf(buf, "%d", default_value);
+    snprintf(buf, sizeof(buf), "%d", default_value);
     lv_label_set_text(slider_group->label, buf);
     lv_obj_set_style_text_font(slider_group->label, &lv_font_montserrat_26, 0);
     lv_obj_set_style_text_align(slider_group->label, LV_TEXT_ALIGN_CENTER, 0);
@@ -238,7 +238,7 @@ void create_slider_item(slider_group_t *slider_group, lv_obj_t *parent, const ch
 
 void update_slider_item_with_value(slider_group_t *slider_group, int value) {
     char str[20];
-    sprintf(str, "%d", value);
+    snprintf(str, sizeof(str), "%d", value);
     lv_slider_set_value(slider_group->slider, value, LV_ANIM_OFF);
     lv_label_set_text(slider_group->label, str);
 }

--- a/src/ui/page_elrs.c
+++ b/src/ui/page_elrs.c
@@ -98,13 +98,13 @@ static lv_obj_t *page_elrs_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     create_btn_group_item(&elrs_group, cont, 2, _lang("Backpack"), _lang("On"), _lang("Off"), "", "", POS_PWR);
     btn_group_set_sel(&elrs_group, !g_setting.elrs.enable);
-    sprintf(buf, "%s VTX", _lang("Send"));
+    snprintf(buf, sizeof(buf), "%s VTX", _lang("Send"));
     btn_vtx_send = create_label_item(cont, buf, 1, POS_VTX, 1);
     btn_wifi = create_label_item(cont, "WiFi", 1, POS_WIFI, 1);
     label_wifi_status = create_label_item(cont, _lang("Click to start"), 2, POS_WIFI, 1);
     btn_bind = create_label_item(cont, _lang("Bind"), 1, POS_BIND, 1);
     label_bind_status = create_label_item(cont, _lang("Click to start"), 2, POS_BIND, 1);
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, POS_BACK, 1);
 
     cancel_label = lv_label_create(cont);
@@ -142,7 +142,7 @@ static void elrs_status_timer(struct _lv_timer_t *timer) {
     }
     lv_timer_del(timer);
     if (status[0] & 4) {
-        sprintf(label, "UID: %d,%d,%d,%d,%d,%d", status[1], status[2], status[3], status[4], status[5], status[6]);
+        snprintf(label, sizeof(label), "UID: %d,%d,%d,%d,%d,%d", status[1], status[2], status[3], status[4], status[5], status[6]);
         lv_label_set_text(label_bind_status, label);
     }
 }
@@ -188,28 +188,28 @@ static void page_elrs_on_click(uint8_t key, int sel) {
         msp_channel_update();
     } else if (sel == POS_WIFI) // start ESP Wifi
     {
-        sprintf(buf, "%s...", _lang("Starting"));
+        snprintf(buf, sizeof(buf), "%s...", _lang("Starting"));
         lv_label_set_text(label_wifi_status, buf);
         msp_send_packet(MSP_SET_MODE, MSP_PACKET_COMMAND, 1, (uint8_t *)"W");
         lv_timer_handler();
         if (msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"P", 1000) != AWAIT_SUCCESS) {
-            sprintf(buf, "#FF0000 %s#", _lang("FAILED"));
+            snprintf(buf, sizeof(buf), "#FF0000 %s#", _lang("FAILED"));
             lv_label_set_text(label_wifi_status, buf);
         } else {
-            sprintf(buf, "#00FF00 %s#", _lang("Success"));
+            snprintf(buf, sizeof(buf), "#00FF00 %s#", _lang("Success"));
             lv_label_set_text(label_wifi_status, buf);
         }
     } else if (sel == POS_BIND) // start ESP bind
     {
-        sprintf(buf, "%s...", _lang("Starting"));
+        snprintf(buf, sizeof(buf), "%s...", _lang("Starting"));
         lv_label_set_text(label_bind_status, buf);
         msp_send_packet(MSP_SET_MODE, MSP_PACKET_COMMAND, 1, (uint8_t *)"B");
         lv_timer_handler();
         if (msp_await_resposne(MSP_SET_MODE, 1, (uint8_t *)"P", 1000) != AWAIT_SUCCESS) {
-            sprintf(buf, "#FF0000 %s#", _lang("FAILED"));
+            snprintf(buf, sizeof(buf), "#FF0000 %s#", _lang("FAILED"));
             lv_label_set_text(label_bind_status, buf);
         } else {
-            sprintf(buf, "%s...", _lang("Binding"));
+            snprintf(buf, sizeof(buf), "%s...", _lang("Binding"));
             lv_label_set_text(label_bind_status, buf);
             lv_obj_clear_flag(cancel_label, LV_OBJ_FLAG_HIDDEN);
             binding = true;
@@ -219,20 +219,20 @@ static void page_elrs_on_click(uint8_t key, int sel) {
             pthread_mutex_lock(&lvgl_mutex);
             switch (response) {
             case AWAIT_SUCCESS:
-                sprintf(buf, "#00FF00 %s#", _lang("Success"));
+                snprintf(buf, sizeof(buf), "#00FF00 %s#", _lang("Success"));
                 lv_label_set_text(label_bind_status, buf);
                 request_uid();
                 break;
             case AWAIT_TIMEDOUT:
-                sprintf(buf, "#FEBE00 %s#", _lang("Timeout"));
+                snprintf(buf, sizeof(buf), "#FEBE00 %s#", _lang("Timeout"));
                 lv_label_set_text(label_bind_status, buf);
                 break;
             case AWAIT_FAILED:
-                sprintf(buf, "#FF0000 %s#", _lang("FAILED"));
+                snprintf(buf, sizeof(buf), "#FF0000 %s#", _lang("FAILED"));
                 lv_label_set_text(label_bind_status, buf);
                 break;
             case AWAIT_CANCELLED:
-                sprintf(buf, "#FEBE00 %s#", _lang("Cancelled"));
+                snprintf(buf, sizeof(buf), "#FEBE00 %s#", _lang("Cancelled"));
                 lv_label_set_text(label_bind_status, buf);
                 // repower the module and re-request binding info
                 disable_esp32();

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -53,7 +53,7 @@ static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Fans"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Fans"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -74,7 +74,7 @@ static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_slider_item(&slider_group[1], cont, _lang("Side Fans"), MAX_FAN_SIDE, 2, 2);
     lv_slider_set_range(slider_group[1].slider, MIN_FAN_SIDE, MAX_FAN_SIDE);
 
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, 3, 1);
 
     btn_group_set_sel(&btn_group_fans, !g_setting.fans.auto_mode);
@@ -82,9 +82,9 @@ static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_slider_set_value(slider_group[0].slider, g_setting.fans.top_speed, LV_ANIM_OFF);
     lv_slider_set_value(slider_group[1].slider, g_setting.fans.left_speed, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", g_setting.fans.top_speed);
+    snprintf(buf, sizeof(buf), "%d", g_setting.fans.top_speed);
     lv_label_set_text(slider_group[0].label, buf);
-    sprintf(buf, "%d", g_setting.fans.left_speed);
+    snprintf(buf, sizeof(buf), "%d", g_setting.fans.left_speed);
     lv_label_set_text(slider_group[1].label, buf);
 
     update_visibility();
@@ -101,7 +101,7 @@ static void fans_top_speed_inc() {
 
     lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", value);
+    snprintf(buf, sizeof(buf), "%d", value);
     lv_label_set_text(slider_group[0].label, buf);
 
     fans_top_setspeed(value);
@@ -118,7 +118,7 @@ static void fans_top_speed_dec() {
         value -= 1;
 
     lv_slider_set_value(slider_group[0].slider, value, LV_ANIM_OFF);
-    sprintf(buf, "%d", value);
+    snprintf(buf, sizeof(buf), "%d", value);
     lv_label_set_text(slider_group[0].label, buf);
 
     fans_top_setspeed(value);
@@ -136,7 +136,7 @@ static void fans_side_speed_inc() {
 
     lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", value);
+    snprintf(buf, sizeof(buf), "%d", value);
     lv_label_set_text(slider_group[1].label, buf);
 
     g_setting.fans.left_speed = value;
@@ -153,7 +153,7 @@ static void fans_side_speed_dec() {
         value -= 1;
 
     lv_slider_set_value(slider_group[1].slider, value, LV_ANIM_OFF);
-    sprintf(buf, "%d", value);
+    snprintf(buf, sizeof(buf), "%d", value);
     lv_label_set_text(slider_group[1].label, buf);
 
     g_setting.fans.left_speed = value;
@@ -250,7 +250,7 @@ void step_topfan() {
     ini_putl("fans", "top_speed", g_setting.fans.top_speed, SETTING_INI);
 
     lv_slider_set_value(slider_group[0].slider, g_setting.fans.top_speed, LV_ANIM_OFF);
-    sprintf(str, "%d", g_setting.fans.top_speed);
+    snprintf(str, sizeof(str), "%d", g_setting.fans.top_speed);
     lv_label_set_text(slider_group[0].label, str);
 }
 

--- a/src/ui/page_fans.c
+++ b/src/ui/page_fans.c
@@ -93,7 +93,7 @@ static lv_obj_t *page_fans_create(lv_obj_t *parent, panel_arr_t *arr) {
 }
 
 static void fans_top_speed_inc() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[0].slider);
 
     if (value < MAX_FAN_TOP)
@@ -111,7 +111,7 @@ static void fans_top_speed_inc() {
 }
 
 static void fans_top_speed_dec() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[0].slider);
 
     if (value > MIN_FAN_TOP)
@@ -128,7 +128,7 @@ static void fans_top_speed_dec() {
 }
 
 static void fans_side_speed_inc() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[1].slider);
 
     if (value < MAX_FAN_SIDE)
@@ -146,7 +146,7 @@ static void fans_side_speed_inc() {
 }
 
 static void fans_side_speed_dec() {
-    char buf[5];
+    char buf[12];
     int32_t value = lv_slider_get_value(slider_group[1].slider);
 
     if (value > MIN_FAN_SIDE)

--- a/src/ui/page_focus_chart.c
+++ b/src/ui/page_focus_chart.c
@@ -21,12 +21,12 @@ lv_obj_t *page_focus_chart_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Focus Chart"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Focus Chart"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_menu_cont_create(section);
     lv_obj_t *desc_label = lv_label_create(cont);
-    sprintf(buf, "%s.\n%s.", _lang("Click the Enter Button to display the Back Focusing Chart"), _lang("Click the Enter Button again to exit"));
+    snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Click the Enter Button to display the Back Focusing Chart"), _lang("Click the Enter Button again to exit"));
     lv_label_set_text(desc_label, buf);
     lv_obj_set_style_text_font(desc_label, &lv_font_montserrat_26, 0);
     lv_obj_set_style_text_color(desc_label, lv_color_make(255, 255, 255), 0);

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -233,7 +233,7 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
 
 static void ht_angle_inc(void) {
     int32_t value = 0;
-    char buf[5];
+    char buf[12];
 
     value = lv_slider_get_value(slider_group.slider);
     if (value < 360)
@@ -251,7 +251,7 @@ static void ht_angle_inc(void) {
 
 static void ht_angle_dec(void) {
     int32_t value = 0;
-    char buf[5];
+    char buf[12];
 
     value = lv_slider_get_value(slider_group.slider);
     if (value > 0)

--- a/src/ui/page_headtracker.c
+++ b/src/ui/page_headtracker.c
@@ -143,7 +143,7 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Head Tracker"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Head Tracker"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -180,7 +180,7 @@ static lv_obj_t *page_headtracker_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_slider_item(&slider_group, cont, _lang("Max Angle"), 360, g_setting.ht.max_angle, 4);
     lv_slider_set_range(slider_group.slider, 0, 360);
 
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, 5, 1);
 
     btn_group_set_sel(&btn_group, !g_setting.ht.enable);
@@ -241,7 +241,7 @@ static void ht_angle_inc(void) {
 
     lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", value);
+    snprintf(buf, sizeof(buf), "%d", value);
     lv_label_set_text(slider_group.label, buf);
 
     ht_set_maxangle(value);
@@ -259,7 +259,7 @@ static void ht_angle_dec(void) {
 
     lv_slider_set_value(slider_group.slider, value, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", value);
+    snprintf(buf, sizeof(buf), "%d", value);
     lv_label_set_text(slider_group.label, buf);
 
     ht_set_maxangle(value);
@@ -305,7 +305,7 @@ static void page_headtracker_on_click_page1(uint8_t key, int sel) {
 
         update_visibility(curr_page);
     } else if (sel == 2) {
-        sprintf(buf, "%s...", _lang("Calibrating"));
+        snprintf(buf, sizeof(buf), "%s...", _lang("Calibrating"));
         lv_label_set_text(label_cali, buf);
         lv_timer_handler();
         ht_calibrate();
@@ -331,7 +331,7 @@ static void page_headtracker_on_click_page2(uint8_t key, int sel) {
         g_setting.ht.alarm_state = btn_group_get_sel(&alarm_state);
         ini_putl("ht", "alarm_state", g_setting.ht.alarm_state, SETTING_INI);
     } else if (sel == 2) {
-        sprintf(buf, "%s...", "Updating Angle");
+        snprintf(buf, sizeof(buf), "%s...", "Updating Angle");
         lv_label_set_text(label_alarm_angle, buf);
         set_alarm_angle_timer = lv_timer_create(page_headtracker_set_alarm_angle_timer_cb, 1000, NULL);
         lv_timer_set_repeat_count(set_alarm_angle_timer, 1);

--- a/src/ui/page_imagesettings.c
+++ b/src/ui/page_imagesettings.c
@@ -38,7 +38,7 @@ static lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Image Setting"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Image Setting"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -57,10 +57,10 @@ static lv_obj_t *page_imagesettings_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_slider_item(&slider_group1, cont, _lang("Brightness"), 78, g_setting.image.brightness, 1);
     create_slider_item(&slider_group2, cont, _lang("Saturation"), 47, g_setting.image.saturation, 2);
     create_slider_item(&slider_group3, cont, _lang("Contrast"), 47, g_setting.image.contrast, 3);
-    sprintf(buf, "OLED %s", _lang("Auto Off"));
+    snprintf(buf, sizeof(buf), "OLED %s", _lang("Auto Off"));
     create_slider_item(&slider_group4, cont, buf, 3, g_setting.image.auto_off, 4);
 
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, 5, 1);
 
     lv_obj_t *label2 = lv_label_create(cont);
@@ -83,26 +83,26 @@ void set_slider_value() {
     //	LOGI("set_slider_value %d %d %d %d.",g_setting.image.oled,g_setting.image.brightness,
     //											 g_setting.image.saturation,g_setting.image.contrast);
 
-    sprintf(buf, "%d", g_setting.image.oled);
+    snprintf(buf, sizeof(buf), "%d", g_setting.image.oled);
     lv_label_set_text(slider_group.label, buf);
     lv_slider_set_value(slider_group.slider, g_setting.image.oled, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", g_setting.image.brightness);
+    snprintf(buf, sizeof(buf), "%d", g_setting.image.brightness);
     lv_label_set_text(slider_group1.label, buf);
     lv_slider_set_value(slider_group1.slider, g_setting.image.brightness, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", g_setting.image.saturation);
+    snprintf(buf, sizeof(buf), "%d", g_setting.image.saturation);
     lv_label_set_text(slider_group2.label, buf);
     lv_slider_set_value(slider_group2.slider, g_setting.image.saturation, LV_ANIM_OFF);
 
-    sprintf(buf, "%d", g_setting.image.contrast);
+    snprintf(buf, sizeof(buf), "%d", g_setting.image.contrast);
     lv_label_set_text(slider_group3.label, buf);
     lv_slider_set_value(slider_group3.slider, g_setting.image.contrast, LV_ANIM_OFF);
 
     if (g_setting.image.auto_off == 4)
         strcpy(buf, _lang("Never"));
     else
-        sprintf(buf, "%d %s", g_setting.image.auto_off * 2 + 1, _lang("min"));
+        snprintf(buf, sizeof(buf), "%d %s", g_setting.image.auto_off * 2 + 1, _lang("min"));
     lv_label_set_text(slider_group4.label, buf);
     lv_slider_set_value(slider_group4.slider, g_setting.image.auto_off, LV_ANIM_OFF);
 }

--- a/src/ui/page_input.c
+++ b/src/ui/page_input.c
@@ -221,7 +221,7 @@ static lv_obj_t *page_input_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, contentWidth + 93, contentHeight + 294);
 
-    sprintf(buf, "%s:", _lang("Input"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Input"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *content = lv_obj_create(section);
@@ -236,41 +236,41 @@ static lv_obj_t *page_input_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     create_select_item(arr, content);
 
-    sprintf(buf, "%s:", _lang("Roller"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Roller"));
     create_label_item(content, buf, 1, ROLLER, 1);
     pageItems[ROLLER] = create_dropdown_item(content, rollerOptionsStr, 2, ROLLER, 320, row_dsc[ROLLER], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
     lv_dropdown_set_selected(pageItems[ROLLER], rollerIndexFromId(g_setting.inputs.roller));
 
-    sprintf(buf, "%s:", _lang("Left short"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Left short"));
     create_label_item(content, buf, 1, LEFT_SHORT, 1);
     pageItems[LEFT_SHORT] = create_dropdown_item(content, btnOptionsStr, 2, LEFT_SHORT, 320, row_dsc[LEFT_SHORT], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
     lv_dropdown_set_selected(pageItems[LEFT_SHORT], btnIndexFromId(g_setting.inputs.left_click));
 
-    sprintf(buf, "%s:", _lang("Left long"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Left long"));
     create_label_item(content, buf, 1, LEFT_LONG, 1);
     pageItems[LEFT_LONG] = create_dropdown_item(content, btnOptionsStr, 2, LEFT_LONG, 320, row_dsc[LEFT_LONG], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
     lv_dropdown_set_selected(pageItems[LEFT_LONG], btnIndexFromId(g_setting.inputs.left_press));
 
-    sprintf(buf, "%s:", _lang("Right short"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Right short"));
     create_label_item(content, buf, 1, RIGHT_SHORT, 1);
     pageItems[RIGHT_SHORT] = create_dropdown_item(content, btnOptionsStr, 2, RIGHT_SHORT, 320, row_dsc[RIGHT_SHORT], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
     lv_dropdown_set_selected(pageItems[RIGHT_SHORT], btnIndexFromId(g_setting.inputs.right_click));
 
-    sprintf(buf, "%s:", _lang("Right long"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Right long"));
     create_label_item(content, buf, 1, RIGHT_LONG, 1);
     pageItems[RIGHT_LONG] = create_dropdown_item(content, btnOptionsStr, 2, RIGHT_LONG, 320, row_dsc[RIGHT_LONG], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
     lv_dropdown_set_selected(pageItems[RIGHT_LONG], btnIndexFromId(g_setting.inputs.right_press));
 
-    sprintf(buf, "%s:", _lang("Right double"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Right double"));
     create_label_item(content, buf, 1, RIGHT_DOUBLE, 1);
     pageItems[RIGHT_DOUBLE] = create_dropdown_item(content, btnOptionsStr, 2, RIGHT_DOUBLE, 320, row_dsc[RIGHT_DOUBLE], 2, 10, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
     lv_dropdown_set_selected(pageItems[RIGHT_DOUBLE], btnIndexFromId(g_setting.inputs.right_double_click));
 
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     pageItems[BACK_BTN] = create_label_item(content, buf, 1, BACK_BTN, 1);
 
     lv_obj_t *label = lv_label_create(content);
-    sprintf(buf, "*%s\n%s",
+    snprintf(buf, sizeof(buf), "*%s\n%s",
             _lang("Settings apply to video mode only"),
             _lang("'Toggle source' will switch between HDZero and Expansion module"));
     lv_label_set_text(label, buf);

--- a/src/ui/page_osd.c
+++ b/src/ui/page_osd.c
@@ -63,12 +63,12 @@ static lv_obj_t *page_osd_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     // create menu entries
     create_label_item(cont, _lang("Adjust OSD Elements"), 1, ROW_ADJUST_OSD_ELEMENTS, 1);
-    sprintf(buf, "OSD %s", _lang("Orbit"));
+    snprintf(buf, sizeof(buf), "OSD %s", _lang("Orbit"));
     create_btn_group_item(&btn_group_osd_orbit, cont, 3, buf, _lang("Off"), _lang("Min"), _lang("Max"), "", ROW_OSD_ORBIT);
-    sprintf(buf, "OSD %s", _lang("Mode"));
+    snprintf(buf, sizeof(buf), "OSD %s", _lang("Mode"));
     create_btn_group_item(&btn_group_osd_mode, cont, 2, buf, "4x3", "16x9", "", "", ROW_OSD_MODE);
     create_btn_group_item(&btn_group_osd_startup_visibility, cont, 3, _lang("At Startup"), _lang("Show"), _lang("Hide"), _lang("Last"), "", ROW_OSD_STARTUP_VISIBILITY);
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, ROW_BACK, 1);
 
     lv_obj_t *label_user_hint = lv_label_create(cont);

--- a/src/ui/page_playback.c
+++ b/src/ui/page_playback.c
@@ -72,7 +72,7 @@ static lv_obj_t *page_playback_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1142, 894);
 
-    sprintf(buf, "%s:", _lang("Playback"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Playback"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -119,7 +119,7 @@ static lv_obj_t *page_playback_create(lv_obj_t *parent, panel_arr_t *arr) {
     }
 
     lv_obj_t *label = lv_label_create(cont);
-    sprintf(buf, "*%s\n**%s", _lang("Long press the Enter button to exit"), _lang("Long press the Func button to delete"));
+    snprintf(buf, sizeof(buf), "*%s\n**%s", _lang("Long press the Enter button to exit"), _lang("Long press the Func button to delete"));
     lv_label_set_text(label, buf);
     lv_obj_set_style_text_font(label, &lv_font_montserrat_16, 0);
     lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, 0);
@@ -149,9 +149,9 @@ static void show_pb_item(uint8_t pos, char *label, bool star) {
     lv_obj_set_pos(pb_ui[pos]._label, labelPosX, labelPosY);
     lv_obj_set_pos(pb_ui[pos]._arrow, labelPosX - lv_obj_get_width(pb_ui[pos]._arrow) - 5, labelPosY);
 
-    sprintf(fname, "%s/%s." REC_packJPG, TMP_DIR, label);
+    snprintf(fname, sizeof(fname), "%s/%s." REC_packJPG, TMP_DIR, label);
     if (fs_file_exists(fname))
-        sprintf(fname, "A:%s/%s." REC_packJPG, TMP_DIR, label);
+        snprintf(fname, sizeof(fname), "A:%s/%s." REC_packJPG, TMP_DIR, label);
     else
         osd_resource_path(fname, "%s", OSD_RESOURCE_720, DEF_VIDEOICON);
     lv_img_set_src(pb_ui[pos]._img, fname);
@@ -244,7 +244,7 @@ static int walk_sdcard() {
             continue;
         }
 
-        sprintf(fname, "%s%s", MEDIA_FILES_DIR, in_file->d_name);
+        snprintf(fname, sizeof(fname), "%s%s", MEDIA_FILES_DIR, in_file->d_name);
 
         long size = fs_filesize(fname);
         size >>= 20; // in MB
@@ -280,7 +280,7 @@ static int walk_sdcard() {
     free(namelist);
 
     // copy all thumbnail files to /tmp
-    sprintf(fname, "cp %s*." REC_packJPG " %s", MEDIA_FILES_DIR, TMP_DIR);
+    snprintf(fname, sizeof(fname), "cp %s*." REC_packJPG " %s", MEDIA_FILES_DIR, TMP_DIR);
     system_exec(fname);
 
     return media_db.count;
@@ -382,13 +382,13 @@ static void mark_video_file(int const seq) {
 
     char cmd[256];
     char newLabel[68];
-    sprintf(newLabel, "%s%s", REC_hotPREFIX, pnode->label);
+    snprintf(newLabel, sizeof(newLabel), "%s%s", REC_hotPREFIX, pnode->label);
 
-    sprintf(cmd, "mv %s%s %s%s.%s", MEDIA_FILES_DIR, pnode->filename, MEDIA_FILES_DIR, newLabel, pnode->ext);
+    snprintf(cmd, sizeof(cmd), "mv %s%s %s%s.%s", MEDIA_FILES_DIR, pnode->filename, MEDIA_FILES_DIR, newLabel, pnode->ext);
     system_exec(cmd);
-    sprintf(cmd, "mv %s%s." REC_packJPG " %s%s." REC_packJPG, MEDIA_FILES_DIR, pnode->label, MEDIA_FILES_DIR, newLabel);
+    snprintf(cmd, sizeof(cmd), "mv %s%s." REC_packJPG " %s%s." REC_packJPG, MEDIA_FILES_DIR, pnode->label, MEDIA_FILES_DIR, newLabel);
     system_exec(cmd);
-    sprintf(cmd, "mv %s%s" REC_starSUFFIX " %s%s.%s" REC_starSUFFIX, MEDIA_FILES_DIR, pnode->filename, MEDIA_FILES_DIR, newLabel, pnode->ext);
+    snprintf(cmd, sizeof(cmd), "mv %s%s" REC_starSUFFIX " %s%s.%s" REC_starSUFFIX, MEDIA_FILES_DIR, pnode->filename, MEDIA_FILES_DIR, newLabel, pnode->ext);
     system_exec(cmd);
 
     walk_sdcard();
@@ -404,7 +404,7 @@ static void delete_video_file(int seq) {
     }
 
     char cmd[128];
-    sprintf(cmd, "rm %s%s.*", MEDIA_FILES_DIR, pnode->label);
+    snprintf(cmd, sizeof(cmd), "rm %s%s.*", MEDIA_FILES_DIR, pnode->label);
 
     if (system_exec(cmd) != -1) {
         walk_sdcard();

--- a/src/ui/page_power.c
+++ b/src/ui/page_power.c
@@ -58,12 +58,12 @@ static void page_power_update_cell_count() {
     LOGI("cell_count:%d", g_battery.type);
     ini_putl("power", "cell_count", g_battery.type, SETTING_INI);
 
-    sprintf(str, "%dS", g_battery.type);
+    snprintf(str, sizeof(str), "%dS", g_battery.type);
     lv_label_set_text(label_cell_count, str);
 
     lv_slider_set_value(slider_group_cell_count.slider, g_battery.type, LV_ANIM_OFF);
     char buf[5];
-    sprintf(buf, "%d", g_battery.type);
+    snprintf(buf, sizeof(buf), "%d", g_battery.type);
     lv_label_set_text(slider_group_cell_count.label, buf);
 
     const bool isAutoCellCount = btn_group_cell_count_mode.current == 0;
@@ -81,7 +81,7 @@ static void page_power_update_calibration_offset() {
 
     lv_slider_set_value(slider_group_calibration_offset.slider, g_battery.offset, LV_ANIM_OFF);
     char buf[7];
-    sprintf(buf, "%.2fV", g_battery.offset / 1000.0);
+    snprintf(buf, sizeof(buf), "%.2fV", g_battery.offset / 1000.0);
     lv_label_set_text(slider_group_calibration_offset.label, buf);
 }
 
@@ -100,7 +100,7 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1063, 984);
 
-    sprintf(buf, "%s:", _lang("Power"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Power"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -128,25 +128,25 @@ static lv_obj_t *page_power_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     // Batch 2 goggles only
     if (getHwRevision() >= HW_REV_2) {
-        sprintf(buf, "%s %s", _lang("AnalogRX"), _lang("Power"));
+        snprintf(buf, sizeof(buf), "%s %s", _lang("AnalogRX"), _lang("Power"));
         create_btn_group_item(&btn_group_power_ana, cont, 2, buf, _lang("On"), _lang("Auto"), "", "", ROW_POWER_ANA);
     }
 
     // Back entry
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, pp_power.p_arr.max - 1, 1);
 
     // set menu entry min/max values and labels
     char str[6];
-    sprintf(str, "%.2f", g_setting.power.voltage / 1000.0);
+    snprintf(str, sizeof(buf), "%.2f", g_setting.power.voltage / 1000.0);
     lv_slider_set_range(slider_group_cell_voltage.slider, WARNING_CELL_VOLTAGE_MIN, WARNING_CELL_VOLTAGE_MAX);
     lv_label_set_text(slider_group_cell_voltage.label, str);
 
-    sprintf(str, "%d", g_setting.power.cell_count);
+    snprintf(str, sizeof(buf), "%d", g_setting.power.cell_count);
     lv_slider_set_range(slider_group_cell_count.slider, CELL_MIN_COUNT, CELL_MAX_COUNT);
     lv_label_set_text(slider_group_cell_count.label, str);
 
-    sprintf(str, "%.2fV", g_setting.power.calibration_offset / 1000.0);
+    snprintf(str, sizeof(buf), "%.2fV", g_setting.power.calibration_offset / 1000.0);
     lv_slider_set_range(slider_group_calibration_offset.slider, CALIBRATION_OFFSET_MIN, CALIBRATION_OFFSET_MAX);
     lv_label_set_text(slider_group_calibration_offset.label, str);
 
@@ -198,7 +198,7 @@ static void power_warning_voltage_inc(void) {
     lv_slider_set_value(slider_group_cell_voltage.slider, value, LV_ANIM_OFF);
 
     char buf[6];
-    sprintf(buf, "%.2f", value / 1000.0);
+    snprintf(buf, sizeof(buf), "%.2f", value / 1000.0);
     lv_label_set_text(slider_group_cell_voltage.label, buf);
 
     g_setting.power.voltage = value;
@@ -215,7 +215,7 @@ static void power_warning_voltage_dec(void) {
 
     lv_slider_set_value(slider_group_cell_voltage.slider, value, LV_ANIM_OFF);
     char buf[6];
-    sprintf(buf, "%.2f", value / 1000.0);
+    snprintf(buf, sizeof(buf), "%.2f", value / 1000.0);
     lv_label_set_text(slider_group_cell_voltage.label, buf);
 
     g_setting.power.voltage = value;

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -51,7 +51,7 @@ static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Record Option"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Record Option"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -72,7 +72,7 @@ static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_btn_group_item(&btn_group_record_audio, cont, 2, _lang("Record Audio"), _lang("Yes"), _lang("No"), "", "", 3);
     create_btn_group_item(&btn_group_audio_source, cont, 3, _lang("Audio Source"), _lang("Mic"), _lang("Line In"), _lang("A/V In"), "", 4);
     create_btn_group_item(&btn_group_file_naming, cont, 2, _lang("Naming Scheme"), _lang("Digits"), _lang("Date"), "", "", 5);
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, 6, 1);
 
     btn_group_set_sel(&btn_group_record_mode, g_setting.record.mode_manual ? 1 : 0);

--- a/src/ui/page_scannow.c
+++ b/src/ui/page_scannow.c
@@ -316,7 +316,7 @@ int8_t scan_now(void) {
     uint8_t valid_index;
     char buf[128];
 
-    sprintf(buf, "%s...", _lang("Scanning"));
+    snprintf(buf, sizeof(buf), "%s...", _lang("Scanning"));
     lv_label_set_text(label, buf);
     lv_bar_set_value(progressbar, 0, LV_ANIM_OFF);
     lv_timer_handler();

--- a/src/ui/page_sleep.c
+++ b/src/ui/page_sleep.c
@@ -20,12 +20,12 @@ lv_obj_t *page_sleep_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Go Sleep"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Go Sleep"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_menu_cont_create(section);
     lv_obj_t *desc_label = lv_label_create(cont);
-    sprintf(buf, "%s.\n%s.",
+    snprintf(buf, sizeof(buf), "%s.\n%s.",
             _lang("Click the Enter Button to go sleep"),
             _lang("Click any button to exit sleep mode"));
     lv_label_set_text(desc_label, buf);

--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -43,7 +43,7 @@ static lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Source"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Source"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -59,9 +59,9 @@ static lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_select_item(arr, cont);
 
     label[0] = create_label_item(cont, "HDZero", 1, 0, 3);
-    sprintf(buf, "HDMI %s", _lang("In"));
+    snprintf(buf, sizeof(buf), "HDMI %s", _lang("In"));
     label[1] = create_label_item(cont, buf, 1, 1, 3);
-    sprintf(buf, "AV %s", _lang("In"));
+    snprintf(buf, sizeof(buf), "AV %s", _lang("In"));
     label[2] = create_label_item(cont, buf, 1, 2, 3);
     label[3] = create_label_item(cont, _lang("Expansion Module"), 1, 3, 3);
 
@@ -74,7 +74,7 @@ static lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
     create_btn_group_item(&btn_group2, cont, 2, _lang("HDZero BW"), _lang("Wide"), _lang("Narrow"), "", "", 6);
     btn_group_set_sel(&btn_group2, g_setting.source.hdzero_bw);
 
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     if (g_setting.storage.selftest) {
         pp_source.p_arr.max = 9;
         label[4] = create_label_item(cont, "OLED Pattern: Normal", 1, 7, 3);
@@ -101,32 +101,32 @@ void source_status_timer() {
     ch = g_setting.scan.channel & 0x7F;
     if (g_setting.source.hdzero_band == SETTING_SOURCES_HDZERO_BAND_RACEBAND) {
         if (ch <= 8) {
-            sprintf(buf, "HDZero: R%d", ch);
+            snprintf(buf, sizeof(buf), "HDZero: R%d", ch);
         } else {
-            sprintf(buf, "HDZero: F%d", (ch - 8) * 2);
+            snprintf(buf, sizeof(buf), "HDZero: F%d", (ch - 8) * 2);
         }
     } else {
         if (ch > 8) {
             g_setting.scan.channel = 1;
         }
-        sprintf(buf, "HDZero: L%d", ch);
+        snprintf(buf, sizeof(buf), "HDZero: L%d", ch);
     }
     lv_label_set_text(label[0], buf);
 
-    sprintf(buf, "HDMI %s: %s", _lang("In"), state2string(g_source_info.hdmi_in_status));
+    snprintf(buf, sizeof(buf), "HDMI %s: %s", _lang("In"), state2string(g_source_info.hdmi_in_status));
     lv_label_set_text(label[1], buf);
 
-    sprintf(buf, "AV %s: %s", _lang("In"), state2string(g_source_info.av_in_status));
+    snprintf(buf, sizeof(buf), "AV %s: %s", _lang("In"), state2string(g_source_info.av_in_status));
     lv_label_set_text(label[2], buf);
 
-    sprintf(buf, "%s: %s", _lang("Expansion Module"), state2string(g_source_info.av_bay_status));
+    snprintf(buf, sizeof(buf), "%s: %s", _lang("Expansion Module"), state2string(g_source_info.av_bay_status));
     lv_label_set_text(label[3], buf);
 
     if (g_setting.storage.selftest && label[3]) {
         uint8_t oled_tm = oled_tst_mode & 0x0F;
         char *pattern_label[6] = {"Normal", "Color Bar", "Grid", "All Black", "All White", "Boot logo"};
         char str[32];
-        sprintf(str, "OLED Pattern: %s", pattern_label[oled_tm]);
+        snprintf(str, sizeof(buf), "OLED Pattern: %s", pattern_label[oled_tm]);
         lv_label_set_text(label[4], str);
     }
 }

--- a/src/ui/page_storage.c
+++ b/src/ui/page_storage.c
@@ -292,28 +292,28 @@ static void page_storage_format_sd_timer_cb(struct _lv_timer_t *timer) {
 
     switch (page_storage_format_sd()) {
     case FMC_SUCCESS:
-        sprintf(buf, "%s.\n%s.", _lang("Format was successful"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Format was successful"), _lang("Press click to exit"));
         break;
     case FMC_FAILURE:
-        sprintf(buf, "%s.\n%s.", _lang("Format has failed"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Format has failed"), _lang("Press click to exit"));
         break;
     case FMC_ERR_SDCARD_NOT_INSERTED:
-        sprintf(buf, "%s.\n%s.", _lang("Please insert a SD Card"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Please insert a SD Card"), _lang("Press click to exit"));
         break;
     case FMC_ERR_RESULTS_NOT_EXTRACTED:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to extract results"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to extract results"), _lang("Press click to exit"));
         break;
     case FMC_ERR_RESULTS_NOT_ACCESSIBLE:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to access results"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to access results"), _lang("Press click to exit"));
         break;
     case FMC_ERR_RESULTS_FILE_MISSING:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to generate results"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to generate results"), _lang("Press click to exit"));
         break;
     case FMC_ERR_PROCESS_DID_NOT_START:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to start format"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to start format"), _lang("Press click to exit"));
         break;
     default:
-        sprintf(buf, "%s.\n%s.", _lang("Unsupported status code"), _lang("Press click to exit"));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Unsupported status code"), _lang("Press click to exit"));
         break;
     }
 
@@ -328,31 +328,31 @@ static void page_storage_repair_sd_timer_cb(struct _lv_timer_t *timer) {
     char buf[128];
     switch (page_storage_repair_sd()) {
     case RPC_SUCCESS_NO_CHANGES:
-        sprintf(buf, "%s.\n%s.", _lang("Filesystem is OK"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Filesystem is OK"), _lang("Press click to exit."));
         break;
     case RPC_SUCCESS_CARD_FIXED:
-        sprintf(buf, "%s.\n%s.", _lang("Filesystem was modified and fixed"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Filesystem was modified and fixed"), _lang("Press click to exit."));
         break;
     case RPC_ERR_SDCARD_NOT_INSERTED:
-        sprintf(buf, "%s.\n%s.", _lang("Please insert a SD Card"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Please insert a SD Card"), _lang("Press click to exit."));
         break;
     case RPC_ERR_RESULTS_NOT_EXTRACTED:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to extract results"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to extract results"), _lang("Press click to exit."));
         break;
     case RPC_ERR_RESULTS_NOT_ACCESSIBLE:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to access results"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to access results"), _lang("Press click to exit."));
         break;
     case RPC_ERR_FAILED_TO_REMOUNT_CARD:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to remount SD Card"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to remount SD Card"), _lang("Press click to exit."));
         break;
     case RPC_ERR_RESULTS_FILE_MISSING:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to generate results"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to generate results"), _lang("Press click to exit."));
         break;
     case RPC_ERR_PROCESS_DID_NOT_START:
-        sprintf(buf, "%s.\n%s.", _lang("Failed to start repair"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Failed to start repair"), _lang("Press click to exit."));
         break;
     default:
-        sprintf(buf, "%s.\n%s.", _lang("Unsupported status code"), _lang("Press click to exit."));
+        snprintf(buf, sizeof(buf), "%s.\n%s.", _lang("Unsupported status code"), _lang("Press click to exit."));
         break;
     }
 
@@ -375,7 +375,7 @@ static lv_obj_t *page_storage_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Storage"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Storage"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -396,7 +396,7 @@ static lv_obj_t *page_storage_create(lv_obj_t *parent, panel_arr_t *arr) {
     page_storage.format_sd = create_label_item(cont, _lang("Format SD Card"), 1, 1, 3);
     page_storage.repair_sd = create_label_item(cont, _lang("Repair SD Card"), 1, 2, 3);
     page_storage.clear_dvr = create_label_item(cont, _lang("Clear DVR Folder"), 1, 3, 3);
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     page_storage.back = create_label_item(cont, buf, 1, 4, 1);
 
     page_storage.note = lv_label_create(cont);
@@ -409,12 +409,12 @@ static lv_obj_t *page_storage_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_grid_cell(page_storage.note, LV_GRID_ALIGN_START, 1, 4, LV_GRID_ALIGN_START, 5, 2);
 
     if (g_setting.storage.selftest) {
-        sprintf(buf, "%s,%s.", _lang("Self-Test is enabled"), _lang("All storage options are disabled"));
+        snprintf(buf, sizeof(buf), "%s,%s.", _lang("Self-Test is enabled"), _lang("All storage options are disabled"));
         lv_label_set_text(page_storage.note, buf);
         disable_controls();
     } else {
         if (fs_file_exists(DEVELOP_SCRIPT) || fs_file_exists(APP_BIN_FILE)) {
-            sprintf(buf, "%s, %s.\n%s:\n%s\n%s",
+            snprintf(buf, sizeof(buf), "%s, %s.\n%s:\n%s\n%s",
                     _lang("Detected files being accessed by SD Card"),
                     _lang("All storage options are disabled"),
                     _lang("Remove the following files from the SD Card and try again"),
@@ -494,11 +494,11 @@ static void page_storage_on_click(uint8_t key, int sel) {
                 page_storage.confirm_format = 2;
                 page_storage_format_sd_timer = lv_timer_create(page_storage_format_sd_timer_cb, 1000, NULL);
                 lv_timer_set_repeat_count(page_storage_format_sd_timer, 1);
-                sprintf(buf, "%s #FF0000 %s...#", _lang("Format SD Card"), _lang("Formatting"));
+                snprintf(buf, sizeof(buf), "%s #FF0000 %s...#", _lang("Format SD Card"), _lang("Formatting"));
                 lv_label_set_text(page_storage.format_sd, buf);
             } else {
                 page_storage.confirm_format = 1;
-                sprintf(buf, "%s #FFFF00 %s...#", _lang("Format SD Card"), _lang("Click to confirm or Scroll to cancel"));
+                snprintf(buf, sizeof(buf), "%s #FFFF00 %s...#", _lang("Format SD Card"), _lang("Click to confirm or Scroll to cancel"));
                 lv_label_set_text(page_storage.format_sd, buf);
             }
         }
@@ -509,12 +509,12 @@ static void page_storage_on_click(uint8_t key, int sel) {
                 page_storage.confirm_repair = 2;
                 page_storage_repair_sd_timer = lv_timer_create(page_storage_repair_sd_timer_cb, 1000, NULL);
                 lv_timer_set_repeat_count(page_storage_repair_sd_timer, 1);
-                sprintf(buf, "%s #FF0000 %s...#", _lang("Repair SD Card"), _lang("Repairing"));
+                snprintf(buf, sizeof(buf), "%s #FF0000 %s...#", _lang("Repair SD Card"), _lang("Repairing"));
                 lv_label_set_text(page_storage.repair_sd, buf);
 
             } else {
                 page_storage.confirm_repair = 1;
-                sprintf(buf, "%s #FFFF00 %s...#", _lang("Repair SD Card"), _lang("Click to confirm or Scroll to cancel"));
+                snprintf(buf, sizeof(buf), "%s #FFFF00 %s...#", _lang("Repair SD Card"), _lang("Click to confirm or Scroll to cancel"));
                 lv_label_set_text(page_storage.repair_sd, buf);
             }
         }
@@ -523,21 +523,21 @@ static void page_storage_on_click(uint8_t key, int sel) {
         if (!page_storage.disable_controls) {
             if (page_storage.confirm_clear) {
                 page_storage.confirm_clear = 2;
-                sprintf(buf, "%s #FF0000 %s...#", _lang("Clear DVR Folder"), _lang("Removing"));
+                snprintf(buf, sizeof(buf), "%s #FF0000 %s...#", _lang("Clear DVR Folder"), _lang("Removing"));
                 lv_label_set_text(page_storage.clear_dvr, buf);
                 lv_timer_handler();
                 LOGI("Clear dvr folder");
                 char buf[256];
-                sprintf(buf, "rm -rf %s%s", REC_diskPATH, REC_packPATH);
+                snprintf(buf, sizeof(buf), "rm -rf %s%s", REC_diskPATH, REC_packPATH);
                 system_exec(buf);
-                sprintf(buf, "%s #FFFF00 %s#", _lang("Clear DVR Folder"), _lang("Done"));
+                snprintf(buf, sizeof(buf), "%s #FFFF00 %s#", _lang("Clear DVR Folder"), _lang("Done"));
                 lv_label_set_text(page_storage.clear_dvr, buf);
                 LOGI("Clear done");
                 page_storage.confirm_clear = 3;
                 g_sdcard_det_req = 1;
             } else {
                 page_storage.confirm_clear = 1;
-                sprintf(buf, "%s #FF0000 %s...#", _lang("Clear DVR Folder"), _lang("Click to confirm or Scroll to cancel"));
+                snprintf(buf, sizeof(buf), "%s #FF0000 %s...#", _lang("Clear DVR Folder"), _lang("Click to confirm or Scroll to cancel"));
                 lv_label_set_text(page_storage.clear_dvr, buf);
             }
         }
@@ -594,7 +594,7 @@ static void *page_storage_repair_thread(void *arg) {
     if (!page_storage.disable_controls) {
         page_storage.is_auto_sd_repair_active = true;
         disable_controls();
-        sprintf(buf, "%s, %s.", _lang("SD Card integrity check is active"), _lang("controls are disabled until process has completed"));
+        snprintf(buf, sizeof(buf), "%s, %s.", _lang("SD Card integrity check is active"), _lang("controls are disabled until process has completed"));
         lv_label_set_text(page_storage.note, buf);
         page_storage_repair_sd();
         enable_controls();

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -225,7 +225,7 @@ static void flash_vtx() {
     char buf[128];
 
     lv_obj_clear_flag(bar_vtx, LV_OBJ_FLAG_HIDDEN);
-    sprintf(buf, "%s...", _lang("Flashing"));
+    snprintf(buf, sizeof(buf), "%s...", _lang("Flashing"));
     lv_label_set_text(btn_vtx, buf);
     lv_timer_handler();
 
@@ -240,17 +240,17 @@ static void flash_vtx() {
 
     if (ret == 1) {
         if (fs_compare_files("/tmp/HDZERO_TX.bin", "/tmp/HDZERO_TX_RB.bin")) {
-            sprintf(buf, "#00FF00 %s#", _lang("SUCCESS"));
+            snprintf(buf, sizeof(buf), "#00FF00 %s#", _lang("SUCCESS"));
             lv_label_set_text(btn_vtx, buf);
         } else {
-            sprintf(buf, "#FF0000 %s#", _lang("Verification failed, try it again"));
+            snprintf(buf, sizeof(buf), "#FF0000 %s#", _lang("Verification failed, try it again"));
             lv_label_set_text(btn_vtx, buf);
         }
     } else if (ret == 2) {
-        sprintf(buf, "$FFFF00 %s.#", _lang("No firmware found"));
+        snprintf(buf, sizeof(buf), "$FFFF00 %s.#", _lang("No firmware found"));
         lv_label_set_text(btn_vtx, buf);
     } else {
-        sprintf(buf, "#FF0000 %s...#", _lang("Failed, check connection"));
+        snprintf(buf, sizeof(buf), "#FF0000 %s...#", _lang("Failed, check connection"));
         lv_label_set_text(btn_vtx, buf);
     }
     lv_timer_handler();
@@ -272,7 +272,7 @@ static void flash_goggle() {
 
     lv_obj_clear_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
 
-    sprintf(buf, "%s... %s... ", _lang("WAIT"), _lang("DO NOT POWER OFF"));
+    snprintf(buf, sizeof(buf), "%s... %s... ", _lang("WAIT"), _lang("DO NOT POWER OFF"));
     lv_label_set_text(btn_goggle, buf);
     lv_timer_handler();
 
@@ -298,13 +298,13 @@ static void flash_goggle() {
         reboot_flag = true;
         lv_timer_handler();
     } else if (ret == 2) {
-        sprintf(buf, "$FFFF00 %s.#", _lang("No firmware found"));
+        snprintf(buf, sizeof(buf), "$FFFF00 %s.#", _lang("No firmware found"));
         lv_label_set_text(btn_goggle, buf);
     } else if (ret == 3) {
-        sprintf(buf, "#FFFF00 %s. %s.#", _lang("Multiple versions been found"), _lang("Keep only one"));
+        snprintf(buf, sizeof(buf), "#FFFF00 %s. %s.#", _lang("Multiple versions been found"), _lang("Keep only one"));
         lv_label_set_text(btn_goggle, buf);
     } else {
-        sprintf(buf, "#FF0000 %s#", _lang("FAILED"));
+        snprintf(buf, sizeof(buf), "#FF0000 %s#", _lang("FAILED"));
         lv_label_set_text(btn_goggle, buf);
     }
     lv_obj_add_flag(bar_goggle, LV_OBJ_FLAG_HIDDEN);
@@ -336,7 +336,7 @@ int generate_current_version(sys_version_t *sys_ver) {
              sys_ver->commit,
              sys_ver->rx, sys_ver->va);
 
-        sprintf(sys_ver->current, "app: %hhu.%hhu.%hhu-%s rx: %u va: %u",
+        snprintf(sys_ver->current, CURRENT_VER_MAX, "app: %hhu.%hhu.%hhu-%s rx: %u va: %u",
                 sys_ver->app_major,
                 sys_ver->app_minor,
                 sys_ver->app_patch,
@@ -349,7 +349,7 @@ int generate_current_version(sys_version_t *sys_ver) {
              sys_ver->app_patch,
              sys_ver->rx, sys_ver->va);
 
-        sprintf(sys_ver->current, "app: %hhu.%hhu.%hhu rx: %u va: %u",
+        snprintf(sys_ver->current, CURRENT_VER_MAX, "app: %hhu.%hhu.%hhu rx: %u va: %u",
                 sys_ver->app_major,
                 sys_ver->app_minor,
                 sys_ver->app_patch,
@@ -504,13 +504,13 @@ static void page_version_fw_scan_for_updates() {
         }
 
         if (has_online_goggle_update || has_online_vtx_update) {
-            sprintf(buf, "%s, %s\n%s.",
+            snprintf(buf, sizeof(buf), "%s, %s\n%s.",
                     _lang("To view release notes"),
                     _lang("select either Update VTX or Update Goggle"),
                     _lang("then press the Func button to display or hide the release notes"));
             lv_label_set_text(label_note, buf);
         } else if (fw_select_goggle.alt_title || fw_select_vtx.alt_title) {
-            sprintf(buf, "%s.", _lang("Remove HDZERO_TX or HDZERO_GOGGLE binary files from the root of\nSD Card in order to install the latest online downloaded firmware files"));
+            snprintf(buf, sizeof(buf), "%s.", _lang("Remove HDZERO_TX or HDZERO_GOGGLE binary files from the root of\nSD Card in order to install the latest online downloaded firmware files"));
             lv_label_set_text(label_note, buf);
         }
     } else {
@@ -546,7 +546,7 @@ static void page_version_release_notes_show(fw_select_t *fw_select) {
                     written += rbytes;
                 }
             } else {
-                sprintf(mbuff, "\n\n%s.", _lang("Visit https://github.com/hdzero for the complete list of changes"));
+                snprintf(mbuff, sizeof(mbuff), "\n\n%s.", _lang("Visit https://github.com/hdzero for the complete list of changes"));
                 break;
             }
         }
@@ -740,7 +740,7 @@ static void page_version_fw_select_create(const char *device, fw_select_t *fw_se
     snprintf(text, sizeof(text), "%s %s", _lang("Update"), device);
 
     fw_select->flash = flash;
-    sprintf(buf, "%s:", _lang("Target"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Target"));
     fw_select->msgbox = create_msgbox_item(device, buf);
     fw_select->container = lv_obj_create(fw_select->msgbox);
 
@@ -760,7 +760,7 @@ static void page_version_fw_select_create(const char *device, fw_select_t *fw_se
     fw_select->page = pp_version.p_arr;
     fw_select->dropdown = create_dropdown_item(fw_select->container, "", 1, 0, 600, 40, 1, 4, LV_GRID_ALIGN_START, &lv_font_montserrat_26);
     fw_select->update = create_label_item(fw_select->container, text, 1, 1, 4);
-    sprintf(text, "< %s", _lang("Back"));
+    snprintf(text, sizeof(text), "< %s", _lang("Back"));
     fw_select->back = create_label_item(fw_select->container, text, 1, 2, 4);
 
     lv_obj_set_style_grid_column_dsc_array(fw_select->msgbox, col_dsc, 0);
@@ -789,7 +789,7 @@ static lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("Firmware"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("Firmware"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -806,14 +806,14 @@ static lv_obj_t *page_version_create(lv_obj_t *parent, panel_arr_t *arr) {
     cur_ver_label = create_label_item(cont, _lang("Current Version"), 1, ROW_CUR_VERSION, 2);
 
     btn_reset_all_settings = create_label_item(cont, _lang("Reset all settings"), 1, ROW_RESET_ALL_SETTINGS, 2);
-    sprintf(buf, "%s VTX", _lang("Update"));
+    snprintf(buf, sizeof(buf), "%s VTX", _lang("Update"));
     btn_vtx = create_label_item(cont, buf, 1, ROW_UPDATE_VTX, 2);
-    sprintf(buf, "%s %s", _lang("Update"), _lang("Goggle"));
+    snprintf(buf, sizeof(buf), "%s %s", _lang("Update"), _lang("Goggle"));
     btn_goggle = create_label_item(cont, buf, 1, ROW_UPDATE_GOGGLE, 2);
-    sprintf(buf, "%s ESP32", _lang("Update"));
+    snprintf(buf, sizeof(buf), "%s ESP32", _lang("Update"));
     btn_esp = create_label_item(cont, buf, 1, ROW_UPDATE_ESP32, 2);
     label_esp = create_label_item(cont, "", 3, ROW_UPDATE_ESP32, 2);
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     create_label_item(cont, buf, 1, ROW_BACK, 1);
 
     bar_vtx = lv_bar_create(cont);
@@ -938,7 +938,7 @@ static void elrs_version_timer(struct _lv_timer_t *timer) {
         return;
     }
     lv_timer_del(timer);
-    sprintf(label, "ver: %s", version);
+    snprintf(label, sizeof(label), "ver: %s", version);
     lv_label_set_text(label_esp, label);
 }
 
@@ -1015,7 +1015,7 @@ static void page_version_on_click(uint8_t key, int sel) {
                 lv_obj_clear_flag(msgbox_settings_reset, LV_OBJ_FLAG_HIDDEN);
                 app_state_push(APP_STATE_USER_INPUT_DISABLED);
             } else {
-                sprintf(buf, "#FFFF00 %s#", _lang("Click to confirm or Scroll to cancel"));
+                snprintf(buf, sizeof(buf), "#FFFF00 %s#", _lang("Click to confirm or Scroll to cancel"));
                 lv_label_set_text(btn_reset_all_settings, buf);
                 reset_all_settings_confirm = CONFIRMATION_CONFIRMED;
             }
@@ -1023,14 +1023,14 @@ static void page_version_on_click(uint8_t key, int sel) {
 
         case ROW_UPDATE_VTX:
             page_version_fw_scan_for_updates();
-            sprintf(buf, "VTX %s", _lang("Firmware"));
+            snprintf(buf, sizeof(buf), "VTX %s", _lang("Firmware"));
             page_version_fw_select_show(buf, &fw_select_vtx);
             break;
 
         case ROW_UPDATE_GOGGLE:
             if (!reboot_flag) {
                 page_version_fw_scan_for_updates();
-                sprintf(buf, "%s %s", _lang("Goggle"), _lang("Firmware"));
+                snprintf(buf, sizeof(buf), "%s %s", _lang("Goggle"), _lang("Firmware"));
                 page_version_fw_select_show(buf, &fw_select_goggle);
             }
             break;
@@ -1038,17 +1038,17 @@ static void page_version_on_click(uint8_t key, int sel) {
         case ROW_UPDATE_ESP32: // flash ESP via SD
             lv_obj_clear_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(label_esp, LV_OBJ_FLAG_HIDDEN);
-            sprintf(buf, "%s...", _lang("Flashing"));
+            snprintf(buf, sizeof(buf), "%s...", _lang("Flashing"));
             lv_label_set_text(btn_esp, buf);
             lv_timer_handler();
             esp_loader_error_t ret = flash_elrs();
             lv_obj_add_flag(bar_esp, LV_OBJ_FLAG_HIDDEN);
             lv_obj_clear_flag(label_esp, LV_OBJ_FLAG_HIDDEN);
             if (ret == ESP_LOADER_SUCCESS) {
-                sprintf(buf, "#00FF00 %s#", _lang("SUCCESS"));
+                snprintf(buf, sizeof(buf), "#00FF00 %s#", _lang("SUCCESS"));
                 lv_label_set_text(btn_esp, buf);
             } else {
-                sprintf(buf, "#FF0000 %s#", _lang("FAILED"));
+                snprintf(buf, sizeof(buf), "#FF0000 %s#", _lang("FAILED"));
                 lv_label_set_text(btn_esp, buf);
             }
             page_version_enter();
@@ -1101,7 +1101,7 @@ void update_current_version() {
     if (bInit) {
         sys_version_t sys_version;
         generate_current_version(&sys_version);
-        sprintf(buf, "%s %s", _lang("Current Version"), sys_version.current);
+        snprintf(buf, sizeof(buf), "%s %s", _lang("Current Version"), sys_version.current);
         lv_label_set_text(cur_ver_label, buf);
         bInit = false;
     }
@@ -1110,13 +1110,13 @@ void update_current_version() {
 void version_update_title() {
     char buf[128];
     update_current_version();
-    sprintf(buf, "%s VTX", _lang("Update"));
+    snprintf(buf, sizeof(buf), "%s VTX", _lang("Update"));
     lv_label_set_text(btn_vtx, buf);
     if (!reboot_flag) {
-        sprintf(buf, "%s %s", _lang("Update"), _lang("Goggle"));
+        snprintf(buf, sizeof(buf), "%s %s", _lang("Update"), _lang("Goggle"));
         lv_label_set_text(btn_goggle, buf);
     }
-    sprintf(buf, "%s ESP32", _lang("Update"));
+    snprintf(buf, sizeof(buf), "%s ESP32", _lang("Update"));
     lv_label_set_text(btn_esp, buf);
 }
 

--- a/src/ui/page_version.c
+++ b/src/ui/page_version.c
@@ -301,7 +301,7 @@ static void flash_goggle() {
         sprintf(buf, "$FFFF00 %s.#", _lang("No firmware found"));
         lv_label_set_text(btn_goggle, buf);
     } else if (ret == 3) {
-        sprintf("#FFFF00 %s. %s.#", _lang("Multiple versions been found"), _lang("Keep only one"));
+        sprintf(buf, "#FFFF00 %s. %s.#", _lang("Multiple versions been found"), _lang("Keep only one"));
         lv_label_set_text(btn_goggle, buf);
     } else {
         sprintf(buf, "#FF0000 %s#", _lang("FAILED"));

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -846,7 +846,7 @@ static void page_wifi_on_roller(uint8_t key) {
                 value += 1;
             }
         }
-        char buf[3];
+        char buf[12];
         sprintf(buf, "%d", value + 1);
         lv_label_set_text(page_wifi.page_2.rf_channel.input.label, buf);
         lv_slider_set_value(page_wifi.page_2.rf_channel.input.slider, value, LV_ANIM_OFF);

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -356,7 +356,7 @@ static void page_wifi_update_page_1_notes() {
     }
 
     static char buf[1024];
-    sprintf(buf, "%s:\n    %s,%s.\n\n%s:\n    1. %s.\n    2. %s:\n\n        rtsp://%s:8554/hdzero\n\n",
+    snprintf(buf, sizeof(buf), "%s:\n    %s,%s.\n\n%s:\n    1. %s.\n    2. %s:\n\n        rtsp://%s:8554/hdzero\n\n",
             _lang("Password Requirements"),
             _lang("Minimum 8 characters"),
             _lang("maximum 64 characters"),
@@ -369,7 +369,7 @@ static void page_wifi_update_page_1_notes() {
 
 static void page_wifi_update_page_3_notes() {
     static char buf[256];
-    sprintf(buf, "%s:\n    %s,%s.\n\n",
+    snprintf(buf, sizeof(buf), "%s:\n    %s,%s.\n\n",
             _lang("Password Requirements"),
             _lang("Minimum 8 characters"),
             _lang("maximum 64 characters"));
@@ -566,7 +566,7 @@ static void page_wifi_apply_settings_pending_cb(struct _lv_timer_t *timer) {
         static int dir = 20;
         static char buf[128];
         static uint8_t red = 150;
-        sprintf(buf, "#%02x0000 %s#", red, _lang("Apply Settings"));
+        snprintf(buf, sizeof(buf), "#%02x0000 %s#", red, _lang("Apply Settings"));
         lv_label_set_text(page_wifi.page_1.apply_settings, buf);
         lv_label_set_text(page_wifi.page_2.apply_settings, buf);
         lv_label_set_text(page_wifi.page_3.apply_settings, buf);
@@ -646,7 +646,7 @@ static void page_wifi_create_page_1(lv_obj_t *parent) {
     page_wifi_mask_password(page_wifi.page_1.passwd.input, strlen(g_setting.wifi.passwd[g_setting.wifi.mode]));
 
     page_wifi.page_1.apply_settings = create_label_item(parent, _lang("Apply Settings"), 1, 5, 3);
-    sprintf(buf, "< %s", _lang("Back"));
+    snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
     page_wifi.page_1.back = create_label_item(parent, buf, 1, 6, 3);
 
     page_wifi.page_1.note = lv_label_create(parent);
@@ -726,7 +726,7 @@ static lv_obj_t *page_wifi_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
     lv_obj_set_size(section, 1053, 894);
 
-    sprintf(buf, "%s:", _lang("WiFi Module"));
+    snprintf(buf, sizeof(buf), "%s:", _lang("WiFi Module"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
@@ -847,7 +847,7 @@ static void page_wifi_on_roller(uint8_t key) {
             }
         }
         char buf[12];
-        sprintf(buf, "%d", value + 1);
+        snprintf(buf, sizeof(buf), "%d", value + 1);
         lv_label_set_text(page_wifi.page_2.rf_channel.input.label, buf);
         lv_slider_set_value(page_wifi.page_2.rf_channel.input.slider, value, LV_ANIM_OFF);
     }

--- a/src/ui/ui_image_setting.c
+++ b/src/ui/ui_image_setting.c
@@ -118,7 +118,7 @@ static void show_ims_slider(uint8_t index) {
     }
 
     default:
-        sprintf(buf, "%d", p_slider->value);
+        snprintf(buf, sizeof(buf), "%d", p_slider->value);
         break;
     }
 

--- a/src/ui/ui_osd_element_pos.c
+++ b/src/ui/ui_osd_element_pos.c
@@ -442,7 +442,7 @@ static int ui_handle_click() {
         }
 
         lv_obj_set_style_text_font(label_cancel_osd_elements, &lv_font_montserrat_18, 0);
-        sprintf(buf, "#FFFF00 %s/%s#", _lang("click to confirm"), _lang("scroll to cancel"));
+        snprintf(buf, sizeof(buf), "#FFFF00 %s/%s#", _lang("click to confirm"), _lang("scroll to cancel"));
         lv_label_set_text(label_cancel_osd_elements, buf);
         cancel_changes_confirm = CONFIRMATION_CONFIRMED;
         return 0;
@@ -460,7 +460,7 @@ static int ui_handle_click() {
         }
 
         lv_obj_set_style_text_font(label_save_osd_elements, &lv_font_montserrat_18, 0);
-        sprintf(buf, "#FFFF00 %s/%s#", _lang("click to confirm"), _lang("scroll to cancel"));
+        snprintf(buf, sizeof(buf), "#FFFF00 %s/%s#", _lang("click to confirm"), _lang("scroll to cancel"));
         lv_label_set_text(label_save_osd_elements, buf);
         save_changes_confirm = CONFIRMATION_CONFIRMED;
         return 0;
@@ -476,13 +476,13 @@ static int ui_handle_click() {
 
             update_ui();
             osd_update_element_positions();
-            sprintf(buf, "#00FF00 %s.#", _lang("Elements reset"));
+            snprintf(buf, sizeof(buf), "#00FF00 %s.#", _lang("Elements reset"));
             lv_label_set_text(label_reset_all_osd_elements, buf);
             lv_timer_reset(reset_all_osd_elements_timer);
             lv_timer_resume(reset_all_osd_elements_timer);
             reset_all_elements_confirm = CONFIRMATION_TIMEOUT;
         } else {
-            sprintf(buf, "#FFFF00 %s/%s#", _lang("click to confirm"), _lang("scroll to cancel"));
+            snprintf(buf, sizeof(buf), "#FFFF00 %s/%s#", _lang("click to confirm"), _lang("scroll to cancel"));
             lv_label_set_text(label_reset_all_osd_elements, buf);
             reset_all_elements_confirm = CONFIRMATION_CONFIRMED;
         }
@@ -542,7 +542,7 @@ void ui_osd_element_pos_init(void) {
     // create all elements
     create_btn_group_item_compact(&btn_group_osd_mode, ui_root_container, 2, _lang("Mode"), "4x3", "16x9", "", "", ROW_OSD_MODE, 40, 80, &lv_font_montserrat_20);
 
-    sprintf(buf, "%s: ", _lang("Element"));
+    snprintf(buf, sizeof(buf), "%s: ", _lang("Element"));
     create_label_item_compact(ui_root_container, buf, 1, ROW_OSD_ELEMENT, 1, 40, LV_TEXT_ALIGN_LEFT, LV_GRID_ALIGN_START, &lv_font_montserrat_20);
     fill_osd_elements_str();
     dropdown_osd_element = create_dropdown_item(ui_root_container, osd_elements_str, 2, ROW_OSD_ELEMENT, 160, 30, 2, 2, LV_GRID_ALIGN_STRETCH, &lv_font_montserrat_20);

--- a/src/ui/ui_player.c
+++ b/src/ui/ui_player.c
@@ -112,7 +112,7 @@ static void mplayer_create_slider(lv_obj_t *parent, int16_t x, int16_t y) {
     lv_slider_set_value(controller._slider, 0, LV_ANIM_OFF);
 
     controller._label = lv_label_create(parent);
-    sprintf(buf, "00:00/00:00");
+    snprintf(buf, sizeof(buf), "00:00/00:00");
     lv_label_set_text(controller._label, buf);
     lv_obj_set_style_text_font(controller._label, &lv_font_montserrat_26, 0);
     lv_obj_set_style_text_align(controller._label, LV_TEXT_ALIGN_CENTER, 0);

--- a/src/ui/ui_statusbar.c
+++ b/src/ui/ui_statusbar.c
@@ -118,18 +118,18 @@ int statusbar_init(void) {
         lv_obj_set_grid_cell(label[i], LV_GRID_ALIGN_CENTER, ((i + 1) * 2), 1, LV_GRID_ALIGN_CENTER, 0, 1);
     }
 
-    sprintf(buf, "%s                 ", _lang("SD Card"));
+    snprintf(buf, sizeof(buf), "%s                 ", _lang("SD Card"));
 
     lv_label_set_text(label[STS_SDCARD], buf);
     lv_label_set_recolor(label[STS_SDCARD], true);
 
-    sprintf(buf, "%s: HDZero %s", _lang("RF"), channel2str(g_setting.source.hdzero_band, g_setting.scan.channel & 0x7F));
+    snprintf(buf, sizeof(buf), "%s: HDZero %s", _lang("RF"), channel2str(g_setting.source.hdzero_band, g_setting.scan.channel & 0x7F));
     lv_label_set_text(label[STS_SOURCE], buf);
 
-    sprintf(buf, "ELRS: %s", _lang("Off"));
+    snprintf(buf, sizeof(buf), "ELRS: %s", _lang("Off"));
     lv_label_set_text(label[STS_ELRS], buf);
 
-    sprintf(buf, "WiFi: %s", _lang("Off"));
+    snprintf(buf, sizeof(buf), "WiFi: %s", _lang("Off"));
     lv_label_set_text(label[STS_WIFI], buf);
 
     lv_label_set_text(label[STS_BATT], "       ");
@@ -194,13 +194,13 @@ void statubar_update(void) {
         memset(buf, 0, sizeof(buf));
         if (g_source_info.source == SOURCE_HDZERO) { // HDZero
             int ch = g_setting.scan.channel & 0x7F;
-            sprintf(buf, "%s: HDZero %s", _lang("RF"), channel2str(g_setting.source.hdzero_band, g_setting.scan.channel & 0x7F));
+            snprintf(buf, sizeof(buf), "%s: HDZero %s", _lang("RF"), channel2str(g_setting.source.hdzero_band, g_setting.scan.channel & 0x7F));
         } else if (g_source_info.source == SOURCE_HDMI_IN)
-            sprintf(buf, "HDMI %s", _lang("In"));
+            snprintf(buf, sizeof(buf), "HDMI %s", _lang("In"));
         else if (g_source_info.source == SOURCE_AV_IN)
-            sprintf(buf, "AV %s", _lang("In"));
+            snprintf(buf, sizeof(buf), "AV %s", _lang("In"));
         else
-            sprintf(buf, "%s", _lang("Expansion Module"));
+            snprintf(buf, sizeof(buf), "%s", _lang("Expansion Module"));
 
         lv_label_set_text(label[STS_SOURCE], buf);
     }
@@ -218,14 +218,14 @@ void statubar_update(void) {
             lv_img_set_src(img_sdc, &img_sdcard);
             if (cnt != 0) {
                 if (sdcard_is_full())
-                    sprintf(buf, "%d %s, %s %s", cnt, _lang("clip(s)"), _lang("SD Card"), _lang("full"));
+                    snprintf(buf, sizeof(buf), "%d %s, %s %s", cnt, _lang("clip(s)"), _lang("SD Card"), _lang("full"));
                 else
-                    sprintf(buf, "%d %s, %.2fGB %s", cnt, _lang("SD Card"), gb, _lang("available"));
+                    snprintf(buf, sizeof(buf), "%d %s, %.2fGB %s", cnt, _lang("SD Card"), gb, _lang("available"));
             } else {
                 if (sdcard_is_full())
-                    sprintf(buf, "#FF0000 %s %s#", _lang("SD Card"), _lang("full"));
+                    snprintf(buf, sizeof(buf), "#FF0000 %s %s#", _lang("SD Card"), _lang("full"));
                 else
-                    sprintf(buf, "%.2fGB %s", gb, _lang("available"));
+                    snprintf(buf, sizeof(buf), "%.2fGB %s", gb, _lang("available"));
             }
         } else {
             lv_img_set_src(img_sdc, &img_noSdcard);
@@ -241,10 +241,10 @@ void statubar_update(void) {
     }
 
     if (g_setting.elrs.enable) {
-        sprintf(buf, "ELRS: %s ", _lang("On"));
+        snprintf(buf, sizeof(buf), "ELRS: %s ", _lang("On"));
         lv_label_set_text(label[STS_ELRS], buf);
     } else {
-        sprintf(buf, "ELRS: %s ", _lang("Off"));
+        snprintf(buf, sizeof(buf), "ELRS: %s ", _lang("Off"));
         lv_label_set_text(label[STS_ELRS], buf);
     }
 


### PR DESCRIPTION
## Update (2024-11-19)

Per the discussion below, I replaced all calls to `sprintf` with respective ones to `snprintf` that only writes as many chars as fit the target.

## Original description

I compile the emulator locally with gcc-14 and it outputs warnings for some of the buffers used to hold numerical values (see example screenshot below).

These changes should not do any harm but use more of the stack memory while calling the changed methods, but it should be ok imho.

![grafik](https://github.com/user-attachments/assets/08016ab9-db71-4e4e-9443-b1098fd0a64f)
