### PR TITLE
Postbootup enhancements

### DIFF
--- a/src/ui/ui_statusbar.c
+++ b/src/ui/ui_statusbar.c
@@ -211,7 +211,7 @@ void statubar_update(void) {
     if (page_storage_is_sd_repair_active()) {
         lv_img_set_src(img_sdc, &img_sdcard);
         lv_label_set_text(label[STS_SDCARD], _lang("Integrity check"));
-    } else {
+    } else if (-1 == g_bootup_sdcard_state) {
         if (g_sdcard_enable) {
             int cnt = get_videofile_cnt();
             float gb = sdcard_free_size() / 1024.0;


### PR DESCRIPTION
This PR contains few enhancements.

1. Only report sd card status once post bootup actions have completed for sd card repair.  This removes the erroneous sd card status reports while the sd card is remounting.

2. There is no need to stop wifi services when we are initially bootup up.... This will save a second or two of postbootup action execution time.

3. Added comments to overall slider switch statements for readability.