### PR TITLE
Update setup.sh -add toolchain awareness

### DIFF
--- a/.github/workflows/build_and_release_boxpro.yml
+++ b/.github/workflows/build_and_release_boxpro.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Build Firmware
         run: |
-          bash setup.sh
+          bash setup.sh automated_build
           make -C build_boxpro
 
       - name: Get Firmware Name

--- a/.github/workflows/build_and_release_goggle.yml
+++ b/.github/workflows/build_and_release_goggle.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Build Firmware
         run: |
-          bash setup.sh
+          bash setup.sh automated_build
           make -C build_goggle
 
       - name: Get Firmware Name

--- a/setup.sh
+++ b/setup.sh
@@ -1,23 +1,20 @@
 #!/bin/bash
-echo "Working directory: `pwd`"
-
-if [ ! -z "$1" ] && [ "$1" != "automated_build" ]; then
-cp $1 .
-fi
-
 TOOLCHAIN_FILE="armv7-eabihf--musl--stable-2018.02-2.tar.bz2"
 TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/$TOOLCHAIN_FILE"
 
-if [ "$1" == "automated_build" ]; then
-  if [ ! -d toolchain ]; then
+if [ ! -d toolchain ]; then
+  if [ "$1" == "automated_build" ]; then
     echo "Extracting toolchain..."
     mkdir toolchain
     wget -qO- "$TOOLCHAIN_URL" | tar xj --strip-components=1 -C toolchain
   fi
+
+if [ ! -z "$1" ] && [ "$1" != "automated_build" ]; then
+echo "Working directory: `pwd`"
+cp $1 .
 fi
 
-
-if [ ! -f "$TOOLCHAIN_FILE" ]; then
+if [ ! -f "$TOOLCHAIN_FILE" ] && [ "$1" != "automated_build" ]; then
   echo "$TOOLCHAIN_FILE not found."
   while true; do
     read -p "download $TOOLCHAIN_URL? (y/n): " yn
@@ -28,12 +25,13 @@ if [ ! -f "$TOOLCHAIN_FILE" ]; then
       esac
   done
 fi
-if [ -f "$TOOLCHAIN_FILE" ]; then  
-  echo "Using toolchain `pwd`/$TOOLCHAIN_FILE"
-  if [ ! -d toolchain ]; then
-	echo "Extracting toolchain..."
-	mkdir toolchain
-	tar -xvjf $TOOLCHAIN_FILE --strip-components=1 -C toolchain
+  if [ -f "$TOOLCHAIN_FILE" ]; then  
+    echo "Using toolchain `pwd`/$TOOLCHAIN_FILE"
+    if [ ! -d toolchain ]; then
+      echo "Extracting toolchain..."
+      mkdir toolchain
+      tar -xvjf $TOOLCHAIN_FILE --strip-components=1 -C toolchain
+    fi
   fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 echo "Working directory: `pwd`"
 
-if [ ! -z "$1" ]; then
+if [ ! -z "$1" ] || [ "$1" != "automated_build" ]; then
 cp $1 .
 fi
 
 TOOLCHAIN_FILE="armv7-eabihf--musl--stable-2018.02-2.tar.bz2"
 TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/$TOOLCHAIN_FILE"
+
+if [ "$1" == "automated_build" ]; then
+  if [ ! -d toolchain ]; then
+    echo "Extracting toolchain..."
+    mkdir toolchain
+    wget -qO- "$TOOLCHAIN_URL" | tar xj --strip-components=1 -C toolchain
+  fi
+fi
+
 
 if [ ! -f "$TOOLCHAIN_FILE" ]; then
   echo "$TOOLCHAIN_FILE not found."

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Working directory: `pwd`"
 
-if [ ! -z "$1" ] || [ "$1" != "automated_build" ]; then
+if [ ! -z "$1" ] && [ "$1" != "automated_build" ]; then
 cp $1 .
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,31 @@
 #!/bin/bash
-set -e
+echo "Working directory: `pwd`"
 
-TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/armv7-eabihf--musl--stable-2018.02-2.tar.bz2"
+if [ ! -z "$1" ]; then
+cp $1 .
+fi
 
-if [ ! -d toolchain ]; then
+TOOLCHAIN_FILE="armv7-eabihf--musl--stable-2018.02-2.tar.bz2"
+TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/$TOOLCHAIN_FILE"
+
+if [ ! -f "$TOOLCHAIN_FILE" ]; then
+  echo "$TOOLCHAIN_FILE not found."
+  while true; do
+    read -p "download $TOOLCHAIN_URL? (y/n): " yn
+      case $yn in
+        [yY]* ) wget "$TOOLCHAIN_URL"; break;; # Accepts 'y', 'Y', 'yes', 'YES', etc.
+        [nN]* ) echo "Please run setup.sh with path to toolchain archive eg: "; echo "./setup.sh $TOOLCHAIN_FILE"; exit;; # Accepts 'n', 'N', 'no', 'NO', etc.
+        * ) echo "Invalid response. Please enter 'y' or 'n'.";;
+      esac
+  done
+fi
+if [ -f "$TOOLCHAIN_FILE" ]; then  
+  echo "Using toolchain `pwd`/$TOOLCHAIN_FILE"
+  if [ ! -d toolchain ]; then
 	echo "Extracting toolchain..."
 	mkdir toolchain
-	wget -qO- "$TOOLCHAIN_URL" | tar xj --strip-components=1 -C toolchain
+	tar -xvjf $TOOLCHAIN_FILE --strip-components=1 -C toolchain
+  fi
 fi
 
 rm -rf build_*


### PR DESCRIPTION
updates to setup.sh script will now:
-prompt the source code user before downloading tool chain (~50mb)
-add verbosity for download and extraction status
-preserve downloaded tool chain .tar.bz2 file for future use
-allow user to pass full path of tool chain file or manually copy tool chain file into root of source to prevent prompting or new download of tool chain

launch with "automated_build for automated build environments. eg:
./setup.sh automated_build

These changes potentially reduce network data usage, increase tool chain portability during toolchains.bootlin.com service interruptions (~2025-06-21), and promote general awareness of source code users.