### PR TITLE
add declarative firmware build via nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ media.tar.gz
 /.vscode/settings.json
 .DS_Store
 utilities/font/out
+
+# nix related
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note: decompressing the repository in Windows system may damage some files and p
 ### Devcontainer Setup
 
 This repository supports the [vscode devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) integration.
-To get started install docker, vscode and the decontainer extension.
+To get started, install docker, vscode and the devcontainer extension.
 A [prompt](https://code.visualstudio.com/docs/devcontainers/create-dev-container#_add-configuration-files-to-a-repository) to reopen this repository in a container should appear.
 
 ### Native Setup
@@ -28,11 +28,25 @@ An appropiate vscode build task ships with this repository as well.
 
 ```
 ~/hdzero-goggle$ cd build
-~/hdzero-goggle/build$ make clean all -j `nproc`
+~/hdzero-goggle/build$ make clean all -j $(nproc)
 ```
 
-The firmware is generated as ~/hdz_goggle/code/out/HDZERO_GOGGLE-x.x.x.bin
+The firmware is generated as hdzero-goggle/out/HDZERO_GOGGLE-x.x.x.bin
 Where x.x.x is the OTA_VER.RX_VER.VA_VER
+
+### Building the firmware using nix
+
+The nix build system can be used to build the firmware on any linux system.  
+Make sure that nix [is installed](https://nixos.org/download/), and the [flakes feature](https://wiki.nixos.org/wiki/Flakes) is enabled.  
+No bootstrapping or installation of any tools is required.
+
+Use this command to build the firmware
+
+```shellSession
+nix build .#goggle-app
+```
+
+After this succeeds, the firmware can be found under `./result` in the current directory.
 
 
 ## Loading the Firmware
@@ -81,7 +95,7 @@ sudo apt-get install build-essential libsdl2-dev
 ~/hdzero-goggle$ mkdir build_emu
 ~/hdzero-goggle$ cd build_emu
 ~/hdzero-goggle/build_emu$ cmake .. -DEMULATOR_BUILD=ON -DCMAKE_BUILD_TYPE=Debug
-~/hdzero-goggle/build_emu$ make -j `nproc`
+~/hdzero-goggle/build_emu$ make -j $(nproc)
 ~/hdzero-goggle/build_emu$ ./HDZGOGGLE
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+# This file is the entry point used by the nix package manager.
+# It declares package builds and development environments.
+# See https://wiki.nixos.org/wiki/Flakes for more information on the `flake.nix` format.
+# In case of questions, feel free to ask @DavHau
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nix-filter.url = "github:numtide/nix-filter";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    nix-filter,
+  }: let
+    # Currently can only support x86_64-linux builders, due to the hardcoded toolchain
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+
+    # Source code without the nix directory and flake files to improve build caching
+    hdzero-goggle-src = nix-filter.lib {
+      root = ./.;
+      exclude = [ "nix" "flake.nix" "flake.lock" ];
+    };
+  in
+  {
+    # Packages that can be built via `nix build .#<name>`
+    packages.${system} = {
+
+      # the goggle app including the jffs2 image with service binaries
+      goggle-app = pkgs.callPackage ./nix/goggle-app.nix {
+        inherit hdzero-goggle-src;
+        inherit (self.packages.${system}) toolchain;
+      };
+
+      # make the goggle app the default package
+      default = self.packages.${system}.goggle-app;
+
+      # patched toolchain to make compatible with nix build sandbox
+      toolchain = pkgs.callPackage ./nix/toolchain.nix {};
+    };
+
+    # a dev environment which can be entered via `nix develop .`
+    devShells.${system}.default = pkgs.callPackage ./nix/devShell.nix {
+      inherit (self.packages.${system}) toolchain;
+    };
+  };
+}

--- a/mkapp/mkapp_ota.sh
+++ b/mkapp/mkapp_ota.sh
@@ -2,7 +2,7 @@
 set -e
 
 function make_img_md5() {
-    ${BIN_DIR}/md5sum $1 | awk '{print $1}' > $1.md5
+    md5sum $1 | awk '{print $1}' > $1.md5
 }
 
 function get_app_version() {
@@ -10,7 +10,7 @@ function get_app_version() {
 
     # check if we are on a tag
     git describe --exact-match --tags HEAD > /dev/null 2>&1
-    if [ $? -ne 0 ]; then 
+    if [ $? -ne 0 ]; then
         # no? attach commit hash
         echo "${base_version}-$(git rev-parse --short HEAD)"
     else
@@ -29,12 +29,15 @@ APP_SIZE=8388608
 APP_IMAGE=${IMG_DIR}/app.fex
 APP_VERSION=$(get_app_version)
 
+# append BIN_DIR to PATH, preferring tooling which is already in PATH
+export PATH="${PATH:+$PATH:}${BIN_DIR}"
+
 echo "${APP_VERSION}" > ${APP_DIR}/version
 
 rm -rf $IMG_DIR
 mkdir -p $IMG_DIR
 
-${BIN_DIR}/mkfs.jffs2 \
+mkfs.jffs2 \
     --little-endian \
     --eraseblock=0x10000 \
     --root=${APP_DIR} \
@@ -57,14 +60,14 @@ HAL_VA_VER=${HAL_VERSION#*-}
 
 OTA_VERSION="${HAL_VERSION}-${APP_VERSION}"
 
-cp $MKAPP_DIR/hal/HDZGOGGLE_RX.bin HDZGOGGLE_RX-${HAL_RX_VER}.bin 
-cp $MKAPP_DIR/hal/HDZGOGGLE_VA.bin HDZGOGGLE_VA-${HAL_VA_VER}.bin 
+cp $MKAPP_DIR/hal/HDZGOGGLE_RX.bin HDZGOGGLE_RX-${HAL_RX_VER}.bin
+cp $MKAPP_DIR/hal/HDZGOGGLE_VA.bin HDZGOGGLE_VA-${HAL_VA_VER}.bin
 
 echo -e "\npacking ota:"
 rm $ROOT_DIR/out/HDZERO_GOGGLE-* || true
 tar cvf $ROOT_DIR/out/HDZERO_GOGGLE-${OTA_VERSION}.bin \
     hdzgoggle_app_ota-${APP_VERSION}.tar \
     HDZGOGGLE_RX-${HAL_RX_VER}.bin \
-    HDZGOGGLE_VA-${HAL_VA_VER}.bin 
+    HDZGOGGLE_VA-${HAL_VA_VER}.bin
 
 echo -e "\ngenerated out/HDZERO_GOGGLE-${OTA_VERSION}.bin"

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,19 @@
+{
+  mkShell,
+  cmake,
+  libxcrypt,
+  sdl2-compat,
+  mtdutils,
+
+  # defined by this project
+  toolchain,
+}:
+mkShell {
+  packages = [
+    cmake
+    libxcrypt
+    sdl2-compat.dev
+    mtdutils
+  ];
+  CMAKE_TOOLCHAIN_FILE = "${toolchain}/share/buildroot/toolchainfile.cmake";
+}

--- a/nix/goggle-app.nix
+++ b/nix/goggle-app.nix
@@ -1,0 +1,42 @@
+{
+  # nixpkgs inputs
+  cmake,
+  lib,
+  mtdutils,
+  stdenv,
+
+  # defined by this project
+  hdzero-goggle-src,
+  toolchain,
+}:
+let
+  inherit (lib)
+    readFile
+    removeSuffix
+    ;
+  version = removeSuffix "\n" (readFile (hdzero-goggle-src + "/VERSION"));
+in
+stdenv.mkDerivation {
+  pname = "hdzero-goggle";
+  version = version;
+  src = hdzero-goggle-src;
+  postPatch = ''
+    substituteInPlace ./mkapp/mkapp_ota.sh \
+      --replace-fail "APP_VERSION=\$(get_app_version)" "APP_VERSION=${version}"
+    patchShebangs ./mkapp
+  '';
+  dontConfigure = true;
+  dontInstall = true;
+  dontFixup = true;
+  nativeBuildInputs = [
+    cmake
+    mtdutils
+  ];
+  buildPhase = ''
+    mkdir build
+    cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${toolchain}/share/buildroot/toolchainfile.cmake -Bbuild
+    cd build
+    make all -j$NIX_BUILD_CORES
+    mv ../out $out
+  '';
+}

--- a/nix/toolchain.nix
+++ b/nix/toolchain.nix
@@ -1,0 +1,29 @@
+{
+  autoPatchelfHook,
+  coreutils,
+  fetchzip,
+  libgcc,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  name = "hdzero-google-toolchain";
+  src = fetchzip {
+    url = "https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/armv7-eabihf--musl--stable-2018.02-2.tar.bz2";
+    sha256 = "sha256-rcUDw4I7hryOzgY7aJwUuiQLpXX5MRKdGK0m1irzvfQ=";
+  };
+  dontCheckForBrokenSymlinks = true;
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    libgcc.lib
+  ];
+  buildPhase = ''
+    cp -r . $out
+  '';
+  postFixup = ''
+    for file in $(find $out -type f); do
+      sed -i "s|/bin/true|${coreutils}/bin/true|g" $file
+    done
+  '';
+}


### PR DESCRIPTION
This allows developers with a linux machine or docker or wsl to build
the app via this command.

```nix
nix build .#goggle-app
```

Except the nix package manager, no other tools need to be installed and
no environment needs to be set up.

The nix build system is quite flexible and has a rich ecosystem.
In the future, the nix declarations could be extended in order to:

- add automated testing to the build pipeline
- switch to a recent toolchain instead of the outdated one from 2018
currently pulled in by `setup.sh`
- cleanup the repo from binary files like busybox, tinycurl, dropbear,
etc. Instead declare dependencies through its source and build
definition, which simplifies updating, modifying and adding stuff.
- update the currently used 4.9.X linux kernel which is end-of-life
since 2023 and likely insecure
- declare a reproducible build for the base os, so it can be more easily
extended by the community
- improve the firmware architecture and update mechanism to make it easy
to deliver updates including the base os
