### PR TITLE
Move merged goggle2 code in ifdef

### DIFF
--- a/src/driver/rtc6715.c
+++ b/src/driver/rtc6715.c
@@ -56,7 +56,6 @@ static void rtc6715_power(bool is_on) {
     gpio_set(GPIO_RTC6715_ON, is_on);
 #elif defined(HDZGOGGLE2)
     DM5680_InternalAnalog_Power(is_on);
-    I2C_Write(ADDR_FPGA, 0x8C, (is_on << 1)); // rf switch
 #endif
 
     if (is_on) {

--- a/src/driver/rtc6715.c
+++ b/src/driver/rtc6715.c
@@ -56,8 +56,8 @@ static void rtc6715_power(bool is_on) {
     gpio_set(GPIO_RTC6715_ON, is_on);
 #elif defined(HDZGOGGLE2)
     DM5680_InternalAnalog_Power(is_on);
-#endif
     I2C_Write(ADDR_FPGA, 0x8C, (is_on << 1)); // rf switch
+#endif
 
     if (is_on) {
         usleep(200 * 1000); // wait for power stable


### PR DESCRIPTION
Back when goggle2 code got merged into this unified target repo the particular line of code from hdzero-goggle2 repo was put in the common section causing AV-In not showing image on BoxPro. The code should go inside the block of if defined(HDZGOGGLE2).