### PR TITLE
Automatic recording HDMI in

### DIFF
--- a/src/core/app_state.c
+++ b/src/core/app_state.c
@@ -97,7 +97,9 @@ void app_switch_to_hdmi_in() {
     IT66121_close();
     sleep(2);
 
-    if (g_hw_stat.hdmiin_vtmg == 1)
+    if (g_hw_stat.hdmiin_vtmg == HDMIIN_VTMG_1080P60 ||
+        g_hw_stat.hdmiin_vtmg == HDMIIN_VTMG_1080P50 ||
+        g_hw_stat.hdmiin_vtmg == HDMIIN_VTMG_1080Pother)
         lvgl_switch_to_1080p();
     else
         lvgl_switch_to_720p();
@@ -106,7 +108,8 @@ void app_switch_to_hdmi_in() {
     osd_clear();
     lv_timer_handler();
 
-    dvr_update_vi_conf((g_hw_stat.hdmiin_vtmg == 1) ? VR_1080P30 : VR_720P60);
+    // update vi conf at HDMI_in_detect()
+    // dvr_update_vi_conf((g_hw_stat.hdmiin_vtmg == 1) ? VR_1080P30 : VR_720P60);
 
     app_state_push(APP_STATE_VIDEO);
     g_source_info.source = SOURCE_HDMI_IN;

--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -158,13 +158,13 @@ void dvr_star() {
 }
 
 static void dvr_update_record_conf() {
-    LOGI("CAM_MODE=%d", CAM_MODE);
     if (g_setting.record.format_ts)
         ini_puts("record", "type", "ts", REC_CONF);
     else
         ini_puts("record", "type", "mp4", REC_CONF);
 
     if (g_source_info.source == SOURCE_HDZERO) {
+        LOGI("CAM_MODE=%d", CAM_MODE);
         if (CAM_MODE == VR_1080P30) {
             ini_putl("venc", "width", 1920, REC_CONF);
             ini_putl("venc", "height", 1080, REC_CONF);
@@ -197,55 +197,56 @@ static void dvr_update_record_conf() {
         else
             ini_putl("venc", "fps", 60, REC_CONF);
     } else if (g_source_info.source == SOURCE_HDMI_IN) {
+        LOGI("g_hw_stat.hdmiin_vtmg=%d", g_hw_stat.hdmiin_vtmg);
         switch (g_hw_stat.hdmiin_vtmg) {
         case HDMIIN_VTMG_1080P60:
             ini_putl("venc", "width", 1920, REC_CONF);
             ini_putl("venc", "height", 1080, REC_CONF);
             ini_putl("venc", "fps", 60, REC_CONF);
             ini_putl("venc", "kbps", 34000, REC_CONF);
-            ini_putl("venc", "h265", 1, REC_CONF);
+            ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_1080P50:
             ini_putl("venc", "width", 1920, REC_CONF);
             ini_putl("venc", "height", 1080, REC_CONF);
             ini_putl("venc", "fps", 50, REC_CONF);
             ini_putl("venc", "kbps", 34000, REC_CONF);
-            ini_putl("venc", "h265", 1, REC_CONF);
+            ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_1080Pother:
             ini_putl("venc", "width", 1920, REC_CONF);
             ini_putl("venc", "height", 1080, REC_CONF);
             ini_putl("venc", "fps", 50, REC_CONF);
             ini_putl("venc", "kbps", 34000, REC_CONF);
-            ini_putl("venc", "h265", 1, REC_CONF);
+            ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_720P50:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 50, REC_CONF);
             ini_putl("venc", "kbps", 34000, REC_CONF);
-            ini_putl("venc", "h265", 1, REC_CONF);
+            ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_720P60:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 60, REC_CONF);
             ini_putl("venc", "kbps", 34000, REC_CONF);
-            ini_putl("venc", "h265", 1, REC_CONF);
+            ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_720P100:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 90, REC_CONF);
             ini_putl("venc", "kbps", 34000, REC_CONF);
-            ini_putl("venc", "h265", 1, REC_CONF);
+            ini_putl("venc", "h265", 0, REC_CONF);
             break;
         default:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 60, REC_CONF);
             ini_putl("venc", "kbps", 34000, REC_CONF);
-            ini_putl("venc", "h265", 1, REC_CONF);
+            ini_putl("venc", "h265", 0, REC_CONF);
             break;
         }
     }

--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -36,6 +36,8 @@ void dvr_update_status() {
         }
         if (ret != 1) {
             dvr_is_recording = false;
+            system_script(REC_STOP);
+            sleep(2); // wait for record process
         }
     }
     pthread_mutex_unlock(&dvr_mutex);

--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -160,7 +160,7 @@ void dvr_star() {
 }
 
 static void dvr_update_record_conf() {
-    if (g_setting.record.format_ts)
+    if (g_setting.record.format_ts || (g_source_info.source == SOURCE_HDMI_IN))
         ini_puts("record", "type", "ts", REC_CONF);
     else
         ini_puts("record", "type", "mp4", REC_CONF);

--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -71,19 +71,57 @@ void dvr_select_audio_source(uint8_t source) {
 
 void dvr_update_vi_conf(video_resolution_t fmt) {
     pthread_mutex_lock(&dvr_mutex);
-    if (fmt == VR_1080P30) {
+    switch (fmt) {
+    case VR_720P50:
+        ini_putl("vi", "width", 1280, REC_CONF);
+        ini_putl("vi", "height", 720, REC_CONF);
+        ini_putl("vi", "fps", 50, REC_CONF);
+        break;
+    case VR_720P60:
+        ini_putl("vi", "width", 1280, REC_CONF);
+        ini_putl("vi", "height", 720, REC_CONF);
+        ini_putl("vi", "fps", 60, REC_CONF);
+        break;
+    case VR_720P30:
+        ini_putl("vi", "width", 1280, REC_CONF);
+        ini_putl("vi", "height", 720, REC_CONF);
+        ini_putl("vi", "fps", 30, REC_CONF);
+        break;
+    case VR_540P90:
+        ini_putl("vi", "width", 1280, REC_CONF);
+        ini_putl("vi", "height", 720, REC_CONF);
+        ini_putl("vi", "fps", 90, REC_CONF);
+        break;
+    case VR_540P60:
+        ini_putl("vi", "width", 1280, REC_CONF);
+        ini_putl("vi", "height", 720, REC_CONF);
+        ini_putl("vi", "fps", 60, REC_CONF);
+        break;
+    case VR_960x720P60:
+        ini_putl("vi", "width", 1280, REC_CONF);
+        ini_putl("vi", "height", 720, REC_CONF);
+        ini_putl("vi", "fps", 60, REC_CONF);
+        break;
+    case VR_540P90_CROP:
+        ini_putl("vi", "width", 1280, REC_CONF);
+        ini_putl("vi", "height", 720, REC_CONF);
+        ini_putl("vi", "fps", 90, REC_CONF);
+        break;
+    case VR_1080P30:
+        ini_putl("vi", "width", 1920, REC_CONF);
+        ini_putl("vi", "height", 1080, REC_CONF);
+        ini_putl("vi", "fps", 30, REC_CONF);
+        break;
+    case VR_1080P50:
         ini_putl("vi", "width", 1920, REC_CONF);
         ini_putl("vi", "height", 1080, REC_CONF);
         ini_putl("vi", "fps", 50, REC_CONF);
-    } else {
-        ini_putl("vi", "width", 1280, REC_CONF);
-        ini_putl("vi", "height", 720, REC_CONF);
-        if ((fmt == VR_540P90) || (fmt == VR_540P90_CROP))
-            ini_putl("vi", "fps", 90, REC_CONF);
-        else if (fmt == VR_720P50)
-            ini_putl("vi", "fps", 50, REC_CONF);
-        else
-            ini_putl("vi", "fps", 60, REC_CONF);
+        break;
+    case VR_1080P60:
+        ini_putl("vi", "width", 1920, REC_CONF);
+        ini_putl("vi", "height", 1080, REC_CONF);
+        ini_putl("vi", "fps", 60, REC_CONF);
+        break;
     }
     pthread_mutex_unlock(&dvr_mutex);
 
@@ -148,7 +186,7 @@ static void dvr_update_record_conf() {
             ini_putl("venc", "kbps", 24000, REC_CONF);
             ini_putl("venc", "h265", 1, REC_CONF);
         }
-    } else if (g_source_info.source != SOURCE_HDMI_IN) { // AV  (HDMI no record)
+    } else if (g_source_info.source == SOURCE_AV_IN || g_source_info.source == SOURCE_EXPANSION) { // Analog
         ini_putl("venc", "width", 1280, REC_CONF);
         ini_putl("venc", "height", 720, REC_CONF);
 
@@ -158,6 +196,58 @@ static void dvr_update_record_conf() {
             ini_putl("venc", "fps", 50, REC_CONF);
         else
             ini_putl("venc", "fps", 60, REC_CONF);
+    } else if (g_source_info.source == SOURCE_HDMI_IN) {
+        switch (g_hw_stat.hdmiin_vtmg) {
+        case HDMIIN_VTMG_1080P60:
+            ini_putl("venc", "width", 1920, REC_CONF);
+            ini_putl("venc", "height", 1080, REC_CONF);
+            ini_putl("venc", "fps", 60, REC_CONF);
+            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "h265", 1, REC_CONF);
+            break;
+        case HDMIIN_VTMG_1080P50:
+            ini_putl("venc", "width", 1920, REC_CONF);
+            ini_putl("venc", "height", 1080, REC_CONF);
+            ini_putl("venc", "fps", 50, REC_CONF);
+            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "h265", 1, REC_CONF);
+            break;
+        case HDMIIN_VTMG_1080Pother:
+            ini_putl("venc", "width", 1920, REC_CONF);
+            ini_putl("venc", "height", 1080, REC_CONF);
+            ini_putl("venc", "fps", 50, REC_CONF);
+            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "h265", 1, REC_CONF);
+            break;
+        case HDMIIN_VTMG_720P50:
+            ini_putl("venc", "width", 1280, REC_CONF);
+            ini_putl("venc", "height", 720, REC_CONF);
+            ini_putl("venc", "fps", 50, REC_CONF);
+            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "h265", 1, REC_CONF);
+            break;
+        case HDMIIN_VTMG_720P60:
+            ini_putl("venc", "width", 1280, REC_CONF);
+            ini_putl("venc", "height", 720, REC_CONF);
+            ini_putl("venc", "fps", 60, REC_CONF);
+            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "h265", 1, REC_CONF);
+            break;
+        case HDMIIN_VTMG_720P100:
+            ini_putl("venc", "width", 1280, REC_CONF);
+            ini_putl("venc", "height", 720, REC_CONF);
+            ini_putl("venc", "fps", 90, REC_CONF);
+            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "h265", 1, REC_CONF);
+            break;
+        default:
+            ini_putl("venc", "width", 1280, REC_CONF);
+            ini_putl("venc", "height", 720, REC_CONF);
+            ini_putl("venc", "fps", 60, REC_CONF);
+            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "h265", 1, REC_CONF);
+            break;
+        }
     }
 
     ini_putl("record", "audio", g_setting.record.audio, REC_CONF);
@@ -185,11 +275,6 @@ void dvr_cmd(osd_dvr_cmd_t cmd) {
     case DVR_START:
         start_rec = true;
         break;
-    }
-
-    if (g_source_info.source == SOURCE_HDMI_IN) {
-        // no record for hdmi-in :<
-        start_rec = false;
     }
 
     if (start_rec) {

--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -122,7 +122,7 @@ void dvr_update_vi_conf(video_resolution_t fmt) {
     case VR_1080P60:
         ini_putl("vi", "width", 1920, REC_CONF);
         ini_putl("vi", "height", 1080, REC_CONF);
-        ini_putl("vi", "fps", 60, REC_CONF);
+        ini_putl("vi", "fps", 59, REC_CONF); // If set fps to 60, DVR is wrong. I don't why. 59 or 61 is ok.
         break;
     }
     pthread_mutex_unlock(&dvr_mutex);

--- a/src/core/msp_displayport.h
+++ b/src/core/msp_displayport.h
@@ -32,7 +32,9 @@ typedef enum {
     VR_540P60 = 4,
     VR_960x720P60 = 5,
     VR_540P90_CROP = 6,
-    VR_1080P30 = 7
+    VR_1080P30 = 7,
+    VR_1080P50 = 8,
+    VR_1080P60 = 9
 } video_resolution_t;
 
 typedef enum {

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -112,13 +112,11 @@ static void check_source_signal(int vtmg_change) {
         cnt = 0;
     }
 
-    // Auto DVT HDMI_IN VTMG change -> stop recording first
-    if (g_source_info.source == SOURCE_HDMI_IN) {
-        if (vtmg_change && dvr_is_recording) {
-            LOGI("HDMI IN VTMG change");
-            dvr_cmd(DVR_STOP);
-            dvr_cmd(DVR_START);
-        }
+    // HDMI VTMG change -> Restart recording
+    if (g_source_info.source == SOURCE_HDMI_IN && vtmg_change) {
+        LOGI("HDMI IN VTMG change");
+        dvr_cmd(DVR_STOP);
+        cnt = 0;
     }
 
     if (dvr_is_recording) { // in-recording

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -67,7 +67,7 @@ static void detect_sdcard(void) {
 // Signal loss|accquire processing
 #define SIGNAL_LOSS_DURATION_THR 20 // 25=4 seconds,
 #define SIGNAL_ACCQ_DURATION_THR 10
-static void check_hdzero_signal(int vtmg_change) {
+static void check_source_signal(int vtmg_change) {
     static uint8_t cnt = 0;
     uint8_t is_valid;
 
@@ -78,7 +78,9 @@ static void check_hdzero_signal(int vtmg_change) {
         tune_channel_timer();
     }
 
-    if (g_source_info.source == SOURCE_AV_IN)
+    if (g_source_info.source == SOURCE_HDMI_IN)
+        is_valid = g_source_info.hdmi_in_status;
+    else if (g_source_info.source == SOURCE_AV_IN)
         is_valid = g_source_info.av_in_status;
     else if (g_source_info.source == SOURCE_EXPANSION)
         is_valid = g_source_info.av_bay_status;
@@ -90,11 +92,7 @@ static void check_hdzero_signal(int vtmg_change) {
     }
 
     // exit if no SD card or not in video mode
-    if (g_setting.record.mode_manual || (!g_sdcard_enable) || (g_app_state != APP_STATE_VIDEO))
-        return;
-
-    // exit if HDMI in
-    if (g_source_info.source == SOURCE_HDMI_IN)
+    if ((g_setting.record.mode_manual && (g_source_info.source != SOURCE_HDMI_IN)) || (!g_sdcard_enable) || (g_app_state != APP_STATE_VIDEO))
         return;
 
     // Analog VTMG change -> Restart recording
@@ -112,6 +110,15 @@ static void check_hdzero_signal(int vtmg_change) {
         dvr_cmd(DVR_STOP);
         system_script(REC_STOP_LIVE);
         cnt = 0;
+    }
+
+    // Auto DVT HDMI_IN VTMG change -> stop recording first
+    if (g_source_info.source == SOURCE_HDMI_IN) {
+        if (vtmg_change && dvr_is_recording) {
+            LOGI("HDMI IN VTMG change");
+            dvr_cmd(DVR_STOP);
+            dvr_cmd(DVR_START);
+        }
     }
 
     if (dvr_is_recording) { // in-recording
@@ -132,8 +139,9 @@ static void check_hdzero_signal(int vtmg_change) {
                 cnt = 0;
                 LOGI("Signal accquired");
                 sdcard_update_free_size();
-                if (!sdcard_is_full())
+                if (!sdcard_is_full()) {
                     dvr_cmd(DVR_START);
+                }
             }
         } else
             cnt = 0;
@@ -167,11 +175,11 @@ static void *thread_peripheral(void *ptr) {
             g_source_info.av_bay_status = g_hw_stat.av_valid[1];
 
             // detect HDMI in
-            HDMI_in_detect();
+            record_vtmg_change |= HDMI_in_detect();
             g_source_info.hdmi_in_status = g_hw_stat.hdmiin_valid;
 
             g_latency_locked = (bool)Get_VideoLatancy_status();
-            check_hdzero_signal(record_vtmg_change);
+            check_source_signal(record_vtmg_change);
             record_vtmg_change = 0;
         }
         j++;

--- a/src/driver/hardware.h
+++ b/src/driver/hardware.h
@@ -104,7 +104,7 @@ void Analog_Module_Power(bool Force);
 
 int HDZERO_detect();
 int AV_in_detect();
-void HDMI_in_detect();
+int HDMI_in_detect();
 
 int Get_VideoLatancy_status(); // ret: 0=unlocked, 1=locked
 int Get_HAN_status();          // ret: 0=error; 1=ok


### PR DESCRIPTION
When goggle displays HDMI in, if the SD card exists and has more than 100MB of remaining storage, it will automatically record.
- h264 encoding
- 34 mbps
- TS format only
  
I tested:
- 1080p30
- 1080p50
- 1080p60
- 720p50
- 720p60
- 720p90
- 720p100*

Note that HDMI in 720p100 will be recorded at 720p90.