### PR TITLE
Fix MSP_GET_BP_STATUS truncating last UID byte in ELRS bind display

### DIFF
--- a/src/ui/page_elrs.c
+++ b/src/ui/page_elrs.c
@@ -134,7 +134,7 @@ static void page_elrs_on_roller(uint8_t key) {
 static void elrs_status_timer(struct _lv_timer_t *timer) {
     char label[80];
     uint8_t status[7] = {0};
-    uint16_t size = sizeof(status) - 1;
+    uint16_t size = sizeof(status);
 
     if (!msp_read_resposne(MSP_GET_BP_STATUS, &size, status)) {
         msp_send_packet(MSP_GET_BP_STATUS, MSP_PACKET_COMMAND, 0, NULL);


### PR DESCRIPTION
## Summary

The ELRS Bind menu displays the last UID byte as `0` regardless of the actual value. Caused by an off-by-one in the `MSP_GET_BP_STATUS` read length: the buffer is 7 bytes (status flag + 6 UID bytes) but the read is capped at 6, so the 6th UID byte is dropped and the display picks up the zero-init value of the unread slot.

## Root Cause

`src/ui/page_elrs.c` — `elrs_status_timer`:

```c
uint8_t status[7] = {0};
uint16_t size = sizeof(status) - 1;   // ← 6, not 7

if (!msp_read_resposne(MSP_GET_BP_STATUS, &size, status)) { ... }
...
snprintf(label, sizeof(label), "UID: %d,%d,%d,%d,%d,%d",
         status[1], status[2], status[3], status[4], status[5], status[6]);
```

The backpack response is 7 bytes (`status[0]` = flags, `status[1..6]` = UID). `msp_read_resposne` copies `min(actual, max)` = 6 bytes, so `status[6]` is never written and remains its zero-init value. The display then prints that `0` as the last UID byte.

## Reproduction

A backpack flashed with bind phrase `"hdzero"` has `firmwareOptions.uid = 76:6F:BF:98:AE:42` = `118,111,191,152,174,66`. Before the fix the menu shows `118,111,191,152,174,0`. After the fix it shows the full `118,111,191,152,174,66`.

This happens for any bind phrase whose UID's 6th byte is non-zero (most of them, statistically — only ~1/256 phrases would coincidentally end in `0` and hide the bug).

## Fix

Read the full 7 bytes the backpack actually sends:

```diff
-    uint16_t size = sizeof(status) - 1;
+    uint16_t size = sizeof(status);
```

## Test plan

- [x] Built `HDZERO_GOGGLE-77-206-9.5.0` from `fix-elrs-uid-display` branch
- [x] Flashed onto HDZero Goggle (RX 51, R5)
- [x] Confirmed `Bind UID` line in ELRS menu changed from `<5 real bytes>,0` to the full UID — matches the actual UID the backpack listens on