### PR TITLE
set MAX_PANEKS to 10

### DIFF
--- a/src/ui/page_common.h
+++ b/src/ui/page_common.h
@@ -74,7 +74,7 @@ extern "C" {
 #define RIGHT_BUTTON_IMG "right_button.png"
 #define ALERT_IMG        "alert.png"
 
-#define MAX_PANELS 9
+#define MAX_PANELS 10
 
 #define FLAG_SELECTABLE LV_OBJ_FLAG_USER_1
 #define STATE_DISABLED  LV_STATE_USER_1


### PR DESCRIPTION
When using `self_test.txt`, the source page has 10 options, which will cause the app to crash.