### PR TITLE
Enable 802.11n support for double the bandwidth when running as host.

### DIFF
--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -178,6 +178,8 @@ static void page_wifi_update_services() {
         fprintf(fp, "ssid=%s\n", g_setting.wifi.ssid[WIFI_MODE_AP]);
         fprintf(fp, "channel=%d\n", g_setting.wifi.rf_channel);
         fprintf(fp, "hw_mode=g\n");
+        fprintf(fp, "ieee80211n=1\n");
+        fprintf(fp, "wmm_enabled=1\n");
         fprintf(fp, "ignore_broadcast_ssid=0\n");
         fprintf(fp, "auth_algs=1\n");
         fprintf(fp, "wpa=3\n");


### PR DESCRIPTION
Title says it all.... we can now achieve close to 5.5MB/s when goggle is running as host.

Top terminal is the goggles running iperf3 as a server.
Bottom terminal is the macbook running iperf3 as a client.

![Screenshot 2025-04-03 at 10 41 24 PM](https://github.com/user-attachments/assets/4537f0f4-3614-4c35-83a7-2880037f5f3a)
