### PR TITLE
Prevent update from bricking goggle

### DIFF
--- a/mkapp/app/script/update_goggle.sh
+++ b/mkapp/app/script/update_goggle.sh
@@ -22,7 +22,40 @@ gpio_export()
 		echo "258">/sys/class/gpio/export
 	        echo "out">/sys/class/gpio/gpio258/direction
 	fi
+        if [ ! -f /sys/class/gpio/gpio131/direction ] 
+        then                                                          
+                echo "131">/sys/class/gpio/export
+                echo "out">/sys/class/gpio/gpio131/direction                     
+        fi
 }
+
+beep_success()
+{
+    	echo "1">/sys/class/gpio/gpio131/value
+		sleep 0.1
+    	echo "0">/sys/class/gpio/gpio131/value
+		sleep 0.5
+    	echo "1">/sys/class/gpio/gpio131/value
+		sleep 0.05
+    	echo "0">/sys/class/gpio/gpio131/value
+}
+
+
+beep_failure()
+{
+    	echo "1">/sys/class/gpio/gpio131/value
+		sleep 1
+    	echo "0">/sys/class/gpio/gpio131/value
+		sleep 0.5
+    	echo "1">/sys/class/gpio/gpio131/value
+		sleep 1
+    	echo "0">/sys/class/gpio/gpio131/value
+		sleep 0.5
+    	echo "1">/sys/class/gpio/gpio131/value
+		sleep 0.05
+    	echo "0">/sys/class/gpio/gpio131/value
+}
+
 
 gpio_set_reset()
 {
@@ -68,6 +101,23 @@ untar_file()
 	mv ${TMP_DIR}/HDZGOGGLE_RX*.bin ${TMP_DIR}/HDZGOGGLE_RX.bin
 	mv ${TMP_DIR}/HDZGOGGLE_VA*.bin ${TMP_DIR}/HDZGOGGLE_VA.bin
 }
+ 
+# eg: check_mtd_write /dev/mtdX check-size erase-size file-size bin-file
+check_mtd_write()
+{
+	mtd_info=`mtd_debug info $1`
+	echo "$mtd_info"
+	value=`echo "$mtd_info" | grep mtd.size | grep "($2)"`                
+	if [ ! -z "$value" ];then
+	    echo "$1 size is ($2)" 
+		mtd_debug erase $1 0 $3
+		mtd_debug write $1 0 $4 $5
+		beep_success
+	else
+	    echo "$1 size is NOT ($2) !" 
+		beep_failure
+	fi
+}
 
 update_rx()
 {
@@ -76,12 +126,13 @@ update_rx()
 	gpio_export
 	gpio_set_reset
 	insmod /mnt/app/ko/w25q128.ko
-
-	mtd_debug erase /dev/mtd8 0 65536
-	mtd_debug write /dev/mtd8 0 $filesize ${TMP_DIR}/HDZGOGGLE_RX.bin
-	mtd_debug erase /dev/mtd9 0 65536
-	mtd_debug write /dev/mtd9 0 $filesize ${TMP_DIR}/HDZGOGGLE_RX.bin
-
+	check_mtd_write /dev/mtd8 1M 65536 $filesize ${TMP_DIR}/HDZGOGGLE_RX.bin
+    echo "5"                                                                          
+    echo "5" > /tmp/progress_goggle
+	sleep 1
+	check_mtd_write /dev/mtd9 1M 65536 $filesize ${TMP_DIR}/HDZGOGGLE_RX.bin
+    echo "10"                                                                          
+    echo "10" > /tmp/progress_goggle
 	echo "update finish RX, running"
 	gpio_clear_reset
 	sleep 1
@@ -96,9 +147,9 @@ update_fpga()
 	gpio_set_reset
 	disconnect_fpga_flash
 	insmod /mnt/app/ko/w25q128.ko
-
-	mtd_debug erase /dev/mtd10 0 16777216
-	mtd_debug write /dev/mtd10 0 $filesize2 ${TMP_DIR}/HDZGOGGLE_VA.bin
+	check_mtd_write /dev/mtd10 16M 16777216 $filesize2 ${TMP_DIR}/HDZGOGGLE_VA.bin
+    echo "45"                                                                         
+    echo "45" > /tmp/progress_goggle  
 	echo "update finish VA, running"
 	gpio_clear_reset
 	sleep 1
@@ -123,12 +174,8 @@ then
 	cp -f /mnt/app/setting.ini /mnt/UDISK/
 	#disable it66021
 	i2cset -y 3 0x49 0x10 0xff
-	update_rx
-	echo "1"
-	echo "1" > /tmp/progress_goggle
+        update_rx
 	update_fpga
-	echo "45"
-	echo "45" > /tmp/progress_goggle
 	hdz_upgrade_app.sh
 	echo "100"
 	echo "100" > /tmp/progress_goggle
@@ -141,4 +188,3 @@ else
 		echo "repeat"
 	fi
 fi
-

--- a/mkapp/app/script/write_flashes.sh
+++ b/mkapp/app/script/write_flashes.sh
@@ -2,14 +2,28 @@
 
 function gpio_export()
 {
-        echo "224">/sys/class/gpio/export
-        echo "228">/sys/class/gpio/export
-        echo "131">/sys/class/gpio/export
-        echo "258">/sys/class/gpio/export
-        echo "out">/sys/class/gpio/gpio224/direction
-        echo "out">/sys/class/gpio/gpio228/direction
-        echo "out">/sys/class/gpio/gpio131/direction
-        echo "out">/sys/class/gpio/gpio258/direction
+	if [ ! -f /sys/class/gpio/gpio224/direction ]
+	then
+	      echo "224">/sys/class/gpio/export
+	      echo "out">/sys/class/gpio/gpio224/direction
+	fi
+
+	if [ ! -f /sys/class/gpio/gpio228/direction ]
+	then
+		echo "228">/sys/class/gpio/export
+        	echo "out">/sys/class/gpio/gpio228/direction
+	fi
+
+	if [ ! -f /sys/class/gpio/gpio258/direction ]
+	then
+		echo "258">/sys/class/gpio/export
+	        echo "out">/sys/class/gpio/gpio258/direction
+	fi
+        if [ ! -f /sys/class/gpio/gpio131/direction ] 
+        then                                                          
+                echo "131">/sys/class/gpio/export
+                echo "out">/sys/class/gpio/gpio131/direction                     
+        fi
 }
 
 function beep_on()
@@ -28,6 +42,34 @@ function beep()
 				sleep 1
         echo "0">/sys/class/gpio/gpio131/value
 }
+
+beep_success()
+{
+    echo "1">/sys/class/gpio/gpio131/value
+		sleep 0.1
+    echo "0">/sys/class/gpio/gpio131/value
+		sleep 0.5
+    echo "1">/sys/class/gpio/gpio131/value
+		sleep 0.05
+    echo "0">/sys/class/gpio/gpio131/value
+}
+
+
+beep_failure()
+{
+    echo "1">/sys/class/gpio/gpio131/value
+		sleep 1
+    echo "0">/sys/class/gpio/gpio131/value
+		sleep 0.5
+    echo "1">/sys/class/gpio/gpio131/value
+		sleep 1
+    echo "0">/sys/class/gpio/gpio131/value
+		sleep 0.5
+    echo "1">/sys/class/gpio/gpio131/value
+		sleep 0.05
+    echo "0">/sys/class/gpio/gpio131/value
+}
+
 
 function disconnect_fpga_flash()
 {
@@ -58,6 +100,25 @@ function gpio_set_send()
         echo "0">/sys/class/gpio/gpio228/value
 }
 
+# eg: check_mtd_write /dev/mtdX check-size erase-size file-size bin-file
+check_mtd_write()
+{
+	mtd_info=`mtd_debug info $1`
+	echo "$mtd_info"
+	value=`echo "$mtd_info" | grep mtd.size | grep "($2)"`                
+	if [ ! -z "$value" ];then
+	        echo "$1 size is ($2)" 
+		mtd_debug erase $1 0 $3
+		mtd_debug write $1 0 $4 $5
+		beep_success
+	else
+	        echo "$1 size is NOT ($2) !" 
+		beep_failure
+	fi
+}
+
+
+
 
 echo "<<<<-------------------------------------------------------------------->>>>"
 
@@ -73,8 +134,9 @@ then
 
 
 		touch /tmp/update.ing
-        mtd_debug erase /dev/mtd10 0 16777216
-        mtd_debug write /dev/mtd10 0 $filesize2 /mnt/extsd/HDZGOGGLE_VA.bin
+    #	check_mtd_write /dev/mtd8 16M 16777216 $filesize2 ${TMP_DIR}/HDZGOGGLE_VA.bin
+    #	check_mtd_write /dev/mtd9 16M 16777216 $filesize2 ${TMP_DIR}/HDZGOGGLE_VA.bin
+	  check_mtd_write /dev/mtd10 16M 16777216 $filesize2 ${TMP_DIR}/HDZGOGGLE_VA.bin
 		rm /tmp/update.ing -rf
 
 		if [ ! -f /mnt/extsd/DONOTREMOVE.txt ]
@@ -100,26 +162,9 @@ then
 		sleep 1
     insmod /mnt/app/ko/w25q128.ko
 
-    valude=`mtd_debug info /dev/mtd8 | grep mtd.size | grep 1M`                
-    if [ "$valude" = "" ];then                                     
-			beep_on
-			usleep 500
-			beep_off
-			exit 0
-		fi
-    
-    valude=`mtd_debug info /dev/mtd9 | grep mtd.size | grep 1M`                
-    if [ "$valude" = "" ];then                                     
-			beep_on
-			usleep 500
-			beep_off
-			exit 0
-		fi
-
-    mtd_debug erase /dev/mtd8 0 65536
-        mtd_debug write /dev/mtd8 0 $filesize /mnt/extsd/HDZGOGGLE_RX.bin
-    mtd_debug erase /dev/mtd9 0 65536
-        mtd_debug write /dev/mtd9 0 $filesize /mnt/extsd/HDZGOGGLE_RX.bin
+	  check_mtd_write /dev/mtd8 1M 65536 $filesize ${TMP_DIR}/HDZGOGGLE_RX.bin
+	  check_mtd_write /dev/mtd9 1M 65536 $filesize ${TMP_DIR}/HDZGOGGLE_RX.bin
+    #	check_mtd_write /dev/mtd10 1M 65536 $filesize ${TMP_DIR}/HDZGOGGLE_RX.bin
 
 		if [ ! -f /mnt/extsd/DONOTREMOVE.txt ]
 		then


### PR DESCRIPTION
This PR changes both the update_goggle.sh and write_flashes.sh scripts to prevent writing a bin into an /dev/mtd8-10 of unexpected size.

Notes:
-prevents soft bricking of goggle VA or RXs
-needs formal testing on fully working goggles (neither of the RX in my goggle are currently mounting to /dev/mtd8/9)
-beeps a quick double chirp on success finding the expected size of each /dev/mtd* 
-beeps two long and a chirp on failure to find the expected size /dev/mtd*
-does not automatically recover the google however commented lines in write_flashes can allow for easy recovery of erroneously flashed VA and RX. 

To recover a broken VA or RX place these files on SD card to :
HDZGOGGLE_VA.bin  # from Recovery if  VA is failing (no video on goggle)
HDZGOGGLE_RX.bin # from Recovery if one or more RX are failing (two or four HDZero signal indicators stuck)
develop.sh # copy of write_flashes.sh and uncomment  check_mtd_write for HDZGOGGLE_RX/HDZGOGGLE_VA as needed

Other SD card files that may help while trying to recover:
self_test.txt # empty file to dump diagnostic logging into
DONOTREMOVE.txt # empty file -write_flashes will leave .bin files on SD card. However, after goggle display returns remove the HDZGOGGLE_VA.bin file from SD card. When both HDZero RXs have been verified remove the HDZGOGGLE_RX.bin from SD card.

