### PR TITLE
feat: Add arm64 devcontainer for Apple Silicon Macs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,0 @@
-FROM --platform=linux/x86_64 mcr.microsoft.com/devcontainers/base:ubuntu
-
-RUN export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update && \
-    apt-get -y install --no-install-recommends cmake build-essential ninja-build libsdl2-dev

--- a/.devcontainer/arm64/Dockerfile
+++ b/.devcontainer/arm64/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+RUN dpkg --add-architecture armhf && apt-get update
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y install --no-install-recommends \
+    cmake \
+    build-essential \
+    ninja-build \
+    libsdl2-dev \
+    wget \
+    gcc-arm-linux-gnueabihf \
+    g++-arm-linux-gnueabihf \
+    libcrypt-dev:armhf \
+    mtd-utils \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/arm64/devcontainer.json
+++ b/.devcontainer/arm64/devcontainer.json
@@ -1,0 +1,25 @@
+{
+    "name": "HDZero for ARM64",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    "containerEnv": {
+        "DISPLAY": "host.docker.internal:0"
+    },
+    "customizations": {
+        "vscode": {
+            "settings": {},
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.cmake-tools"
+            ]
+        }
+    },
+    "postCreateCommand": "bash .devcontainer/arm64/setup.sh",
+    "remoteUser": "vscode"
+}

--- a/.devcontainer/arm64/setup.sh
+++ b/.devcontainer/arm64/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+rm -rf build_*
+
+echo
+echo "**********************************************"
+echo "Preparing HDZero Goggle Build Environment....."
+echo "**********************************************"
+cmake . -DHDZ_GOGGLE=ON -DCMAKE_BUILD_TYPE=Release -DDEVCONTAINER_ARM=ON -Bbuild_goggle
+
+echo
+echo "**********************************************"
+echo "Preparing HDZero BoxPro Build Environment....."
+echo "**********************************************"
+cmake . -DHDZ_BOXPRO=ON -DCMAKE_BUILD_TYPE=Release -DDEVCONTAINER_ARM=ON -Bbuild_boxpro
+
+echo
+echo "**********************************************"
+echo "Preparing HDZero Emulator Build Environment..."
+echo "**********************************************"
+cmake . -DEMULATOR_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DHDZ_GOGGLE=ON -DHDZ_BOXPRO=OFF -Bbuild_emu
+
+echo
+echo "****************************************"
+echo "*** HDZero Goggle Build Instructions ***"
+echo "****************************************"
+echo "cd build_goggle; make -j"
+
+echo
+echo "****************************************"
+echo "*** HDZero BoxPro Build Instructions ***"
+echo "****************************************"
+echo "cd build_boxpro; make -j"
+
+echo
+echo "****************************************"
+echo "***** HDZero Emulator Instructions *****"
+echo "****************************************"
+echo "cd build_emu; make -j"

--- a/.devcontainer/x86_64/Dockerfile
+++ b/.devcontainer/x86_64/Dockerfile
@@ -1,0 +1,10 @@
+FROM --platform=linux/x86_64 mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt-get update
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y install --no-install-recommends \
+    cmake \
+    build-essential \
+    ninja-build \
+    libsdl2-dev

--- a/.devcontainer/x86_64/devcontainer.json
+++ b/.devcontainer/x86_64/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "arm-linux-musleabihf",
+    "name": "HDZero for x86_64",
     "build": {
         "dockerfile": "Dockerfile"
     },

--- a/.devcontainer/x86_64/setup.sh
+++ b/.devcontainer/x86_64/setup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+TOOLCHAIN_FILE="armv7-eabihf--musl--stable-2018.02-2.tar.bz2"
+TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/$TOOLCHAIN_FILE"
+
+if [ ! -d toolchain ]; then
+  if [ "$1" == "automated_build" ]; then
+    echo "Extracting toolchain..."
+    mkdir toolchain
+    wget -qO- "$TOOLCHAIN_URL" | tar xj --strip-components=1 -C toolchain
+  fi
+
+if [ ! -z "$1" ] && [ "$1" != "automated_build" ]; then
+echo "Working directory: `pwd`"
+cp $1 .
+fi
+
+if [ ! -f "$TOOLCHAIN_FILE" ] && [ "$1" != "automated_build" ]; then
+  echo "$TOOLCHAIN_FILE not found."
+  while true; do
+    read -p "download $TOOLCHAIN_URL? (y/n): " yn
+      case $yn in
+        [yY]* ) wget "$TOOLCHAIN_URL"; break;; # Accepts 'y', 'Y', 'yes', 'YES', etc.
+        [nN]* ) echo "Please run setup.sh with path to toolchain archive eg: "; echo "./setup.sh $TOOLCHAIN_FILE"; exit;; # Accepts 'n', 'N', 'no', 'NO', etc.
+        * ) echo "Invalid response. Please enter 'y' or 'n'.";;
+      esac
+  done
+fi
+  if [ -f "$TOOLCHAIN_FILE" ]; then  
+    echo "Using toolchain `pwd`/$TOOLCHAIN_FILE"
+    if [ ! -d toolchain ]; then
+      echo "Extracting toolchain..."
+      mkdir toolchain
+      tar -xvjf $TOOLCHAIN_FILE --strip-components=1 -C toolchain
+    fi
+  fi
+fi
+
+rm -rf build_*
+
+echo
+echo "**********************************************"
+echo "Preparing HDZero Goggle Build Environment....."
+echo "**********************************************"
+cmake . -DHDZ_GOGGLE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain/share/buildroot/toolchainfile.cmake -Bbuild_goggle
+
+echo
+echo "**********************************************"
+echo "Preparing HDZero BoxPro Build Environment....."
+echo "**********************************************"
+cmake . -DHDZ_BOXPRO=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain/share/buildroot/toolchainfile.cmake -Bbuild_boxpro
+
+echo
+echo "**********************************************"
+echo "Preparing HDZero Emulator Build Environment..."
+echo "**********************************************"
+cmake . -DEMULATOR_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DHDZ_GOGGLE=ON -DHDZ_BOXPRO=OFF -Bbuild_emu
+
+echo
+echo "****************************************"
+echo "*** HDZero Goggle Build Instructions ***"
+echo "****************************************"
+echo "cd build_goggle; make -j"
+
+echo
+echo "****************************************"
+echo "*** HDZero BoxPro Build Instructions ***"
+echo "****************************************"
+echo "cd build_boxpro; make -j"
+
+echo
+echo "****************************************"
+echo "***** HDZero Emulator Instructions *****"
+echo "****************************************"
+echo "cd build_emu; make -j"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,22 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_COMPILER_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 
-set(CMAKE_C_FLAGS_RELEASE "-Werror -O3 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE "-Werror -O3 -DNDEBUG")
+if(DEVCONTAINER_ARM)
+    message(STATUS "Using system cross-compiler")
+
+    set(CMAKE_C_COMPILER "arm-linux-gnueabihf-gcc")
+    set(CMAKE_CXX_COMPILER "arm-linux-gnueabihf-g++")
+
+    set(CMAKE_C_FLAGS_RELEASE "-Werror -Wno-error=unused-result -Wno-error=format-truncation -Wno-error=stringop-overflow -O3 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE "-Werror -Wno-error=unused-result -Wno-error=format-truncation -Wno-error=stringop-overflow -O3 -DNDEBUG")
+
+else()
+    message(STATUS "Using provided toolchain file.")
+    set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/toolchain/share/buildroot/toolchainfile.cmake)
+
+    set(CMAKE_C_FLAGS_RELEASE "-Werror -O3 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE "-Werror -O3 -DNDEBUG")
+endif()
 
 set(OS_APP_PATH ${CMAKE_CURRENT_BINARY_DIR}/mkapp/app/app)
 set(RECORD_APP_PATH ${CMAKE_CURRENT_BINARY_DIR}/mkapp/app/app/record)
@@ -189,6 +203,22 @@ if(NOT EMULATOR_BUILD)
 	add_custom_target(MKAPP ALL
 		COMMAND rsync -r ${PROJECT_SOURCE_DIR}/mkapp ${CMAKE_CURRENT_BINARY_DIR}/
 	)
+
+if(DEVCONTAINER_ARM)
+	add_custom_command(
+		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/out/${PROJECT_NAME}
+		COMMAND size -A ${PROJECT_NAME}
+		COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/out/
+		COMMAND cp ${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR}/out/
+		COMMAND cp record ${CMAKE_CURRENT_BINARY_DIR}/out/
+		COMMAND cp rtspLive ${CMAKE_CURRENT_BINARY_DIR}/out/
+		COMMAND cp ${PROJECT_NAME} ${OS_APP_PATH}
+		COMMAND cp record ${RECORD_APP_PATH}
+		COMMAND cp rtspLive ${RECORD_APP_PATH}
+		COMMAND ${CMAKE_COMMAND} -E env DEVCONTAINER_ARM=1 ${CMAKE_CURRENT_BINARY_DIR}/mkapp/mkapp_ota.sh
+		DEPENDS MKAPP ${PROJECT_NAME} record rtspLive
+	)
+else()
 	add_custom_command(
 		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/out/${PROJECT_NAME}
 		COMMAND size -A ${PROJECT_NAME}
@@ -202,6 +232,7 @@ if(NOT EMULATOR_BUILD)
 		COMMAND cd ${CMAKE_CURRENT_BINARY_DIR} && ./mkapp/mkapp_ota.sh
 		DEPENDS MKAPP ${PROJECT_NAME} record rtspLive
 	)
+endif()
 	add_custom_target(${PROJECT_NAME}-OTA ALL
 		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/out/${PROJECT_NAME}
 	)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Compiling HDZero BoxPro:
 ~/hdzero-goggle/build_boxpro$ make clean all -j $(nproc)
 ```
 
+Compiling HDZero Emulator:
+```
+~/hdzero-goggle$ cd build_emu
+~/hdzero-goggle/build_emu$ make clean all -j $(nproc)
+```
+
 The firmware is generated as hdzero-goggle/build_boxpro/out/HDZERO_BOXPRO-x.x.x.bin
 Where x.x.x is the OTA_VER.RX_VER.VA_VER
 
@@ -87,35 +93,68 @@ else
 fi
 ```
 
-## Building the Emulator
+## Building and Running the Emulator
 
-Goggle source code can be built natively on the host machine and used for debugging.
+The goggle's UI can be built and run as an emulator on a host machine for easier development and debugging.
 
-### Library required
+### Prerequisites
 
-Requires build-essential tools and SDL2 development libraries (libsdl2-dev for debian) to be already installed.
+-   **On Linux:** You need the essential build tools and SDL2 development libraries.
+    ```shell
+    sudo apt-get install build-essential libsdl2-dev
+    ```
+-   **On macOS (ARM):** The emulator runs inside the devcontainer. You need to prepare your Mac to display the UI from the container by installing and configuring **XQuartz**.
 
-```
-sudo apt-get install build-essential libsdl2-dev
-```
+### Step 1: Prepare Your Mac for UI Forwarding
 
-### Build and Run
+This setup is done **once** on your Mac to allow UI from the devcontainer to appear on your desktop.
 
-Emulator support for both Goggle and BoxPro is supported by setting the appropriate compilation switches.
+1.  **Install XQuartz:**
+    ```shell
+    brew install --cask xquartz
+    ```
 
-```
-~/hdzero-goggle$ mkdir build_emu
-~/hdzero-goggle$ cd build_emu
-~/hdzero-goggle/build_emu$ cmake .. -DEMULATOR_BUILD=ON -DCMAKE_BUILD_TYPE=Debug -DHDZ_GOGGLE=ON -DHDZ_BOXPRO=OFF
-~/hdzero-goggle/build_emu$ make -j $(nproc)
-~/hdzero-goggle/build_emu$ ./HDZGOGGLE
-```
+2.  **Configure XQuartz:** Open XQuartz. In the top menu bar, go to `XQuartz` -> `Settings...` -> `Security` and ensure **"Allow connections from network clients"** is checked. Restart `XQuartz`
+
+3.  **Apply settings from the terminal:**
+    ```shell
+    defaults write org.xquartz.X11 nolisten_tcp 0
+    defaults write org.xquartz.X11 enable_iglx -bool YES
+    ```
+
+4.  **Reboot your Mac.**
+
+### Step 2: Build the Emulator
+
+The build process is the same for all platforms, but on macOS it should be done inside the devcontainer
+
+1.  **For macOS users:** Open the project in the devcontainer. When prompted, choose the **"HDZero for ARM64"** configuration.
+
+2.  **Compile the emulator:**
+    ```shell
+	cd build_emu
+    make -j
+    ```
+
+### Step 3: Run the Emulator
+
+1.  **On macOS:**
+    *   Make sure the **XQuartz** application is running (Ensure your system keyboard layout is set to **English** to avoid known bug, when **XQuartz** uses __only__ locale that was selected before the start)
+    *   In a **Mac terminal** (not the devcontainer one), run `xhost +` to temporarily allow all connections. This is needed for the container to connect.
+
+2.  **Inside the devcontainer or your terminal**, run the compiled application:
+    ```shell
+    ./HDZGOGGLE
+    ```
 
 ### Emulator Keys
 
 `a` = right button press
+
 `w` = wheel up
+
 `s` = wheel down
+
 `d` = wheel center press
 Use `F11` to toggle full screen where applicable.
 

--- a/mkapp/mkapp_ota.sh
+++ b/mkapp/mkapp_ota.sh
@@ -25,7 +25,21 @@ PLATFORM="$(cat ${MKAPP_DIR}/app/platform)"
 
 BIN_DIR=$MKAPP_DIR/bin
 IMG_DIR=$MKAPP_DIR/ota_app
-APP_DIR=$MKAPP_DIR/app
+
+# Workaround for the macOS permissions issue in the Docker developer container
+if [ "$DEVCONTAINER_ARM" = "1" ]; then
+    STAGING_DIR="/tmp/hdz_app_staging"
+    rm -rf ${STAGING_DIR}
+    mkdir -p ${STAGING_DIR}
+
+    echo "Staging app directory to ${STAGING_DIR} to fix macOS permissions issue"
+    tar -c -C "$(pwd)/../mkapp" app | tar -x -C ${STAGING_DIR}
+
+    APP_DIR=${STAGING_DIR}/app
+else
+    APP_DIR=$MKAPP_DIR/app
+fi
+
 KO_DIR=$APP_DIR/ko
 
 APP_SIZE=8388608

--- a/setup.sh
+++ b/setup.sh
@@ -1,62 +1,7 @@
 #!/bin/bash
-TOOLCHAIN_FILE="armv7-eabihf--musl--stable-2018.02-2.tar.bz2"
-TOOLCHAIN_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/armv7-eabihf/tarballs/$TOOLCHAIN_FILE"
+set -e
 
-if [ ! -d toolchain ]; then
-  if [ "$1" == "automated_build" ]; then
-    echo "Extracting toolchain..."
-    mkdir toolchain
-    wget -qO- "$TOOLCHAIN_URL" | tar xj --strip-components=1 -C toolchain
-  fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+X86_64_SETUP_SCRIPT="${SCRIPT_DIR}/.devcontainer/x86_64/setup.sh"
 
-if [ ! -z "$1" ] && [ "$1" != "automated_build" ]; then
-echo "Working directory: `pwd`"
-cp $1 .
-fi
-
-if [ ! -f "$TOOLCHAIN_FILE" ] && [ "$1" != "automated_build" ]; then
-  echo "$TOOLCHAIN_FILE not found."
-  while true; do
-    read -p "download $TOOLCHAIN_URL? (y/n): " yn
-      case $yn in
-        [yY]* ) wget "$TOOLCHAIN_URL"; break;; # Accepts 'y', 'Y', 'yes', 'YES', etc.
-        [nN]* ) echo "Please run setup.sh with path to toolchain archive eg: "; echo "./setup.sh $TOOLCHAIN_FILE"; exit;; # Accepts 'n', 'N', 'no', 'NO', etc.
-        * ) echo "Invalid response. Please enter 'y' or 'n'.";;
-      esac
-  done
-fi
-  if [ -f "$TOOLCHAIN_FILE" ]; then  
-    echo "Using toolchain `pwd`/$TOOLCHAIN_FILE"
-    if [ ! -d toolchain ]; then
-      echo "Extracting toolchain..."
-      mkdir toolchain
-      tar -xvjf $TOOLCHAIN_FILE --strip-components=1 -C toolchain
-    fi
-  fi
-fi
-
-rm -rf build_*
-
-echo
-echo "**********************************************"
-echo "Preparing HDZero Goggle Build Environment....."
-echo "**********************************************"
-cmake . -DHDZ_GOGGLE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain/share/buildroot/toolchainfile.cmake -Bbuild_goggle
-
-echo
-echo "**********************************************"
-echo "Preparing HDZero BoxPro Build Environment....."
-echo "**********************************************"
-cmake . -DHDZ_BOXPRO=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain/share/buildroot/toolchainfile.cmake -Bbuild_boxpro
-
-echo
-echo "****************************************"
-echo "*** HDZero Goggle Build Instructions ***"
-echo "****************************************"
-echo "cd build_goggle; make -j"
-
-echo
-echo "****************************************"
-echo "*** HDZero BoxPro Build Instructions ***"
-echo "****************************************"
-echo "cd build_boxpro; make -j"
+exec bash "${X86_64_SETUP_SCRIPT}"


### PR DESCRIPTION
This PR adds a native `arm64` devcontainer environment, resolving build failures on Apple Silicon Macs

*   VS Code now prompts users to select between `arm64` and `x86_64` environments on startup
*   `setup.sh` also now handles cmake configuration for the emulator
*   Updated the `README.md` with a guide for setting up XQuartz and running the emulator on macOS via the devcontainer