### PR TITLE
Update page_source.c -corrected source state wording

### DIFF
--- a/src/ui/page_source.c
+++ b/src/ui/page_source.c
@@ -159,7 +159,7 @@ static lv_obj_t *page_source_create(lv_obj_t *parent, panel_arr_t *arr) {
 
 char *state2string(uint8_t status) {
     static char buf[32];
-    snprintf(buf, sizeof(buf), "#%s %s#", status ? "00FF00" : "C0C0C0", status ? _lang("Connected") : _lang("Disconnected"));
+    snprintf(buf, sizeof(buf), "#%s %s#", status ? "00FF00" : "C0C0C0", status ? _lang("Signal detected") : _lang("No signal"));
     return buf;
 }
 


### PR DESCRIPTION
This PR corrects the wording used to indicate source state of Analog, HDMI,  and AV input signals.

The prior wording of Connected and Disconnected is not accurate and has repeatedly mislead users to conclude something is a defective in the google.

I will submit additional PR to facilitate alternate language updates for "Signal detected" and "No signal" as well as   "Analog input requires Expansion Module" introduced with PR #525.