### PR TITLE
Filter out erratic scrollwheel events

### DIFF
--- a/src/core/input_device.c
+++ b/src/core/input_device.c
@@ -540,10 +540,13 @@ static void get_event(int fd) {
             if (event.code == REL_X) {
                 // LOGI("x = %d", event.value);
             } else if (event.code == REL_Y) {
-                roller_value = event.value;
-                // LOGI("y = %d", event.value);
+                if (roller_value != event.value) {
+                    timeradd(&event.time, &rel_time_diff, &next_rel);
+                    roller_value = event.value;
+                    // LOGI("y = %d", event.value);
+                }
+                event_type_last = EV_REL;
             }
-            event_type_last = EV_REL;
         } else {
             discard_scroll = true;
             LOGI("discard EV_REL");


### PR DESCRIPTION
It seems quite common that internal contacts get intermittent inside the scroll wheel which spills out lots of erractic scroll and direction change events. There's no point processing 10s or more events within 10msec when screen update is less than 100Hz. A workaround aside from replacing the scrollwheel is to filter out those events.

Before: https://youtu.be/bQewQVDbmnI
After: https://youtu.be/BJiteTkR8qo