### PR TITLE
Update free SD card space after format

### DIFF
--- a/src/ui/page_storage.c
+++ b/src/ui/page_storage.c
@@ -195,6 +195,7 @@ static format_codes_t page_storage_format_sd() {
     }
 
     clear_videofile_cnt();
+    sdcard_update_free_size();
 
     // Restore logging if needed
     if (applogfile) {


### PR DESCRIPTION
In attempt to fix #412, I added a call for updating the free sd card size to the formatting method. Unfortunately, @evilC was not able to reproduce and therefore confirm the fix, but I decided to give it a shot anyway.

Closes #412 