### PR TITLE
Fix color problems with HDMI-In at 90Hz+ modes

### DIFF
--- a/src/driver/hardware-boxpro.c
+++ b/src/driver/hardware-boxpro.c
@@ -937,7 +937,7 @@ int HDMI_in_detect() {
                         break;
 
                     case HDMIIN_VTMG_720P100:
-                        system_exec("dispw -s vdpo 720p30"); // 100fps actually
+                        system_exec("dispw -s vdpo 720p90"); // 100fps actually
                         dvr_update_vi_conf(VR_540P90);
                         g_hw_stat.vdpo_tmg = VDPO_TMG_720P100;
                         I2C_Write(ADDR_FPGA, 0x8D, 0x04);


### PR DESCRIPTION
Symptom: HDMI-In modes at 90Hz and up get wrong colors. It may start out looking normal but as time goes on even without any change on the screen the colors start shimmer and shift to the point they get very much off.

Having had some discussions and diagnostics on discord with "Alf Skaar", I started looking at the vtmg code and noticed with case HDMI_VTMG_720P100 it makes system call to change vdpo to 720p30 mode. I wonder why it's not set to 720p90 instead so I tried and it fixed the color problem on my BoxPro! I can set up Windows to the listed 1280x720p100Hz mode or my 1280x720p90Hz mode (with my custom timing) no color issues.

I'm not sure if the code change should apply to goggle 1 and 2 though since I haven't heard anybody having same problem with them. I don't have goggle 1 or 2 so should I make the code change for google 1 and 2 also and let people have those goggles to test?