### PR TITLE
Add manual and automatic NTP time sync options in Clock menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,9 @@ if(EMULATOR_BUILD)
 else()
 	list(APPEND SRC_FILES ${SRC_FILES_PLAYER})
 endif()
-add_executable(${PROJECT_NAME} ${SRC_FILES})
+add_executable(${PROJECT_NAME} ${SRC_FILES}
+	src/util/wifi_status.c
+)
 
 target_include_directories(${PROJECT_NAME} PRIVATE 
 	src/

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -323,6 +323,8 @@ void settings_init(void) {
     int file_version = ini_getl("settings", "file_version", SETTINGS_INI_VERSION_UNKNOWN, SETTING_INI);
     if (file_version != SETTING_INI_VERSION)
         settings_reset();
+
+    g_setting.clock.auto_sync = ini_getl("clock", "auto_sync", 0, SETTING_INI);
 }
 
 void settings_load(void) {

--- a/src/core/settings.c
+++ b/src/core/settings.c
@@ -178,6 +178,7 @@ const setting_t g_setting_defaults = {
             },
         },
     },
+    // En la inicialización de g_setting_defaults en settings.c
     .clock = {
         .year = 2023,
         .month = 3,
@@ -186,6 +187,7 @@ const setting_t g_setting_defaults = {
         .min = 30,
         .sec = 30,
         .format = 0,
+        .utc_offset = 0, // UTC±00:00 por defecto
     },
     // Refer to `page_input.c`'s arrays `rollerFunctionPointers` and `btnFunctionPointers`
     .inputs = {
@@ -467,6 +469,9 @@ void settings_load(void) {
     if (!language_config()) {
         g_setting.language.lang = ini_getl("language", "lang", g_setting_defaults.language.lang, SETTING_INI);
     }
+
+    // UTC
+    g_setting.clock.utc_offset = ini_getl("clock", "utc_offset", 0, SETTING_INI); // Por defecto UTC±00:00
 
     // Check
     if (fs_file_exists(SELF_TEST_FILE)) {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -199,6 +199,7 @@ typedef struct {
     int sec;
     int format;
     int utc_offset;
+    int auto_sync; // 0: Disabled, 1: Enabled
 } setting_clock_t;
 
 #define WIFI_RF_CHANNELS  14 // World Channels

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -198,6 +198,7 @@ typedef struct {
     int min;
     int sec;
     int format;
+    int utc_offset;
 } setting_clock_t;
 
 #define WIFI_RF_CHANNELS  14 // World Channels

--- a/src/ui/page_clock.c
+++ b/src/ui/page_clock.c
@@ -84,7 +84,7 @@ static int page_clock_set_clock_confirm = 0;
 static int page_clock_is_dirty = 0;
 static struct rtc_date page_clock_rtc_date = {0};
 
-// Opciones de zona horaria UTC
+// UTC timezone options
 static char* utc_options[] = {
     "UTC-12:00", "UTC-11:00", "UTC-10:00", "UTC-09:00", "UTC-08:00",
     "UTC-07:00", "UTC-06:00", "UTC-05:00", "UTC-04:00", "UTC-03:00",
@@ -94,7 +94,7 @@ static char* utc_options[] = {
     "UTC+13:00", "UTC+14:00"
 };
 
-// Valores de offset en segundos correspondientes a las opciones
+// Offset values in seconds corresponding to the options
 static const int utc_seconds[] = {
 -43200,  // UTC−12:00
 -39600,  // UTC−11:00
@@ -125,10 +125,10 @@ static const int utc_seconds[] = {
  50400   // UTC+14:00
 };
 
-// Convertir offset en segundos a índice en el array
+// Convert seconds offset to array index
 int utc_offset_to_index(int offset_seconds) {
-    // Buscar el offset más cercano
-    int index = 12; // Por defecto UTC±00:00
+    // Find closest offset
+    int index = 12; // Default UTC±00:00
     int min_diff = abs(offset_seconds);
     
     for (int i = 0; i < sizeof(utc_seconds)/sizeof(utc_seconds[0]); i++) {
@@ -142,13 +142,13 @@ int utc_offset_to_index(int offset_seconds) {
     return index;
 }
 
-// Convertir índice a offset en segundos
+// Convert index to seconds offset 
 int index_to_utc_offset(int index) {
     if (index >= 0 && index < sizeof(utc_seconds)/sizeof(utc_seconds[0])) {
         return utc_seconds[index];
     }
     
-    return 0; // Por defecto UTC±00:00
+    return 0; // Default UTC±00:00
 }
 
 /**

--- a/src/ui/page_clock.c
+++ b/src/ui/page_clock.c
@@ -495,15 +495,26 @@ static lv_obj_t *page_clock_create(lv_obj_t *parent, panel_arr_t *arr) {
     btn_group_set_sel(&page_clock_items[ITEM_FORMAT].data.btn, g_setting.clock.format);
 
     // Time Zone label y dropdown - En una nueva fila
-    create_label_item(cont, _lang("Time Zone"), 1, 3, 1);
+    lv_obj_t* label = create_label_item(cont, _lang("Time Zone"), 1, 3, 1);
     
-    lv_obj_t* utc_dropdown = lv_dropdown_create(cont);
+    lv_obj_t* utc_dropdown = create_dropdown_item(
+        cont,                      // parent
+        "",                       // inicialmente vacío
+        2,                        // columna
+        3,                        // fila
+        200,                      // ancho
+        row_dsc[3],              // altura (usar la altura de la fila)
+        2,                        // col_span
+        10,                       // padding_top fijo de 10
+        LV_GRID_ALIGN_START,      // alineación
+        &lv_font_montserrat_26    // fuente
+    );
+
+    // Agregar las opciones al dropdown
     lv_dropdown_clear_options(utc_dropdown);
     for (int i = 0; i < sizeof(utc_options)/sizeof(utc_options[0]); i++) {
         lv_dropdown_add_option(utc_dropdown, utc_options[i], LV_DROPDOWN_POS_LAST);
     }
-    lv_obj_set_size(utc_dropdown, 200, 40);
-    lv_obj_set_grid_cell(utc_dropdown, LV_GRID_ALIGN_START, 2, 2, LV_GRID_ALIGN_START, 3, 1);
     lv_dropdown_set_selected(utc_dropdown, utc_offset_to_index(g_setting.clock.utc_offset));
 
     page_clock_items[ITEM_UTC].data.obj = utc_dropdown;

--- a/src/ui/page_clock.h
+++ b/src/ui/page_clock.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 #include "ui/ui_main_menu.h"
+#include "util/ntp_client.h"  // Incluir la cabecera en lugar de declarar la función
 
 extern page_pack_t pp_clock;
 

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -881,7 +881,7 @@ static void page_wifi_on_update(uint32_t delta_ms) {
         was_connected = is_connected;
     }
 
-    // Verificar inmediatamente después de ejecutar, luego cada 5 minutos para actualizaciones.
+    // Check immediately after executing, then every 5 minutes for updates.
     if (g_setting.wifi.enable && (elapsed == -1 || (elapsed += delta_ms) > 300000)) {
         switch (g_setting.wifi.mode) {
         case WIFI_MODE_STA:

--- a/src/ui/page_wifi.c
+++ b/src/ui/page_wifi.c
@@ -340,6 +340,16 @@ static void page_wifi_update_settings() {
             system_exec("dropbear");
         }
     }
+
+    // Check if we should sync time when connected as client
+    if (g_setting.wifi.mode == WIFI_MODE_STA && g_setting.clock.auto_sync) {
+        WIFI_STA_CONNECT_STATUS_S status;
+        if (wifi_sta_get_connect_status("wlan0", &status) == 0 && 
+            status.state == WIFI_STA_STATUS_CONNECTED) {
+            // Trigger NTP sync
+            clock_sync_from_ntp();
+        }
+    }
 }
 
 /**

--- a/src/ui/page_wifi.h
+++ b/src/ui/page_wifi.h
@@ -9,7 +9,17 @@ extern "C" {
 extern page_pack_t pp_wifi;
 
 extern void page_wifi_get_statusbar_text(char *buffer, int size);
+extern bool page_wifi_is_sta_connected(void); // Nueva función
 
 #ifdef __cplusplus
 }
 #endif
+
+#ifndef PAGE_WIFI_H
+#define PAGE_WIFI_H
+
+#include <stdbool.h>
+
+bool page_wifi_is_sta_connected(void);
+
+#endif // PAGE_WIFI_H

--- a/src/util/ntp_client.c
+++ b/src/util/ntp_client.c
@@ -1,0 +1,145 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <time.h>
+#include <arpa/inet.h>
+
+#include <log/log.h>
+
+#include "driver/rtc.h"
+#include "util/system.h"
+#include "core/settings.h"
+#include "ui/page_clock.h"
+
+#define NTP_TIMESTAMP_DELTA 2208988800ull
+
+// Estructura del paquete NTP
+typedef struct {
+    uint8_t li_vn_mode;      /* leap indicator, version and mode */
+    uint8_t stratum;         /* stratum level */
+    uint8_t poll;            /* poll interval */
+    uint8_t precision;       /* precision */
+    uint32_t rootdelay;      /* root delay */
+    uint32_t rootdispersion; /* root dispersion */
+    uint32_t refid;          /* reference ID */
+    uint32_t refts_sec;      /* reference timestamp seconds */
+    uint32_t refts_frac;     /* reference timestamp fraction */
+    uint32_t origts_sec;     /* originate timestamp seconds */
+    uint32_t origts_frac;    /* originate timestamp fraction */
+    uint32_t recvts_sec;     /* receive timestamp seconds */
+    uint32_t recvts_frac;    /* receive timestamp fraction */
+    uint32_t xmitts_sec;     /* transmit timestamp seconds */
+    uint32_t xmitts_frac;    /* transmit timestamp fraction */
+} ntp_packet;
+
+int clock_sync_from_ntp(void) {
+    int sockfd, n;
+    struct sockaddr_in serv_addr;
+    struct hostent *server;
+    ntp_packet packet = {0};
+    
+    // Verificar si WiFi está habilitado
+    if (!g_setting.wifi.enable) {
+        LOGE("WiFi disabled, cannot sync time from NTP");
+        return -1;
+    }
+    
+    // Habilitar WiFi si es necesario
+    system_exec("ifconfig wlan0 up");
+    usleep(1000000); // Esperar 1 segundo para que se conecte
+    
+    // Inicializar paquete NTP
+    packet.li_vn_mode = 0x1b; // Leap = 0, Version = 3, Mode = 3 (cliente)
+    
+    // Crear socket
+    sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sockfd < 0) {
+        LOGE("Error opening socket for NTP");
+        return -1;
+    }
+    
+    // Configurar timeout
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+        LOGE("Error setting socket timeout");
+        close(sockfd);
+        return -1;
+    }
+    
+    // Configurar servidor NTP - intentar conexión por nombre
+    server = gethostbyname("pool.ntp.org");
+    if (server == NULL) {
+        LOGI("Could not resolve pool.ntp.org, trying with IP address");
+        // Si falla, intentar con IPs directas
+        memset((char *)&serv_addr, 0, sizeof(serv_addr));
+        serv_addr.sin_family = AF_INET;
+        serv_addr.sin_port = htons(123); // Puerto NTP
+        
+        // Intentar con una IP estática de un servidor NTP conocido
+        if (inet_pton(AF_INET, "162.159.200.1", &serv_addr.sin_addr) <= 0) {
+            LOGE("Invalid NTP server address");
+            close(sockfd);
+            return -1;
+        }
+    } else {
+        // Configuración normal si la resolución de nombres funciona
+        memset((char *)&serv_addr, 0, sizeof(serv_addr));
+        serv_addr.sin_family = AF_INET;
+        memcpy((char *)&serv_addr.sin_addr.s_addr, (char *)server->h_addr, server->h_length);
+        serv_addr.sin_port = htons(123); // Puerto NTP
+    }
+    
+    // Enviar paquete
+    n = sendto(sockfd, (char *)&packet, sizeof(ntp_packet), 0, 
+              (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+    if (n < 0) {
+        LOGE("Error writing to socket for NTP");
+        close(sockfd);
+        return -1;
+    }
+    
+    // Recibir respuesta
+    n = recvfrom(sockfd, (char *)&packet, sizeof(ntp_packet), 0, NULL, NULL);
+    if (n < 0) {
+        LOGE("Error reading from socket for NTP");
+        close(sockfd);
+        return -1;
+    }
+    
+    close(sockfd);
+    
+    // Convertir tiempo recibido
+    uint32_t txTm = ntohl(packet.xmitts_sec);
+    time_t time_ntp = txTm - NTP_TIMESTAMP_DELTA;
+    
+    LOGI("NTP time received: %u", (unsigned int)time_ntp);
+    
+    // Actualizar RTC con el tiempo recibido
+    struct timeval tv_now;
+    tv_now.tv_sec = time_ntp;
+    tv_now.tv_usec = 0;
+    
+    struct rtc_date rd;
+    rtc_tv2rd(&tv_now, &rd);
+    
+    // Validar la fecha
+    if (rtc_has_valid_date(&rd) != 0) {
+        LOGE("NTP returned invalid date: %04d-%02d-%02d %02d:%02d:%02d", 
+             rd.year, rd.month, rd.day, rd.hour, rd.min, rd.sec);
+        return -1;
+    }
+    
+    // Actualizar el RTC
+    rtc_set_clock(&rd);
+    LOGI("NTP time sync successful: %04d-%02d-%02d %02d:%02d:%02d", 
+         rd.year, rd.month, rd.day, rd.hour, rd.min, rd.sec);
+    
+    return 0;
+}

--- a/src/util/ntp_client.c
+++ b/src/util/ntp_client.c
@@ -1,3 +1,4 @@
+#include <minIni.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,6 +9,9 @@
 #include <netdb.h>
 #include <time.h>
 #include <arpa/inet.h>
+#include <pthread.h>
+#include <fcntl.h>
+#include <errno.h>
 
 #include <log/log.h>
 
@@ -15,10 +19,21 @@
 #include "util/system.h"
 #include "core/settings.h"
 #include "ui/page_clock.h"
+#include "util/ntp_client.h"
 
-#define NTP_TIMESTAMP_DELTA 2208988800ull
+#define NTP_TIMESTAMP_DELTA 2208988800ull  // Segundos entre 1900 (NTP) y 1970 (epoch)
+#define NTP_PORT 123
+#define NTP_TIMEOUT_SEC 3                  // Timeout reducido a 3 segundos
 
-// Estructura del paquete NTP
+// Estados para la sincronización NTP
+typedef enum {
+    NTP_SYNC_IDLE = 0,
+    NTP_SYNC_IN_PROGRESS,
+    NTP_SYNC_SUCCESS,
+    NTP_SYNC_FAILED
+} ntp_sync_state_t;
+
+// Estructura del paquete NTP según RFC 5905
 typedef struct {
     uint8_t li_vn_mode;      /* leap indicator, version and mode */
     uint8_t stratum;         /* stratum level */
@@ -35,111 +50,406 @@ typedef struct {
     uint32_t recvts_frac;    /* receive timestamp fraction */
     uint32_t xmitts_sec;     /* transmit timestamp seconds */
     uint32_t xmitts_frac;    /* transmit timestamp fraction */
-} ntp_packet;
+} ntp_packet_t;
 
-int clock_sync_from_ntp(void) {
-    int sockfd, n;
-    struct sockaddr_in serv_addr;
-    struct hostent *server;
-    ntp_packet packet = {0};
-    
-    // Verificar si WiFi está habilitado
-    if (!g_setting.wifi.enable) {
-        LOGE("WiFi disabled, cannot sync time from NTP");
+// Estructura para el callback
+typedef struct {
+    ntp_callback_t callback_fn;
+    void* user_data;
+} ntp_callback_data_t;
+
+// Variables globales
+static volatile ntp_sync_state_t g_ntp_sync_state = NTP_SYNC_IDLE;
+static pthread_mutex_t g_ntp_mutex = PTHREAD_MUTEX_INITIALIZER;
+static char* g_ntp_servers[] = {
+    "pool.ntp.org",
+    "time.google.com",
+    "time.cloudflare.com",
+    "time.apple.com",
+    "time.windows.com"
+};
+static const int g_ntp_server_count = sizeof(g_ntp_servers) / sizeof(g_ntp_servers[0]);
+
+// Lista de direcciones IP estáticas como respaldo
+static char* g_ntp_fallback_ips[] = {
+    "162.159.200.1",    // time.cloudflare.com
+    "216.239.35.4",     // time.google.com
+    "17.253.114.125",   // time.apple.com
+    "13.65.245.138"     // time.windows.com
+};
+static const int g_ntp_fallback_count = sizeof(g_ntp_fallback_ips) / sizeof(g_ntp_fallback_ips[0]);
+
+// Función para convertir el tiempo NTP a unix time
+static time_t ntp_time_to_unix_time(uint32_t ntp_time) {
+    return (time_t)(ntp_time - NTP_TIMESTAMP_DELTA);
+}
+
+// Función para establecer socket no bloqueante
+static int set_socket_nonblocking(int sockfd) {
+    int flags = fcntl(sockfd, F_GETFL, 0);
+    if (flags == -1) {
         return -1;
     }
-    
-    // Habilitar WiFi si es necesario
-    system_exec("ifconfig wlan0 up");
-    usleep(1000000); // Esperar 1 segundo para que se conecte
-    
-    // Inicializar paquete NTP
-    packet.li_vn_mode = 0x1b; // Leap = 0, Version = 3, Mode = 3 (cliente)
-    
-    // Crear socket
-    sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    return fcntl(sockfd, F_SETFL, flags | O_NONBLOCK);
+}
+
+// Función para intentar resolver y conectar a un servidor NTP
+static int connect_to_ntp_server(const char* server, struct sockaddr_in* serv_addr) {
+    int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (sockfd < 0) {
-        LOGE("Error opening socket for NTP");
+        LOGE("Error creating socket for NTP");
         return -1;
     }
-    
+
     // Configurar timeout
     struct timeval tv;
-    tv.tv_sec = 5;
+    tv.tv_sec = NTP_TIMEOUT_SEC;
     tv.tv_usec = 0;
-    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0 ||
+        setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+        LOGE("Error setting socket timeout");
+        close(sockfd);
+        return -1;
+    }
+
+    // Intentar resolver el nombre del servidor
+    struct hostent *host_entry = gethostbyname(server);
+    if (host_entry == NULL) {
+        LOGI("Could not resolve %s", server);
+        close(sockfd);
+        return -1;
+    }
+
+    // Configurar dirección del servidor
+    memset(serv_addr, 0, sizeof(struct sockaddr_in));
+    serv_addr->sin_family = AF_INET;
+    memcpy(&serv_addr->sin_addr.s_addr, host_entry->h_addr, host_entry->h_length);
+    serv_addr->sin_port = htons(NTP_PORT);
+
+    return sockfd;
+}
+
+// Función para intentar conectar a una IP de servidor NTP específica
+static int connect_to_ntp_ip(const char* ip_address, struct sockaddr_in* serv_addr) {
+    int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sockfd < 0) {
+        LOGE("Error creating socket for NTP");
+        return -1;
+    }
+
+    // Configurar timeout
+    struct timeval tv;
+    tv.tv_sec = NTP_TIMEOUT_SEC;
+    tv.tv_usec = 0;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0 ||
+        setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
         LOGE("Error setting socket timeout");
         close(sockfd);
         return -1;
     }
     
-    // Configurar servidor NTP - intentar conexión por nombre
-    server = gethostbyname("pool.ntp.org");
-    if (server == NULL) {
-        LOGI("Could not resolve pool.ntp.org, trying with IP address");
-        // Si falla, intentar con IPs directas
-        memset((char *)&serv_addr, 0, sizeof(serv_addr));
-        serv_addr.sin_family = AF_INET;
-        serv_addr.sin_port = htons(123); // Puerto NTP
-        
-        // Intentar con una IP estática de un servidor NTP conocido
-        if (inet_pton(AF_INET, "162.159.200.1", &serv_addr.sin_addr) <= 0) {
-            LOGE("Invalid NTP server address");
-            close(sockfd);
-            return -1;
+    // Configurar dirección del servidor
+    memset(serv_addr, 0, sizeof(struct sockaddr_in));
+    serv_addr->sin_family = AF_INET;
+    serv_addr->sin_port = htons(NTP_PORT);
+    
+    if (inet_pton(AF_INET, ip_address, &serv_addr->sin_addr) <= 0) {
+        LOGE("Invalid IP address: %s", ip_address);
+        close(sockfd);
+        return -1;
+    }
+    
+    return sockfd;
+}
+
+// Función para enviar y recibir paquete NTP (con reintentos)
+static int send_receive_ntp_packet(int sockfd, struct sockaddr_in* serv_addr, ntp_packet_t* packet) {
+    int retries = 3;
+    socklen_t addr_len = sizeof(struct sockaddr_in);
+    
+    // Inicializar paquete NTP
+    memset(packet, 0, sizeof(ntp_packet_t));
+    packet->li_vn_mode = 0x1b; // LI = 0, Version = 3, Mode = 3 (cliente)
+    
+    while (retries--) {
+        // Enviar paquete
+        if (sendto(sockfd, packet, sizeof(ntp_packet_t), 0, 
+                  (struct sockaddr *)serv_addr, addr_len) < 0) {
+            LOGE("Error sending NTP packet (retry %d): %s", 2-retries, strerror(errno));
+            continue;
         }
+        
+        // Configurar select para timeout
+        fd_set readfds;
+        FD_ZERO(&readfds);
+        FD_SET(sockfd, &readfds);
+        
+        struct timeval timeout;
+        timeout.tv_sec = 1;  // 1 segundo por intento
+        timeout.tv_usec = 0;
+        
+        int select_result = select(sockfd + 1, &readfds, NULL, NULL, &timeout);
+        
+        if (select_result <= 0) {
+            if (select_result == 0) {
+                LOGI("NTP response timeout (retry %d)", 2-retries);
+            } else {
+                LOGE("Select error (retry %d): %s", 2-retries, strerror(errno));
+            }
+            continue;
+        }
+        
+        // Recibir respuesta
+        if (recvfrom(sockfd, packet, sizeof(ntp_packet_t), 0, 
+                    (struct sockaddr *)serv_addr, &addr_len) < 0) {
+            LOGE("Error receiving NTP packet (retry %d): %s", 2-retries, strerror(errno));
+            continue;
+        }
+        
+        // Éxito
+        return 0;
+    }
+    
+    // Agotados los intentos
+    return -1;
+}
+
+// Función para calcular correctamente la diferencia de zona horaria
+static time_t apply_timezone_offset(time_t utc_time, int offset_seconds) {
+    // Simplemente sumar el offset en segundos
+    return utc_time + offset_seconds;
+}
+
+// Función que realiza la sincronización NTP (ejecutada en un hilo)
+static void* ntp_sync_thread(void* arg) {
+    ntp_callback_data_t* callback_data = (ntp_callback_data_t*)arg;
+    int result = -1;
+    int sockfd = -1;
+    ntp_packet_t packet;
+    struct sockaddr_in serv_addr;
+    
+    LOGI("NTP sync thread started");
+    
+    // Verificar si WiFi está habilitado
+    if (!g_setting.wifi.enable) {
+        LOGE("WiFi disabled, cannot sync time from NTP");
+        goto cleanup;
+    }
+    
+    // Asegurarse de que WiFi esté activo
+    system_exec("ifconfig wlan0 up");
+    usleep(500000); // Espera reducida a 0.5 segundos
+    
+    // Intentar varios servidores NTP
+    for (int i = 0; i < g_ntp_server_count; i++) {
+        LOGI("Trying NTP server: %s", g_ntp_servers[i]);
+        
+        sockfd = connect_to_ntp_server(g_ntp_servers[i], &serv_addr);
+        if (sockfd < 0) {
+            continue;
+        }
+        
+        if (send_receive_ntp_packet(sockfd, &serv_addr, &packet) == 0) {
+            result = 0;
+            break;
+        }
+        
+        close(sockfd);
+        sockfd = -1;
+    }
+    
+    // Si ningún servidor funciona, intentar con las IPs de respaldo
+    if (result != 0) {
+        LOGI("Trying fallback NTP server IPs");
+        for (int i = 0; i < g_ntp_fallback_count; i++) {
+            LOGI("Trying NTP fallback IP: %s", g_ntp_fallback_ips[i]);
+            
+            sockfd = connect_to_ntp_ip(g_ntp_fallback_ips[i], &serv_addr);
+            if (sockfd < 0) {
+                continue;
+            }
+            
+            if (send_receive_ntp_packet(sockfd, &serv_addr, &packet) == 0) {
+                result = 0;
+                break;
+            }
+            
+            close(sockfd);
+            sockfd = -1;
+        }
+    }
+    
+    if (result == 0) {
+        // Convertir tiempo recibido
+        uint32_t txTm = ntohl(packet.xmitts_sec);
+        time_t utc_time = ntp_time_to_unix_time(txTm);
+        
+        LOGI("NTP time received (UTC): %u", (unsigned int)utc_time);
+        
+        // Usar el offset configurado por el usuario 
+        int timezone_offset = g_setting.clock.utc_offset;
+        LOGI("Using configured timezone offset: %d seconds", timezone_offset);
+        
+        // Aplicar la zona horaria para obtener la hora local
+        time_t local_time = apply_timezone_offset(utc_time, timezone_offset);
+        LOGI("Local time after timezone adjustment: %u", (unsigned int)local_time);
+        
+        // Actualizar RTC con el tiempo recibido ajustado a zona horaria local
+        struct timeval tv_now;
+        tv_now.tv_sec = local_time;
+        tv_now.tv_usec = 0;
+        
+        struct rtc_date rd;
+        rtc_tv2rd(&tv_now, &rd);
+        
+        // Validar la fecha
+        if (rtc_has_valid_date(&rd) != 0) {
+            LOGE("NTP returned invalid date: %04d-%02d-%02d %02d:%02d:%02d", 
+                 rd.year, rd.month, rd.day, rd.hour, rd.min, rd.sec);
+            result = -1;
+        } else {
+            // Actualizar el RTC
+            rtc_set_clock(&rd);
+            LOGI("NTP time sync successful: %04d-%02d-%02d %02d:%02d:%02d", 
+                 rd.year, rd.month, rd.day, rd.hour, rd.min, rd.sec);
+            
+            // Guardar en settings
+            g_setting.clock.year = rd.year;
+            g_setting.clock.month = rd.month;
+            g_setting.clock.day = rd.day;
+            g_setting.clock.hour = rd.hour;
+            g_setting.clock.min = rd.min;
+            g_setting.clock.sec = rd.sec;
+            
+            // Actualizar archivo de configuración
+            ini_putl("clock", "year", g_setting.clock.year, SETTING_INI);
+            ini_putl("clock", "month", g_setting.clock.month, SETTING_INI);
+            ini_putl("clock", "day", g_setting.clock.day, SETTING_INI);
+            ini_putl("clock", "hour", g_setting.clock.hour, SETTING_INI);
+            ini_putl("clock", "min", g_setting.clock.min, SETTING_INI);
+            ini_putl("clock", "sec", g_setting.clock.sec, SETTING_INI);
+        }
+    }
+    
+cleanup:
+    if (sockfd >= 0) {
+        close(sockfd);
+    }
+    
+    // Actualizar estado
+    pthread_mutex_lock(&g_ntp_mutex);
+    g_ntp_sync_state = (result == 0) ? NTP_SYNC_SUCCESS : NTP_SYNC_FAILED;
+    pthread_mutex_unlock(&g_ntp_mutex);
+    
+    // Llamar al callback si existe
+    if (callback_data != NULL) {
+        if (callback_data->callback_fn != NULL) {
+            callback_data->callback_fn(result, callback_data->user_data);
+        }
+        free(callback_data);
+    }
+    
+    LOGI("NTP sync thread finished with result: %d", result);
+    return NULL;
+}
+
+// Función pública para verificar si hay una sincronización en progreso
+int clock_is_syncing_from_ntp(void) {
+    int is_syncing = 0;
+    
+    pthread_mutex_lock(&g_ntp_mutex);
+    is_syncing = (g_ntp_sync_state == NTP_SYNC_IN_PROGRESS);
+    pthread_mutex_unlock(&g_ntp_mutex);
+    
+    return is_syncing;
+}
+
+// Función pública para iniciar la sincronización NTP (asíncrona con callback)
+int clock_sync_from_ntp_async(ntp_callback_t callback_fn, void* user_data) {
+    int ret = -1;
+    
+    pthread_mutex_lock(&g_ntp_mutex);
+    
+    // Verificar si ya hay una sincronización en progreso
+    if (g_ntp_sync_state == NTP_SYNC_IN_PROGRESS) {
+        LOGI("NTP sync already in progress");
+        pthread_mutex_unlock(&g_ntp_mutex);
+        return -1;
+    }
+    
+    // Actualizar estado
+    g_ntp_sync_state = NTP_SYNC_IN_PROGRESS;
+    
+    // Preparar datos para el callback
+    ntp_callback_data_t* callback_data = malloc(sizeof(ntp_callback_data_t));
+    if (callback_data == NULL) {
+        LOGE("Failed to allocate memory for callback data");
+        g_ntp_sync_state = NTP_SYNC_IDLE;
+        pthread_mutex_unlock(&g_ntp_mutex);
+        return -1;
+    }
+    
+    callback_data->callback_fn = callback_fn;
+    callback_data->user_data = user_data;
+    
+    // Crear hilo para sincronización
+    pthread_t thread_id;
+    if (pthread_create(&thread_id, NULL, ntp_sync_thread, callback_data) != 0) {
+        LOGE("Error creating NTP thread");
+        g_ntp_sync_state = NTP_SYNC_IDLE;
+        free(callback_data);
+        ret = -1;
     } else {
-        // Configuración normal si la resolución de nombres funciona
-        memset((char *)&serv_addr, 0, sizeof(serv_addr));
-        serv_addr.sin_family = AF_INET;
-        memcpy((char *)&serv_addr.sin_addr.s_addr, (char *)server->h_addr, server->h_length);
-        serv_addr.sin_port = htons(123); // Puerto NTP
+        pthread_detach(thread_id);
+        ret = 0;
     }
     
-    // Enviar paquete
-    n = sendto(sockfd, (char *)&packet, sizeof(ntp_packet), 0, 
-              (struct sockaddr *)&serv_addr, sizeof(serv_addr));
-    if (n < 0) {
-        LOGE("Error writing to socket for NTP");
-        close(sockfd);
+    pthread_mutex_unlock(&g_ntp_mutex);
+    return ret;
+}
+
+// Función pública para compatibilidad con el código existente (bloqueante)
+int clock_sync_from_ntp(void) {
+    // Verificar si ya hay una sincronización en progreso
+    if (clock_is_syncing_from_ntp()) {
+        LOGI("NTP sync already in progress");
         return -1;
     }
     
-    // Recibir respuesta
-    n = recvfrom(sockfd, (char *)&packet, sizeof(ntp_packet), 0, NULL, NULL);
-    if (n < 0) {
-        LOGE("Error reading from socket for NTP");
-        close(sockfd);
+    // Intentar iniciar sincronización asíncrona sin callback
+    if (clock_sync_from_ntp_async(NULL, NULL) != 0) {
         return -1;
     }
     
-    close(sockfd);
+    // Esperar resultado (pero con timeout)
+    int result = -1;
+    int timeout_count = 0;
+    const int max_timeout = 10; // 10 * 100ms = 1 segundo máximo
     
-    // Convertir tiempo recibido
-    uint32_t txTm = ntohl(packet.xmitts_sec);
-    time_t time_ntp = txTm - NTP_TIMESTAMP_DELTA;
-    
-    LOGI("NTP time received: %u", (unsigned int)time_ntp);
-    
-    // Actualizar RTC con el tiempo recibido
-    struct timeval tv_now;
-    tv_now.tv_sec = time_ntp;
-    tv_now.tv_usec = 0;
-    
-    struct rtc_date rd;
-    rtc_tv2rd(&tv_now, &rd);
-    
-    // Validar la fecha
-    if (rtc_has_valid_date(&rd) != 0) {
-        LOGE("NTP returned invalid date: %04d-%02d-%02d %02d:%02d:%02d", 
-             rd.year, rd.month, rd.day, rd.hour, rd.min, rd.sec);
-        return -1;
+    while (timeout_count < max_timeout) {
+        usleep(100000); // 100ms
+        
+        pthread_mutex_lock(&g_ntp_mutex);
+        if (g_ntp_sync_state == NTP_SYNC_SUCCESS) {
+            result = 0;
+            g_ntp_sync_state = NTP_SYNC_IDLE;
+            pthread_mutex_unlock(&g_ntp_mutex);
+            break;
+        } else if (g_ntp_sync_state == NTP_SYNC_FAILED) {
+            result = -1;
+            g_ntp_sync_state = NTP_SYNC_IDLE;
+            pthread_mutex_unlock(&g_ntp_mutex);
+            break;
+        }
+        pthread_mutex_unlock(&g_ntp_mutex);
+        
+        timeout_count++;
     }
     
-    // Actualizar el RTC
-    rtc_set_clock(&rd);
-    LOGI("NTP time sync successful: %04d-%02d-%02d %02d:%02d:%02d", 
-         rd.year, rd.month, rd.day, rd.hour, rd.min, rd.sec);
+    // Si aún está en progreso después del timeout, asumimos que continuará en segundo plano
+    if (timeout_count >= max_timeout) {
+        LOGI("NTP sync still in progress, continuing in background");
+    }
     
-    return 0;
+    return result;
 }

--- a/src/util/ntp_client.h
+++ b/src/util/ntp_client.h
@@ -12,10 +12,10 @@ extern "C" {
 #define NTP_ERR_INVALID -3
 
 /**
- * @brief Tipo de función de callback para la sincronización NTP asíncrona
+ * @brief Callback function type for asynchronous NTP synchronization
  * 
- * @param result Resultado de la sincronización (0 = éxito, -1 = error)
- * @param user_data Datos proporcionados por el usuario en la llamada inicial
+ * @param result Synchronization result (0 = success, -1 = error)
+ * @param user_data User data provided in initial call
  */
 typedef void (*ntp_callback_t)(int result, void* user_data);
 

--- a/src/util/ntp_client.h
+++ b/src/util/ntp_client.h
@@ -5,6 +5,12 @@
 extern "C" {
 #endif
 
+// Error codes
+#define NTP_SUCCESS 0
+#define NTP_ERR_CONNECT -1 
+#define NTP_ERR_TIMEOUT -2
+#define NTP_ERR_INVALID -3
+
 /**
  * @brief Tipo de función de callback para la sincronización NTP asíncrona
  * 
@@ -12,6 +18,16 @@ extern "C" {
  * @param user_data Datos proporcionados por el usuario en la llamada inicial
  */
 typedef void (*ntp_callback_t)(int result, void* user_data);
+
+/**
+ * @brief Clock sync status values 
+ */
+typedef enum {
+    CLOCK_SYNC_NONE = 0,
+    CLOCK_SYNC_IN_PROGRESS,
+    CLOCK_SYNC_SUCCESS,
+    CLOCK_SYNC_FAILED
+} clock_sync_status_t;
 
 /**
  * @brief Inicia la sincronización del reloj con un servidor NTP (bloqueante)
@@ -41,6 +57,13 @@ int clock_sync_from_ntp_async(ntp_callback_t callback_fn, void* user_data);
  * @return 1 si hay una sincronización en progreso, 0 en caso contrario
  */
 int clock_is_syncing_from_ntp(void);
+
+/**
+ * @brief Obtiene el estado de la última sincronización
+ * 
+ * @return Estado de la última sincronización usando clock_sync_status_t
+ */
+clock_sync_status_t clock_get_last_sync_status(void);
 
 #ifdef __cplusplus
 }

--- a/src/util/ntp_client.h
+++ b/src/util/ntp_client.h
@@ -1,17 +1,49 @@
-#pragma once
+#ifndef NTP_CLIENT_H
+#define NTP_CLIENT_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * Sincroniza el reloj del sistema con un servidor NTP.
- * Requiere que el WiFi esté habilitado y configurado.
- *
- * @return 0 si la sincronización fue exitosa, -1 en caso de error
+ * @brief Tipo de función de callback para la sincronización NTP asíncrona
+ * 
+ * @param result Resultado de la sincronización (0 = éxito, -1 = error)
+ * @param user_data Datos proporcionados por el usuario en la llamada inicial
+ */
+typedef void (*ntp_callback_t)(int result, void* user_data);
+
+/**
+ * @brief Inicia la sincronización del reloj con un servidor NTP (bloqueante)
+ * 
+ * Esta función intenta sincronizar el reloj con un servidor NTP.
+ * Es bloqueante pero tiene un timeout interno de 1 segundo.
+ * 
+ * @return 0 en caso de éxito, -1 en caso de error
  */
 int clock_sync_from_ntp(void);
+
+/**
+ * @brief Inicia la sincronización del reloj con un servidor NTP (asíncrona)
+ * 
+ * Esta función inicia la sincronización en un hilo separado y retorna inmediatamente.
+ * El resultado se comunicará a través del callback proporcionado.
+ * 
+ * @param callback_fn Función que será llamada al completar la sincronización (puede ser NULL)
+ * @param user_data Datos que serán pasados al callback (puede ser NULL)
+ * @return 0 si se inició correctamente, -1 si hubo un error al iniciar
+ */
+int clock_sync_from_ntp_async(ntp_callback_t callback_fn, void* user_data);
+
+/**
+ * @brief Verifica si hay una sincronización NTP en progreso
+ * 
+ * @return 1 si hay una sincronización en progreso, 0 en caso contrario
+ */
+int clock_is_syncing_from_ntp(void);
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* NTP_CLIENT_H */

--- a/src/util/ntp_client.h
+++ b/src/util/ntp_client.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Sincroniza el reloj del sistema con un servidor NTP.
+ * Requiere que el WiFi esté habilitado y configurado.
+ *
+ * @return 0 si la sincronización fue exitosa, -1 en caso de error
+ */
+int clock_sync_from_ntp(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/util/wifi_status.c
+++ b/src/util/wifi_status.c
@@ -1,0 +1,51 @@
+#include "util/wifi_status.h"
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <netinet/in.h>
+#include <linux/wireless.h>
+
+int wifi_sta_get_connect_status(const char *interface, WIFI_STA_CONNECT_STATUS_S *status) {
+    struct iwreq wreq;
+    int sockfd;
+    
+    if (!interface || !status) {
+        return -1;
+    }
+
+    // Initialize status
+    memset(status, 0, sizeof(WIFI_STA_CONNECT_STATUS_S));
+    
+    // Create socket
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0) {
+        return -1;
+    }
+
+    // Prepare request
+    memset(&wreq, 0, sizeof(struct iwreq));
+    strncpy(wreq.ifr_name, interface, IFNAMSIZ-1);
+
+    // Get connection status
+    if (ioctl(sockfd, SIOCGIWNAME, &wreq) >= 0) {
+        // Check if interface is up
+        struct ifreq ifr;
+        memset(&ifr, 0, sizeof(ifr));
+        strncpy(ifr.ifr_name, interface, IFNAMSIZ-1);
+        
+        if (ioctl(sockfd, SIOCGIFFLAGS, &ifr) >= 0) {
+            if (ifr.ifr_flags & IFF_UP) {
+                status->state = WIFI_STA_STATUS_CONNECTED;
+            } else {
+                status->state = WIFI_STA_STATUS_DISCONNECTED;
+            }
+        }
+    } else {
+        status->state = WIFI_STA_STATUS_FAILED;
+    }
+
+    close(sockfd);
+    return 0;
+}

--- a/src/util/wifi_status.h
+++ b/src/util/wifi_status.h
@@ -1,0 +1,19 @@
+#ifndef WIFI_STATUS_H
+#define WIFI_STATUS_H
+
+typedef enum {
+    WIFI_STA_STATUS_DISCONNECTED = 0,
+    WIFI_STA_STATUS_CONNECTING,
+    WIFI_STA_STATUS_CONNECTED,
+    WIFI_STA_STATUS_FAILED
+} wifi_sta_status_t;
+
+typedef struct {
+    wifi_sta_status_t state;
+    char ssid[32];
+    int signal_strength;
+} WIFI_STA_CONNECT_STATUS_S;
+
+int wifi_sta_get_connect_status(const char *interface, WIFI_STA_CONNECT_STATUS_S *status);
+
+#endif // WIFI_STATUS_H


### PR DESCRIPTION
This update adds new options in the Clock menu to set the time from the Internet using NTP servers.

✅ New features:
Sync from Internet: A new button in the Clock menu that lets you update the date and time using an NTP server.

Time Zone: You can now choose your UTC offset (from UTC−12:00 to UTC+14:00).

Auto Sync: If enabled, the goggles will sync the time automatically when connected to Wi-Fi in client mode.

Settings are saved: The time zone and auto sync settings are saved and loaded correctly.

💻 UI changes:
Added dropdown to select UTC time zone.

New buttons: “Sync from Internet” and “Auto Sync”.

Shows messages when sync is successful or failed.

“Sync from Internet” button is disabled if Wi-Fi is not connected.

⚙️ Technical changes:
Added new file: ntp_client.c to handle NTP sync.

Added file: wifi_status.c to check if Wi-Fi is connected.

Modified page_clock.c, settings.c, page_wifi.c, and others.

🔍 Notes:
If sync fails, the user will see a red message.

If sync works, the clock is updated and saved.

Works only when Wi-Fi is in client mode and connected.

Let me know if something needs to be changed.
Thanks for reviewing!