### PR TITLE
Check correct channel avoiding multiple changes

### DIFF
--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -134,7 +134,7 @@ static void change_channel_analog(uint8_t const channel) {
         LOGE("Invalid analog channel %d", channel);
         return;
     }
-    if (g_setting.scan.channel != channel || g_app_state != APP_STATE_VIDEO) {
+    if (g_setting.source.analog_channel != channel || g_app_state != APP_STATE_VIDEO) {
         g_setting.source.analog_channel = channel;
         beep();
         pthread_mutex_lock(&lvgl_mutex);


### PR DESCRIPTION
The wrong stored channel was checked when seeing if a channel change is actually required. This caused the goggles to try to change channels multiple times as the backpack sends the command 3 times to ensure that one gets through. This also interacted with a bug in the VTX Admin code where the SPI based receivers save the channel to betaflight flash which causes an interruption in the connection, when the connection is re-established another VTXAdmin command was sent because the debounce was too short and got into an infinite loop. See https://github.com/ExpressLRS/ExpressLRS/issues/3488