### PR TITLE
Race timer sets DVR filenames to the heat you flew, e.g. hdz_0042-WinterCup-Mains-A-R5-H1.mp4

### DIFF
--- a/src/core/dvr.c
+++ b/src/core/dvr.c
@@ -1,8 +1,11 @@
 #include "dvr.h"
 
+#include <ctype.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <log/log.h>
@@ -23,6 +26,33 @@ bool record_pending = false;
 
 static time_t dvr_recording_start = 0;
 static pthread_mutex_t dvr_mutex;
+
+// Race label for the next recording, pushed by a race timer over the ELRS
+// backpack (MSP_SET_DVR_NAME). It expires so a recording made well after the
+// heat (e.g. freestyle) doesn't inherit the race's name.
+#define DVR_RACE_LABEL_TTL_S (5 * 60)
+static char dvr_race_label[REC_labelMAXLEN] = "";
+static time_t dvr_race_label_time = 0;
+
+// Store a filename-safe copy of the label: alnum kept, spaces become '-',
+// everything else dropped, capped to REC_labelMAXLEN. Empty input clears it.
+void dvr_set_race_label(const uint8_t *label, uint16_t len) {
+    char clean[REC_labelMAXLEN];
+    size_t n = 0;
+    for (uint16_t i = 0; i < len && n < sizeof(clean) - 1; i++) {
+        char c = (char)label[i];
+        if (isalnum((unsigned char)c) || c == '-' || c == '_') {
+            clean[n++] = c;
+        } else if (c == ' ' && n > 0 && clean[n - 1] != '-') {
+            clean[n++] = '-';
+        }
+    }
+    clean[n] = 0;
+
+    strcpy(dvr_race_label, clean);
+    dvr_race_label_time = time(NULL);
+    LOGI("dvr race label set to \"%s\"", dvr_race_label);
+}
 
 ///////////////////////////////////////////////////////////////////
 //-1=error;
@@ -309,6 +339,13 @@ static void dvr_update_record_conf() {
     ini_putl("record", "audio", g_setting.record.audio, REC_CONF);
     dvr_select_audio_source(g_setting.record.audio_source);
     ini_putl("record", "naming", g_setting.record.naming, REC_CONF);
+
+    // Pass the race label to the record process; always written so a stale
+    // label never survives in the conf, and expired labels are dropped
+    if (dvr_race_label[0] && time(NULL) - dvr_race_label_time > DVR_RACE_LABEL_TTL_S) {
+        dvr_race_label[0] = 0;
+    }
+    ini_puts("record", "label", dvr_race_label, REC_CONF);
 
     sync();
 }

--- a/src/core/dvr.h
+++ b/src/core/dvr.h
@@ -25,6 +25,7 @@ void dvr_cmd(osd_dvr_cmd_t cmd);
 void dvr_update_vi_conf(video_resolution_t fmt);
 void dvr_toggle();
 void dvr_star();
+void dvr_set_race_label(const uint8_t *label, uint16_t len);
 
 #ifdef __cplusplus
 }

--- a/src/core/elrs.c
+++ b/src/core/elrs.c
@@ -415,6 +415,11 @@ void msp_process_packet() {
                 rtc_set_clock(&rd);
             }
             break;
+        case MSP_SET_DVR_NAME:
+            // A race timer naming the next DVR recording, e.g. "WinterCup-Qual1-H2".
+            // An empty payload clears the pending name.
+            dvr_set_race_label(packet.payload, packet.payload_size);
+            break;
         }
     } else if (packet.type == MSP_PACKET_RESPONSE) {
         memcpy(&response_packet, &packet, sizeof(response_packet));

--- a/src/core/elrs.h
+++ b/src/core/elrs.h
@@ -47,6 +47,7 @@ typedef struct __attribute__((packed)) {
 #define MSP_SET_BUZZER     0x030B
 #define MSP_SET_HT_ENABLE  0x030D
 #define MSP_SET_RTC        0x030E
+#define MSP_SET_DVR_NAME   0x030F
 #define MSP_SET_OSD_ELEM   0x00B6
 #define MSP_SET_MODE       0x0380 // goggles to backpack
 #define MSP_GET_BP_VERSION 0x0381 // goggles to backpack

--- a/src/record/confparser.c
+++ b/src/record/confparser.c
@@ -2,6 +2,7 @@
 #define LOG_TAG "CfgParser"
 #include <log/log.h>
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,6 +29,7 @@
 #define KEY_FULL        "full"
 #define KEY_AUDIO       "audio"
 #define KEY_NAMING      "naming"
+#define KEY_LABEL       "label"
 
 #define KEY_WIDTH       "width"
 #define KEY_HEIGHT      "height"
@@ -444,6 +446,21 @@ void conf_loadRecordParams(char* confFile, RecordParams_t* para)
 
     lValue = ini_getbool(SEC_RECORD, KEY_AUDIO, TRUE, confFile);
     para->enableAudio = (lValue>0);
+
+    /* optional race label for the next recording, set by the goggles app
+       from the ELRS backpack; kept filename-safe here in case the conf was
+       edited by hand */
+    memset(para->label, 0, sizeof(para->label));
+    lValue = ini_gets(SEC_RECORD, KEY_LABEL, "", sTemp, sizearray(sTemp), confFile);
+    if( lValue > 0 ) {
+        int n = 0;
+        for( int i = 0; sTemp[i] != 0 && n < (int)sizeof(para->label) - 1; i++ ) {
+            char c = sTemp[i];
+            if( isalnum((unsigned char)c) || c == '-' || c == '_' ) {
+                para->label[n++] = c;
+            }
+        }
+    }
 }
 
 void conf_saveRecordParams(char* confFile, RecordParams_t* para)

--- a/src/record/disk.c
+++ b/src/record/disk.c
@@ -304,64 +304,6 @@ int disk_countMovies(char* sPath, char* sPrefix, char* sExts[], int nExts, int n
     return nIndexMax;
 }
 
-/* Max file index used by race-labelled recordings (YYYY-MM-DD-NNNN-label.ext),
-   so the shared index never collides with hdz_ names. Returns -1 when none. */
-int disk_maxLabeledIndex(char* sPath, char* sExts[], int nExts)
-{
-    DIR* dp = opendir(sPath);
-    if( dp == NULL ) {
-        LOGE("opendir %s fail\n", sPath);
-        return -1;
-    }
-
-    struct dirent *dirp;
-    char sTemp[8];
-    int  nIndexMax = -1;
-    int  i;
-
-    while( (dirp = readdir(dp)) != NULL ) {
-        const char* sName = dirp->d_name;
-        int size = strlen(sName);
-
-        /* YYYY-MM-DD-NNNN- prefix */
-        if( size < 16 ) {
-            continue;
-        }
-        if( !(isdigit((unsigned char)sName[0]) && isdigit((unsigned char)sName[1]) &&
-              isdigit((unsigned char)sName[2]) && isdigit((unsigned char)sName[3]) &&
-              sName[4] == '-' &&
-              isdigit((unsigned char)sName[5]) && isdigit((unsigned char)sName[6]) &&
-              sName[7] == '-' &&
-              isdigit((unsigned char)sName[8]) && isdigit((unsigned char)sName[9]) &&
-              sName[10] == '-' &&
-              isdigit((unsigned char)sName[11]) && isdigit((unsigned char)sName[12]) &&
-              isdigit((unsigned char)sName[13]) && isdigit((unsigned char)sName[14]) &&
-              sName[15] == '-') ) {
-            continue;
-        }
-
-        for(i=0; i<nExts; i++) {
-            int nExtLen = strlen(sExts[i]);
-            if( size > nExtLen && strcmp(sName + (size - nExtLen), sExts[i]) == 0 ) {
-                break;
-            }
-        }
-        if( i >= nExts ) {
-            continue;
-        }
-
-        memset(sTemp, 0, sizeof(sTemp));
-        memcpy(sTemp, sName + 11, 4);
-        int nIndex = atoi(sTemp);
-        if( nIndex > nIndexMax ) {
-            nIndexMax = nIndex;
-        }
-    }
-
-    closedir(dp);
-    return nIndexMax;
-}
-
 void sdcard_check(SdcardContext_t* sdstat, uint32_t tkNow)
 {
 	uint32_t mbTotal=0;

--- a/src/record/disk.c
+++ b/src/record/disk.c
@@ -1,5 +1,6 @@
 #include "disk.h"
 
+#include <ctype.h>
 #include <stdint.h>
 #include <sys/vfs.h>
 #include <sys/stat.h>
@@ -300,6 +301,64 @@ int disk_countMovies(char* sPath, char* sPrefix, char* sExts[], int nExts, int n
 #endif
     }
 
+    return nIndexMax;
+}
+
+/* Max file index used by race-labelled recordings (YYYY-MM-DD-NNNN-label.ext),
+   so the shared index never collides with hdz_ names. Returns -1 when none. */
+int disk_maxLabeledIndex(char* sPath, char* sExts[], int nExts)
+{
+    DIR* dp = opendir(sPath);
+    if( dp == NULL ) {
+        LOGE("opendir %s fail\n", sPath);
+        return -1;
+    }
+
+    struct dirent *dirp;
+    char sTemp[8];
+    int  nIndexMax = -1;
+    int  i;
+
+    while( (dirp = readdir(dp)) != NULL ) {
+        const char* sName = dirp->d_name;
+        int size = strlen(sName);
+
+        /* YYYY-MM-DD-NNNN- prefix */
+        if( size < 16 ) {
+            continue;
+        }
+        if( !(isdigit((unsigned char)sName[0]) && isdigit((unsigned char)sName[1]) &&
+              isdigit((unsigned char)sName[2]) && isdigit((unsigned char)sName[3]) &&
+              sName[4] == '-' &&
+              isdigit((unsigned char)sName[5]) && isdigit((unsigned char)sName[6]) &&
+              sName[7] == '-' &&
+              isdigit((unsigned char)sName[8]) && isdigit((unsigned char)sName[9]) &&
+              sName[10] == '-' &&
+              isdigit((unsigned char)sName[11]) && isdigit((unsigned char)sName[12]) &&
+              isdigit((unsigned char)sName[13]) && isdigit((unsigned char)sName[14]) &&
+              sName[15] == '-') ) {
+            continue;
+        }
+
+        for(i=0; i<nExts; i++) {
+            int nExtLen = strlen(sExts[i]);
+            if( size > nExtLen && strcmp(sName + (size - nExtLen), sExts[i]) == 0 ) {
+                break;
+            }
+        }
+        if( i >= nExts ) {
+            continue;
+        }
+
+        memset(sTemp, 0, sizeof(sTemp));
+        memcpy(sTemp, sName + 11, 4);
+        int nIndex = atoi(sTemp);
+        if( nIndex > nIndexMax ) {
+            nIndexMax = nIndex;
+        }
+    }
+
+    closedir(dp);
     return nIndexMax;
 }
 

--- a/src/record/disk.h
+++ b/src/record/disk.h
@@ -15,6 +15,7 @@ uint32_t disk_availableSize(char* sPath);
 bool     disk_checkPath(char* sPath);
 bool     disk_checkFile(char* sPath);
 int      disk_countMovies(char* sPath, char* sPrefix, char* sExts[], int nExts, int nIndexLen);
+int      disk_maxLabeledIndex(char* sPath, char* sExts[], int nExts);
 
 typedef struct
 {

--- a/src/record/disk.h
+++ b/src/record/disk.h
@@ -15,7 +15,6 @@ uint32_t disk_availableSize(char* sPath);
 bool     disk_checkPath(char* sPath);
 bool     disk_checkFile(char* sPath);
 int      disk_countMovies(char* sPath, char* sPrefix, char* sExts[], int nExts, int nIndexLen);
-int      disk_maxLabeledIndex(char* sPath, char* sExts[], int nExts);
 
 typedef struct
 {

--- a/src/record/main.c
+++ b/src/record/main.c
@@ -326,23 +326,25 @@ int record_start(RecordContext_t *recCtx) {
 
     char dateString[16];
     char sFile[256];
-    if (recCtx->params.label[0]) {
-        /* race-labelled recording: date + index lead so filenames sort in
-           recording order, e.g. 2026-07-13-0042-WinterCup-Qual1-H2.mp4 */
-        const time_t t = time(0);
-        const struct tm *date = localtime(&t);
-        snprintf(dateString, sizeof(dateString), "%04d-%02d-%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday);
-        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, recCtx->params.packType);
-    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
-        REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
+        if (recCtx->params.label[0]) {
+            /* stock name with the race label appended,
+               e.g. hdz_0042-WinterCup-Mains-A-R5-H1.mp4 */
+            REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.label, recCtx->params.packType);
+        } else {
+            REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
+        }
         break;
     case NAMING_DATE: {
         const time_t t = time(0);
         const struct tm *date = localtime(&t);
         snprintf(dateString, sizeof(dateString), "%04d%02d%02d-%02d%02d%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec);
-        snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, recCtx->params.packType);
+        if (recCtx->params.label[0]) {
+            snprintf(sFile, sizeof(sFile), "%s%s-%s.%s", recCtx->params.packPath, dateString, recCtx->params.label, recCtx->params.packType);
+        } else {
+            snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, recCtx->params.packType);
+        }
         break;
     }
     }
@@ -442,15 +444,20 @@ int record_start(RecordContext_t *recCtx) {
         fclose(recording_file);
     }
 
-    if (recCtx->params.label[0]) {
-        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, REC_packSnapTYPE);
-    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
-        REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
+        if (recCtx->params.label[0]) {
+            REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.label, REC_packSnapTYPE);
+        } else {
+            REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
+        }
         break;
     case NAMING_DATE:
-        snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, REC_packSnapTYPE);
+        if (recCtx->params.label[0]) {
+            snprintf(sFile, sizeof(sFile), "%s%s-%s.%s", recCtx->params.packPath, dateString, recCtx->params.label, REC_packSnapTYPE);
+        } else {
+            snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, REC_packSnapTYPE);
+        }
         break;
     }
     ret = record_takePicture(recCtx, sFile);
@@ -504,23 +511,25 @@ bool record_pack(RecordContext_t *recCtx) {
     int nbFileIndex = recCtx->nbFileIndex;
     char dateString[16];
     char sFile[256];
-    if (recCtx->params.label[0]) {
-        /* race-labelled recording: date + index lead so filenames sort in
-           recording order, e.g. 2026-07-13-0042-WinterCup-Qual1-H2.mp4 */
-        const time_t t = time(0);
-        const struct tm *date = localtime(&t);
-        snprintf(dateString, sizeof(dateString), "%04d-%02d-%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday);
-        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, recCtx->params.packType);
-    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
-        REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
+        if (recCtx->params.label[0]) {
+            /* stock name with the race label appended,
+               e.g. hdz_0042-WinterCup-Mains-A-R5-H1.mp4 */
+            REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.label, recCtx->params.packType);
+        } else {
+            REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
+        }
         break;
     case NAMING_DATE: {
         const time_t t = time(0);
         const struct tm *date = localtime(&t);
         snprintf(dateString, sizeof(dateString), "%04d%02d%02d-%02d%02d%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec);
-        snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, recCtx->params.packType);
+        if (recCtx->params.label[0]) {
+            snprintf(sFile, sizeof(sFile), "%s%s-%s.%s", recCtx->params.packPath, dateString, recCtx->params.label, recCtx->params.packType);
+        } else {
+            snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, recCtx->params.packType);
+        }
         break;
     }
     }
@@ -581,15 +590,20 @@ bool record_pack(RecordContext_t *recCtx) {
 
     pthread_mutex_unlock(&recCtx->mutex);
 
-    if (recCtx->params.label[0]) {
-        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, REC_packSnapTYPE);
-    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
-        REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
+        if (recCtx->params.label[0]) {
+            REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.label, REC_packSnapTYPE);
+        } else {
+            REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
+        }
         break;
     case NAMING_DATE:
-        snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, REC_packSnapTYPE);
+        if (recCtx->params.label[0]) {
+            snprintf(sFile, sizeof(sFile), "%s%s-%s.%s", recCtx->params.packPath, dateString, recCtx->params.label, REC_packSnapTYPE);
+        } else {
+            snprintf(sFile, sizeof(sFile), "%s%s.%s", recCtx->params.packPath, dateString, REC_packSnapTYPE);
+        }
         break;
     }
     record_takePicture(recCtx, sFile);
@@ -756,11 +770,6 @@ int record_checkDisk(RecordContext_t *recCtx) {
                 char *sTypes[] = REC_packEXTS;
                 int nIndex = disk_countMovies(recCtx->params.packPath, REC_packPREFIX,
                                               sTypes, REC_packTypesNUM, REC_packIndexLEN);
-                int nLabeled = disk_maxLabeledIndex(recCtx->params.packPath,
-                                                    sTypes, REC_packTypesNUM);
-                if (nLabeled > nIndex) {
-                    nIndex = nLabeled;
-                }
                 recCtx->nbFileIndex = nIndex + 1;
                 LOGD("movies index: %d", recCtx->nbFileIndex);
             }

--- a/src/record/main.c
+++ b/src/record/main.c
@@ -326,6 +326,14 @@ int record_start(RecordContext_t *recCtx) {
 
     char dateString[16];
     char sFile[256];
+    if (recCtx->params.label[0]) {
+        /* race-labelled recording: date + index lead so filenames sort in
+           recording order, e.g. 2026-07-13-0042-WinterCup-Qual1-H2.mp4 */
+        const time_t t = time(0);
+        const struct tm *date = localtime(&t);
+        snprintf(dateString, sizeof(dateString), "%04d-%02d-%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday);
+        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, recCtx->params.packType);
+    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
         REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
@@ -434,6 +442,9 @@ int record_start(RecordContext_t *recCtx) {
         fclose(recording_file);
     }
 
+    if (recCtx->params.label[0]) {
+        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, REC_packSnapTYPE);
+    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
         REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
@@ -493,6 +504,14 @@ bool record_pack(RecordContext_t *recCtx) {
     int nbFileIndex = recCtx->nbFileIndex;
     char dateString[16];
     char sFile[256];
+    if (recCtx->params.label[0]) {
+        /* race-labelled recording: date + index lead so filenames sort in
+           recording order, e.g. 2026-07-13-0042-WinterCup-Qual1-H2.mp4 */
+        const time_t t = time(0);
+        const struct tm *date = localtime(&t);
+        snprintf(dateString, sizeof(dateString), "%04d-%02d-%02d", date->tm_year + 1900, date->tm_mon + 1, date->tm_mday);
+        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, recCtx->params.packType);
+    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
         REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, recCtx->params.packType);
@@ -562,6 +581,9 @@ bool record_pack(RecordContext_t *recCtx) {
 
     pthread_mutex_unlock(&recCtx->mutex);
 
+    if (recCtx->params.label[0]) {
+        REC_labelPathGet(sFile, sizeof(sFile), recCtx->params.packPath, dateString, nbFileIndex, recCtx->params.label, REC_packSnapTYPE);
+    } else
     switch (recCtx->params.fileNaming) {
     case NAMING_CONTIGUOUS:
         REC_filePathGet(sFile, sizeof(sFile), recCtx->params.packPath, REC_packPREFIX, nbFileIndex, REC_packSnapTYPE);
@@ -734,6 +756,11 @@ int record_checkDisk(RecordContext_t *recCtx) {
                 char *sTypes[] = REC_packEXTS;
                 int nIndex = disk_countMovies(recCtx->params.packPath, REC_packPREFIX,
                                               sTypes, REC_packTypesNUM, REC_packIndexLEN);
+                int nLabeled = disk_maxLabeledIndex(recCtx->params.packPath,
+                                                    sTypes, REC_packTypesNUM);
+                if (nLabeled > nIndex) {
+                    nIndex = nLabeled;
+                }
                 recCtx->nbFileIndex = nIndex + 1;
                 LOGD("movies index: %d", recCtx->nbFileIndex);
             }

--- a/src/record/record.h
+++ b/src/record/record.h
@@ -56,6 +56,7 @@ typedef struct
     uint64_t    packSize;
     bool        enableAudio;
     FileNaming_t fileNaming;
+    char        label[REC_labelMAXLEN];
 } RecordParams_t;
 
 typedef struct

--- a/src/record/record_definitions.h
+++ b/src/record/record_definitions.h
@@ -85,7 +85,9 @@ extern "C" {
 #define REC_packTYPE        REC_packTS
 #define REC_packSnapTYPE    REC_packJPG
 #define REC_packIndexLEN    4
-#define REC_labelMAXLEN     33                  //32 chars + NUL, keeps names under 64
+#define REC_labelMAXLEN     44                  //43 chars + NUL; worst case name (date naming
+                                                //"YYYYMMDD-HHMMSS" + '-' + label + ".mp4") stays
+                                                //under the playback list's 64-char buffer
 #define REC_packTYPES       {REC_packMP4,REC_packTS}
 #define DOT                 "."
 #define REC_packEXTS        {DOT REC_packMP4, DOT REC_packTS}
@@ -95,10 +97,10 @@ extern "C" {
 #define REC_filePathGet(BUFF, MAXLEN, PATH, PREFIX, INDEX, FILEFMT) \
     snprintf((BUFF), (MAXLEN), "%s%s%04d.%s", (PATH), (PREFIX), (INDEX), (FILEFMT));
 
-/* Race-labelled recording: YYYY-MM-DD-NNNN-label.ext - date+index lead so a
-   plain filename sort lists the day in recording order */
-#define REC_labelPathGet(BUFF, MAXLEN, PATH, DATE, INDEX, LABEL, FILEFMT) \
-    snprintf((BUFF), (MAXLEN), "%s%s-%04d-%s.%s", (PATH), (DATE), (INDEX), (LABEL), (FILEFMT));
+/* Race-labelled recording: the stock name with "-label" appended before the
+   extension, e.g. hdz_0042-WinterCup-Mains-A-R5-H1.mp4 */
+#define REC_labelPathGet(BUFF, MAXLEN, PATH, PREFIX, INDEX, LABEL, FILEFMT) \
+    snprintf((BUFF), (MAXLEN), "%s%s%04d-%s.%s", (PATH), (PREFIX), (INDEX), (LABEL), (FILEFMT));
 
 #define ZeroMemory(p, size) memset(p, 0, size)
 

--- a/src/record/record_definitions.h
+++ b/src/record/record_definitions.h
@@ -85,6 +85,7 @@ extern "C" {
 #define REC_packTYPE        REC_packTS
 #define REC_packSnapTYPE    REC_packJPG
 #define REC_packIndexLEN    4
+#define REC_labelMAXLEN     33                  //32 chars + NUL, keeps names under 64
 #define REC_packTYPES       {REC_packMP4,REC_packTS}
 #define DOT                 "."
 #define REC_packEXTS        {DOT REC_packMP4, DOT REC_packTS}
@@ -93,6 +94,11 @@ extern "C" {
 
 #define REC_filePathGet(BUFF, MAXLEN, PATH, PREFIX, INDEX, FILEFMT) \
     snprintf((BUFF), (MAXLEN), "%s%s%04d.%s", (PATH), (PREFIX), (INDEX), (FILEFMT));
+
+/* Race-labelled recording: YYYY-MM-DD-NNNN-label.ext - date+index lead so a
+   plain filename sort lists the day in recording order */
+#define REC_labelPathGet(BUFF, MAXLEN, PATH, DATE, INDEX, LABEL, FILEFMT) \
+    snprintf((BUFF), (MAXLEN), "%s%s-%04d-%s.%s", (PATH), (DATE), (INDEX), (LABEL), (FILEFMT));
 
 #define ZeroMemory(p, size) memset(p, 0, size)
 


### PR DESCRIPTION
## Summary

Lets a race timer name the next DVR recording (e.g. `WinterCup-Mains-A-R5-H1`) by sending a new `MSP_SET_DVR_NAME` (0x030F) message through the ELRS backpack.

- `elrs.c` handles the new MSP command and hands the payload to `dvr_set_race_label()`.
- `dvr.c` stores a filename-safe copy of the label (alnum kept, spaces become `-`, everything else dropped) with a 5-minute TTL so a recording made well after the heat doesn't inherit the race's name; an empty payload clears it. The label is written to the record conf on every update so a stale value never survives.
- The record process (`record/`) appends `-label` to the stock filename, just before the extension, for both naming modes — `hdz_0042-WinterCup-Mains-A-R5-H1.mp4` (contiguous) or `20260718-141502-WinterCup-Mains-A-R5-H1.mp4` (date). Snapshot `.jpg` previews and split segments share the name. Because the stock prefix and index position are untouched, the existing contiguous file counter handles labelled names with no changes.

Labels are capped at 43 chars (`REC_labelMAXLEN` 44) — the worst case (date naming + label + `.mp4`) is 63 chars, still inside the playback list's 64-char name buffer. Over-long labels are silently truncated at both entry points (MSP payload and record conf), never rejected.

Additive only — recordings without a label are named exactly as before.

## Related PRs

- ExpressLRS/Backpack#232 — companion firmware PR: the VRX backpack forwards `MSP_ELRS_BACKPACK_SET_DVR_NAME` to the goggles over the serial link, which is what delivers this message.
- ExpressLRS/Backpack#231 — syncs the backpack/goggle RTC so the named recordings also carry correct timestamps.
- ExpressLRS/Lua-Scripts#18 — the ELRS Lua script now seeds that clock automatically whenever it connects to the TX module.
- #614 — lets pilots switch between Raceband and Lowband via the backpack; part of the same integration, independent of this PR.

- ExpressLRS/ExpressLRS#3701 — TX-module side of that time sync: forwards the handset time to the backpack.
