### PR TITLE
merged update scripts to include goggle2

### DIFF
--- a/mkapp/app/script/write_flashes.sh
+++ b/mkapp/app/script/write_flashes.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
 PLATFORM="$(cat /mnt/app/platform)"
-VAbin=/mnt/extsd/${PLATFORM}_VA.bin
-RXbin=/mnt/extsd/${PLATFORM}_RX.bin
+PLATFORMfile=$PLATFORM
+if [ "$PLATFORM" == "HDZGOGGLE2" ];then
+  # work around goggle2 firmware file names matching goggle v1 firmware file names
+  PLATFORMfile=HDZGOGGLE
+fi
+VAbin=/mnt/extsd/${PLATFORMfile}_VA.bin
+RXbin=/mnt/extsd/${PLATFORMfile}_RX.bin
 VAcount=1
 VAwrites=0
 RXcount=2
@@ -85,6 +90,11 @@ function check_mtd_write()
 		mtd_debug erase $1 0 $mtdsizeB
 		echo mtd_debug write $1 0 $filesize $3
 		mtd_debug write $1 0 $filesize $3
+		if [ "$PLATFORM" == "HDZGOGGLE2" ] && [ "$3" == "$VAbin" ] ;then
+		  # write secondary VA firmware for goggle 2
+		  echo mtd_debug write $1 8388608 $filesize $3		  
+		  mtd_debug write $1 8388608 $filesize $3
+		fi		
 		if [ $? == 0 ]; then
 			beep_success
 			if [ "$3" == "$VAbin" ]; then


### PR DESCRIPTION
-work around goggle2 firmware file names matching goggle v1 firmware file names
-add secondary VA write for goggle2

page_version.c should be able to  run update_goggle.sh to update goggle, boxpro, and goggle2.

Notes:
-these changes are completely untested! (family tasks)
-extended from @SumolX boxpro merge. (seems like the best way to handle unified update scripts)
-migrate goggle 2 firmware files to distinct names?
-update_vtx.sh not changed (already appears to perform a destination flash size check.)