### PR TITLE
do not check hdmi in source if quickly enter hdmi in mode after power on

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -108,14 +108,14 @@ void start_running(void) {
             g_source_info.source = SOURCE_AV_IN;
         } else { // HDMI in
             sleep(2);
-            g_source_info.hdmi_in_status = IT66021_Sig_det();
-            if (g_source_info.hdmi_in_status) {
-                app_switch_to_hdmi_in();
-                g_source_info.source = SOURCE_HDMI_IN;
-            } else {
-                g_source_info.source = SOURCE_HDZERO;
-                app_state_push(APP_STATE_MAINMENU);
-            }
+            // g_source_info.hdmi_in_status = IT66021_Sig_det();
+            // if (g_source_info.hdmi_in_status) {
+            app_switch_to_hdmi_in();
+            g_source_info.source = SOURCE_HDMI_IN;
+            //} else {
+            //    g_source_info.source = SOURCE_HDZERO;
+            //    app_state_push(APP_STATE_MAINMENU);
+            //}
         }
     }
 

--- a/src/driver/hardware.c
+++ b/src/driver/hardware.c
@@ -540,7 +540,7 @@ void hw_stat_init() {
     g_hw_stat.av_valid[0] = g_hw_stat.av_valid[1] = 0;
 
     g_hw_stat.hdmiin_valid = 0;
-    g_hw_stat.hdmiin_vtmg = HDMIIN_VTMG_UNKNOW;
+    g_hw_stat.hdmiin_vtmg = HDMIIN_VTMG_1080P50;
     g_hw_stat.IS_TP2825_L = 0;
 
     pthread_mutex_init(&hardware_mutex, NULL);


### PR DESCRIPTION
It is helpful for WS VRX.