### PR TITLE
Fix post bootup action

### DIFF
--- a/src/core/common.c
+++ b/src/core/common.c
@@ -14,7 +14,8 @@
 // globals
 pthread_mutex_t lvgl_mutex;
 atomic_int g_key = 0;
-atomic_int g_init_done = 0; // 0= init not done, 1= done, -1= dial/up/down pressed
+atomic_int g_init_done = 0;       // 0= init not done, 1= done, -1= dial/up/down pressed
+atomic_int g_bootup_sdcard_state; // 0= no card, 1= has card, -1= finalized
 static hw_revision_t g_hw_revsion = HW_REV_UNKNOWN;
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/core/common.hh
+++ b/src/core/common.hh
@@ -34,6 +34,7 @@ hw_revision_t getHwRevision();
 
 extern atomic_int g_key;
 extern atomic_int g_init_done;
+extern atomic_int g_bootup_sdcard_state;
 extern pthread_mutex_t lvgl_mutex;
 
 #ifdef __cplusplus

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -51,6 +51,7 @@ SDL_mutex *global_sdl_mutex;
 #include "ui/ui_osd_element_pos.h"
 #include "ui/ui_porting.h"
 #include "ui/ui_statusbar.h"
+#include "util/sdcard.h"
 
 int gif_cnt = 0;
 
@@ -199,6 +200,7 @@ int main(int argc, char *argv[]) {
     }
 
     // 7. Start threads
+    g_bootup_sdcard_state = sdcard_mounted() ? 1 : 0;
     start_running();
     create_threads();
 

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -31,40 +31,71 @@
 #include "util/sdcard.h"
 #include "util/system.h"
 
-extern bool bootup_actions_completed;
-
 void (*sdcard_ready_cb)() = NULL;
 
 ///////////////////////////////////////////////////////////////////////////////
 // SD card exist
 static void detect_sdcard(void) {
-    // Skip detection during bootup
-    if (bootup_actions_completed) {
-        static bool sdcard_init_scan = true;
-        static bool sdcard_enable_last = false;
+    static bool sdcard_init_scan = true;
+    static bool sdcard_enable_last = false;
 
-        if (!page_storage_is_sd_repair_active()) {
-            g_sdcard_enable = sdcard_mounted();
+    bool ok_to_execute =
+        page_storage_was_sd_repair_invoked() &&
+        !page_storage_is_sd_repair_active();
 
+    // Only run this logic when page storage repair thread
+    // has been invoked at least once and that the sdcard
+    // repair is not currently executing.
+    if (ok_to_execute) {
+        g_sdcard_enable = sdcard_mounted();
+
+        // General Runtime behavior
+        if (-1 == g_bootup_sdcard_state) {
             if ((g_sdcard_enable && !sdcard_enable_last) || g_sdcard_det_req) {
                 sdcard_update_free_size();
                 g_sdcard_det_req = 0;
             }
 
-            // Repair when inserted
-            if (g_init_done) {
-                if (sdcard_init_scan && g_sdcard_enable) {
-                    if (sdcard_ready_cb) {
-                        sdcard_ready_cb();
-                    }
-                    sdcard_init_scan = false;
-                    sdcard_ready_cb = page_storage_init_auto_sd_repair;
-                } else if (!g_sdcard_enable && sdcard_enable_last) {
-                    sdcard_init_scan = true;
+            // Only repair card at when inserted
+            if (sdcard_init_scan && g_sdcard_enable) {
+                if (sdcard_ready_cb) {
+                    sdcard_ready_cb();
                 }
+                sdcard_init_scan = false;
+            } else if (!g_sdcard_enable && sdcard_enable_last) {
+                sdcard_init_scan = true;
             }
 
             sdcard_enable_last = g_sdcard_enable;
+        }
+        // SDCard detected at bootup
+        else if (1 == g_bootup_sdcard_state) {
+            // Wait until card is mounted and ready.
+            if (g_sdcard_enable) {
+                sdcard_update_free_size();
+
+                // Invoke post bootup completed action
+                if (sdcard_ready_cb) {
+                    sdcard_ready_cb();
+                }
+
+                // Prevent sd repair from re-running twice once
+                // we transition into General Runtime behavior!
+                sdcard_init_scan = false;
+                sdcard_enable_last = true;
+                g_bootup_sdcard_state = -1;
+                sdcard_ready_cb = page_storage_init_auto_sd_repair;
+            }
+        }
+        // SDCard NOT found during bootup
+        else {
+            // Invoke post bootup completed action
+            if (sdcard_ready_cb) {
+                sdcard_ready_cb();
+            }
+
+            g_bootup_sdcard_state = -1;
+            sdcard_ready_cb = page_storage_init_auto_sd_repair;
         }
     }
 }
@@ -204,7 +235,6 @@ static void threads_instance(threads_obj_t *obj) {
 
 int create_threads() {
     int ret = 0;
-
     threads_obj_t *obj = &threads_obj;
     threads_instance(obj);
     for (int i = 0; i < THREAD_COUNT; i++) {

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -56,7 +56,7 @@ static void detect_sdcard(void) {
                 g_sdcard_det_req = 0;
             }
 
-            // Only repair card at when inserted
+            // Only repair sd card when inserted
             if (sdcard_init_scan && g_sdcard_enable) {
                 if (sdcard_ready_cb) {
                     sdcard_ready_cb();

--- a/src/ui/page_storage.h
+++ b/src/ui/page_storage.h
@@ -8,6 +8,7 @@ extern "C" {
 
 extern page_pack_t pp_storage;
 
+bool page_storage_was_sd_repair_invoked();
 bool page_storage_is_sd_repair_active();
 void page_storage_init_auto_sd_repair();
 

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -122,6 +122,7 @@ static lv_coord_t row_dsc[] = {60, 60, 60, 60, 60, 60, 60, 60, 40, LV_GRID_TEMPL
 static page_options_t page_wifi = {0};
 static lv_timer_t *page_wifi_apply_settings_timer = NULL;
 static lv_timer_t *page_wifi_apply_settings_pending_timer = NULL;
+static bool page_wifi_pending = true;
 
 /**
  * Refresh WiFi service configuration parameters.
@@ -1152,6 +1153,7 @@ void page_wifi_post_bootup_action(void (*complete_callback)()) {
     page_wifi_update_settings();
 
     if (complete_callback != NULL) {
+        page_wifi_pending = false;
         complete_callback();
     }
 }
@@ -1182,20 +1184,24 @@ page_pack_t pp_wifi = {
  * Provides the WiFi status string referenced by ui_statusbar.
  */
 void page_wifi_get_statusbar_text(char *buffer, int size) {
-    if (g_setting.wifi.enable) {
-        switch (g_setting.wifi.mode) {
-        case WIFI_MODE_AP:
-            snprintf(buffer, size, "WiFi: %s", g_setting.wifi.ssid[WIFI_MODE_AP]);
-            break;
-        case WIFI_MODE_STA:
-            if (page_wifi_get_real_address()) {
-                snprintf(buffer, size, "WiFi: %s", g_setting.wifi.ssid[WIFI_MODE_STA]);
-            } else {
-                snprintf(buffer, size, "WiFi: %s", _lang("Searching"));
+    if (!page_wifi_pending) {
+        if (g_setting.wifi.enable) {
+            switch (g_setting.wifi.mode) {
+            case WIFI_MODE_AP:
+                snprintf(buffer, size, "WiFi: %s", g_setting.wifi.ssid[WIFI_MODE_AP]);
+                break;
+            case WIFI_MODE_STA:
+                if (page_wifi_get_real_address()) {
+                    snprintf(buffer, size, "WiFi: %s", g_setting.wifi.ssid[WIFI_MODE_STA]);
+                } else {
+                    snprintf(buffer, size, "WiFi: %s", _lang("Searching"));
+                }
+                break;
             }
-            break;
+        } else {
+            snprintf(buffer, size, "WiFi: %s", _lang("Off"));
         }
     } else {
-        snprintf(buffer, size, "WiFi: %s", _lang("Off"));
+        snprintf(buffer, size, "WiFi: %s", _lang("Pending"));
     }
 }

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -291,13 +291,15 @@ static void main_menu_create_entry(lv_obj_t *menu, lv_obj_t *section, page_pack_
     }
 }
 
-static int post_bootup_actions_cmp(const void * lhs, const void * rhs) {
-    const int32_t leftPriority = ((page_pack_t*) lhs)->post_bootup_run_priority;
-    const int32_t rightPriority = ((page_pack_t*) rhs)->post_bootup_run_priority;
+static int post_bootup_actions_cmp(const void *lhs, const void *rhs) {
+    page_pack_t *lpp = *(page_pack_t **)lhs;
+    page_pack_t *rpp = *(page_pack_t **)rhs;
+    const int32_t lpri = lpp->post_bootup_run_priority;
+    const int32_t rpri = rpp->post_bootup_run_priority;
 
-    if (leftPriority < rightPriority) {
+    if (lpri < rpri) {
         return -1;
-    } else if (leftPriority > rightPriority) {
+    } else if (lpri > rpri) {
         return 1;
     }
 
@@ -329,7 +331,7 @@ void main_menu_init(void) {
     }
 
     // Resort based on priority
-    qsort(post_bootup_actions, post_bootup_actions_count, sizeof(page_pack_t*), post_bootup_actions_cmp);
+    qsort(post_bootup_actions, post_bootup_actions_count, sizeof(post_bootup_actions[0]), post_bootup_actions_cmp);
 
     lv_obj_add_style(section, &style_rootmenu, LV_PART_MAIN);
     lv_obj_set_size(section, 250, 975);

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -72,6 +72,7 @@ static page_pack_t *page_packs[] = {
 static page_pack_t *post_bootup_actions[PAGE_COUNT];
 static size_t post_bootup_actions_count = 0;
 static bool bootup_actions_fired = false;
+bool bootup_actions_completed = false;
 
 static page_pack_t *find_pp(lv_obj_t *page) {
     for (uint32_t i = 0; i < PAGE_COUNT; i++) {
@@ -365,6 +366,7 @@ static void bootup_action_completed() {
 static void handle_bootup_action() {
     static page_pack_t **next_bootup_action = &post_bootup_actions[0];
     if (next_bootup_action - &post_bootup_actions[0] >= post_bootup_actions_count) {
+        bootup_actions_completed = true;
         return;
     }
 

--- a/src/ui/ui_main_menu.c
+++ b/src/ui/ui_main_menu.c
@@ -72,7 +72,6 @@ static page_pack_t *page_packs[] = {
 static page_pack_t *post_bootup_actions[PAGE_COUNT];
 static size_t post_bootup_actions_count = 0;
 static bool bootup_actions_fired = false;
-bool bootup_actions_completed = false;
 
 static page_pack_t *find_pp(lv_obj_t *page) {
     for (uint32_t i = 0; i < PAGE_COUNT; i++) {
@@ -366,7 +365,6 @@ static void bootup_action_completed() {
 static void handle_bootup_action() {
     static page_pack_t **next_bootup_action = &post_bootup_actions[0];
     if (next_bootup_action - &post_bootup_actions[0] >= post_bootup_actions_count) {
-        bootup_actions_completed = true;
         return;
     }
 


### PR DESCRIPTION
Fixed a few issues where the refactor of post bootup actions caused breakage.

1. SD Card repair thread needs to complete prior to invoking next boot action, thus we need to hold onto the bootup_complete_cb to invoke when thread is finished.

2. Sorting is now working as we need to apply indirection when passing pointers as arguments.

3. Preventing SD Card repair from running twice at bootup.  People should notice the SD Card becoming available at half the previous amount of time.