### PR TITLE
Update es_es.ini -Spanish source page wording update

### DIFF
--- a/mkapp/app/language/es_es.ini
+++ b/mkapp/app/language/es_es.ini
@@ -34,8 +34,9 @@ HDZero BW = "HDZero BW"
 Wide = "Ancho"
 Narrow = "Estrecho"
 Back = "Atrás"
-Connected = "Conectado"
-Disconnected = "Desconectado"
+Signal detected = "Señal detectada"
+No signal = "Sin señal"
+Analog input requires Expansion Module = "Entrada análoga requiere Módulo de Expansión"
 
 ; image setting
 Image Setting = "Imagen"


### PR DESCRIPTION
Spanish variants of source page wording updates in PR #525 & #528 as provided by @mauriciobridge

Signal detected = "Señal detectada"
No signal = "Sin señal"
Analog input requires Expansion Module = "Entrada análoga requiere Módulo de Expansión"