### PR TITLE
dvr: make bitrate configurable

### DIFF
--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -71,6 +71,7 @@ void dvr_select_audio_source(uint8_t source) {
     system_exec(buf);
 }
 
+// video input config
 void dvr_update_vi_conf(video_resolution_t fmt) {
     pthread_mutex_lock(&dvr_mutex);
     switch (fmt) {
@@ -160,6 +161,21 @@ void dvr_star() {
 }
 
 static void dvr_update_record_conf() {
+    int bitrate_scale;
+    switch (g_setting.record.bitrate_scale) {
+        case SETTING_RECORD_BITRATE_SCALE_NORMAL:
+            bitrate_scale = 1;
+            break;
+        case SETTING_RECORD_BITRATE_SCALE_HALF:
+            bitrate_scale = 2;
+            break;
+        case SETTING_RECORD_BITRATE_SCALE_QUARTER:
+            bitrate_scale = 4;
+            break;
+        default:
+            bitrate_scale = 1;
+            break;
+    }
     if (g_setting.record.format_ts || (g_source_info.source == SOURCE_HDMI_IN))
         ini_puts("record", "type", "ts", REC_CONF);
     else
@@ -177,22 +193,22 @@ static void dvr_update_record_conf() {
 
         if (CAM_MODE == VR_1080P30) { // 1080p30
             ini_putl("venc", "fps", 60, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
         } else if (CAM_MODE == VR_540P90 || CAM_MODE == VR_540P90_CROP) { // 90fps
             ini_putl("venc", "fps", 90, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
         } else {
             ini_putl("venc", "fps", 60, REC_CONF);
-            ini_putl("venc", "kbps", 24000, REC_CONF);
+            ini_putl("venc", "kbps", 24000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 1, REC_CONF);
         }
     } else if (g_source_info.source == SOURCE_AV_IN || g_source_info.source == SOURCE_EXPANSION) { // Analog
         ini_putl("venc", "width", 1280, REC_CONF);
         ini_putl("venc", "height", 720, REC_CONF);
 
-        ini_putl("venc", "kbps", 24000, REC_CONF);
+        ini_putl("venc", "kbps", 24000 / bitrate_scale, REC_CONF);
         ini_putl("venc", "h265", 1, REC_CONF);
         if (g_hw_stat.av_pal[g_hw_stat.av_chid])
             ini_putl("venc", "fps", 50, REC_CONF);
@@ -205,49 +221,49 @@ static void dvr_update_record_conf() {
             ini_putl("venc", "width", 1920, REC_CONF);
             ini_putl("venc", "height", 1080, REC_CONF);
             ini_putl("venc", "fps", 60, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_1080P50:
             ini_putl("venc", "width", 1920, REC_CONF);
             ini_putl("venc", "height", 1080, REC_CONF);
             ini_putl("venc", "fps", 50, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_1080Pother:
             ini_putl("venc", "width", 1920, REC_CONF);
             ini_putl("venc", "height", 1080, REC_CONF);
             ini_putl("venc", "fps", 50, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_720P50:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 50, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_720P60:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 60, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
             break;
         case HDMIIN_VTMG_720P100:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 90, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
             break;
         default:
             ini_putl("venc", "width", 1280, REC_CONF);
             ini_putl("venc", "height", 720, REC_CONF);
             ini_putl("venc", "fps", 60, REC_CONF);
-            ini_putl("venc", "kbps", 34000, REC_CONF);
+            ini_putl("venc", "kbps", 34000 / bitrate_scale, REC_CONF);
             ini_putl("venc", "h265", 0, REC_CONF);
             break;
         }

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -45,6 +45,7 @@ const setting_t g_setting_defaults = {
     .record = {
         .mode_manual = false,
         .format_ts = true,
+        .bitrate_scale = SETTING_RECORD_BITRATE_SCALE_NORMAL,
         .osd = true,
         .audio = true,
         .audio_source = SETTING_RECORD_AUDIO_SOURCE_MIC,
@@ -394,6 +395,7 @@ void settings_load(void) {
     // record
     g_setting.record.mode_manual = settings_get_bool("record", "mode_manual", g_setting_defaults.record.mode_manual);
     g_setting.record.format_ts = settings_get_bool("record", "format_ts", g_setting_defaults.record.format_ts);
+    g_setting.record.bitrate_scale = ini_getl("record", "bitrate_scale", g_setting_defaults.record.bitrate_scale, SETTING_INI);
     g_setting.record.osd = settings_get_bool("record", "osd", g_setting_defaults.record.osd);
     g_setting.record.audio = settings_get_bool("record", "audio", g_setting_defaults.record.audio);
     g_setting.record.audio_source = ini_getl("record", "audio_source", g_setting_defaults.record.audio_source, SETTING_INI);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -84,6 +84,12 @@ typedef enum {
 } setting_record_audio_source_t;
 
 typedef enum {
+    SETTING_RECORD_BITRATE_SCALE_NORMAL = 0,
+    SETTING_RECORD_BITRATE_SCALE_HALF = 1,
+    SETTING_RECORD_BITRATE_SCALE_QUARTER = 2,
+} setting_record_bitrate_scale_t;
+
+typedef enum {
     SETTING_NAMING_CONTIGUOUS,
     SETTING_NAMING_DATE
 } setting_record_naming_t;
@@ -91,6 +97,7 @@ typedef enum {
 typedef struct {
     bool mode_manual;
     bool format_ts;
+    setting_record_bitrate_scale_t bitrate_scale;
     bool osd;
     bool audio;
     setting_record_audio_source_t audio_source;

--- a/src/ui/page_record.c
+++ b/src/ui/page_record.c
@@ -14,6 +14,7 @@
 
 static btn_group_t btn_group_record_mode;
 static btn_group_t btn_group_format;
+static btn_group_t btn_group_bitrate_scale;
 static btn_group_t btn_group_record_osd;
 static btn_group_t btn_group_record_audio;
 static btn_group_t btn_group_audio_source;
@@ -44,19 +45,19 @@ static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     char buf[256];
     lv_obj_t *page = lv_menu_page_create(parent, NULL);
     lv_obj_clear_flag(page, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_size(page, 1053, 900);
+    lv_obj_set_size(page, 1053, 980);
     lv_obj_add_style(page, &style_subpage, LV_PART_MAIN);
     lv_obj_set_style_pad_top(page, 94, 0);
 
     lv_obj_t *section = lv_menu_section_create(page);
     lv_obj_add_style(section, &style_submenu, LV_PART_MAIN);
-    lv_obj_set_size(section, 1053, 894);
+    lv_obj_set_size(section, 1053, 984);
 
     snprintf(buf, sizeof(buf), "%s:", _lang("Record Option"));
     create_text(NULL, section, false, buf, LV_MENU_ITEM_BUILDER_VARIANT_2);
 
     lv_obj_t *cont = lv_obj_create(section);
-    lv_obj_set_size(cont, 960, 600);
+    lv_obj_set_size(cont, 960, 680);
     lv_obj_set_pos(cont, 0, 0);
     lv_obj_set_layout(cont, LV_LAYOUT_GRID);
     lv_obj_clear_flag(cont, LV_OBJ_FLAG_SCROLLABLE);
@@ -69,15 +70,17 @@ static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
 
     create_btn_group_item(&btn_group_record_mode, cont, 2, _lang("Record Mode"), _lang("Auto"), _lang("Manual"), "", "", 0);
     create_btn_group_item(&btn_group_format, cont, 2, _lang("Record Format"), "MP4", "TS", "", "", 1);
-    create_btn_group_item(&btn_group_record_osd, cont, 2, _lang("Record OSD"), _lang("Yes"), _lang("No"), "", "", 2);
-    create_btn_group_item(&btn_group_record_audio, cont, 2, _lang("Record Audio"), _lang("Yes"), _lang("No"), "", "", 3);
-    create_btn_group_item(&btn_group_audio_source, cont, 3, _lang("Audio Source"), _lang("Mic"), _lang("Line In"), _lang("A/V In"), "", 4);
-    create_btn_group_item(&btn_group_file_naming, cont, 2, _lang("Naming Scheme"), _lang("Digits"), _lang("Date"), "", "", 5);
+    create_btn_group_item(&btn_group_bitrate_scale, cont, 3, _lang("Record Bitrate"), _lang("Normal"), "1/2", "1/4", "", 2);
+    create_btn_group_item(&btn_group_record_osd, cont, 2, _lang("Record OSD"), _lang("Yes"), _lang("No"), "", "", 3);
+    create_btn_group_item(&btn_group_record_audio, cont, 2, _lang("Record Audio"), _lang("Yes"), _lang("No"), "", "", 4);
+    create_btn_group_item(&btn_group_audio_source, cont, 3, _lang("Audio Source"), _lang("Mic"), _lang("Line In"), _lang("A/V In"), "", 5);
+    create_btn_group_item(&btn_group_file_naming, cont, 2, _lang("Naming Scheme"), _lang("Digits"), _lang("Date"), "", "", 6);
     snprintf(buf, sizeof(buf), "< %s", _lang("Back"));
-    create_label_item(cont, buf, 1, 6, 1);
+    create_label_item(cont, buf, 1, 7, 1);
 
     btn_group_set_sel(&btn_group_record_mode, g_setting.record.mode_manual ? 1 : 0);
     btn_group_set_sel(&btn_group_format, g_setting.record.format_ts ? 1 : 0);
+    btn_group_set_sel(&btn_group_bitrate_scale, g_setting.record.bitrate_scale);
     btn_group_set_sel(&btn_group_record_osd, g_setting.record.osd ? 0 : 1);
     btn_group_set_sel(&btn_group_record_audio, g_setting.record.audio ? 0 : 1);
     btn_group_set_sel(&btn_group_audio_source, g_setting.record.audio_source);
@@ -94,7 +97,7 @@ static lv_obj_t *page_record_create(lv_obj_t *parent, panel_arr_t *arr) {
     lv_obj_set_style_pad_top(label2, 12, 0);
     lv_label_set_long_mode(label2, LV_LABEL_LONG_WRAP);
     lv_obj_set_grid_cell(label2, LV_GRID_ALIGN_START, 1, 4,
-                         LV_GRID_ALIGN_START, 7, 3);
+                         LV_GRID_ALIGN_START, 8, 3);
 
     update_visibility();
 
@@ -115,19 +118,23 @@ static void page_record_on_click(uint8_t key, int sel) {
         else
             ini_puts("record", "type", "mp4", REC_CONF);
     } else if (sel == 2) {
+        btn_group_toggle_sel(&btn_group_bitrate_scale);
+        g_setting.record.bitrate_scale = btn_group_get_sel(&btn_group_bitrate_scale);
+        ini_putl("record", "bitrate_scale", g_setting.record.bitrate_scale, SETTING_INI);
+    } else if (sel == 3) {
         btn_group_toggle_sel(&btn_group_record_osd);
         g_setting.record.osd = !btn_group_get_sel(&btn_group_record_osd);
         settings_put_bool("record", "osd", g_setting.record.osd);
-    } else if (sel == 3) {
+    } else if (sel == 4) {
         btn_group_toggle_sel(&btn_group_record_audio);
         g_setting.record.audio = !btn_group_get_sel(&btn_group_record_audio);
         settings_put_bool("record", "audio", g_setting.record.audio);
         update_visibility();
-    } else if (sel == 4) {
+    } else if (sel == 5) {
         btn_group_toggle_sel(&btn_group_audio_source);
         g_setting.record.audio_source = btn_group_get_sel(&btn_group_audio_source);
         ini_putl("record", "audio_source", g_setting.record.audio_source, SETTING_INI);
-    } else if (sel == 5) {
+    } else if (sel == 6) {
         if (rtc_has_battery() == 0) {
             btn_group_toggle_sel(&btn_group_file_naming);
             g_setting.record.naming = btn_group_get_sel(&btn_group_file_naming);
@@ -139,7 +146,7 @@ static void page_record_on_click(uint8_t key, int sel) {
 page_pack_t pp_record = {
     .p_arr = {
         .cur = 0,
-        .max = 7,
+        .max = 8,
     },
     .name = "Record Option",
     .create = page_record_create,


### PR DESCRIPTION
This change allows lowering the bitrate for the video recording.

The user can now set the bitrate to either: normal, 1/2, 1/4

Since the default bitrate changes according to the resolution and framerate, setting a static bitrate would not make sense.
Therefore I chose to allow configuration in fractions of the original bitrate.

Screenshot:
![image](https://github.com/user-attachments/assets/ea846b2f-b542-4977-88a7-020711ec4563)
