### PR TITLE
Show the live time on the set-clock page instead of a stale cached value

### DIFF
--- a/src/ui/page_clock.c
+++ b/src/ui/page_clock.c
@@ -78,6 +78,7 @@ static lv_timer_t *page_clock_refresh_ui_timer = NULL;
 static lv_timer_t *page_clock_set_clock_timer = NULL;
 static int page_clock_set_clock_confirm = 0;
 static int page_clock_is_dirty = 0;
+static uint32_t page_clock_last_input = 0;
 static struct rtc_date page_clock_rtc_date = {0};
 
 /**
@@ -312,21 +313,44 @@ static void page_clock_refresh_ui_timer_cb(struct _lv_timer_t *timer) {
     page_clock_refresh_datetime();
 
     // Keep the set-clock rollers tracking the live clock once a second,
-    // pausing while the user has a roller open or an unsaved change so
-    // the refresh never fights a manual edit.
+    // pausing while the user has a roller open, an unsaved change, or has
+    // touched the page recently, so the refresh never fights the user.
     static uint8_t ticks = 0;
     if (++ticks < 4) {
         return;
     }
     ticks = 0;
 
-    if (!page_clock_is_dirty && !page_clock_item_focused) {
-        rtc_get_clock(&page_clock_rtc_date);
+    if (page_clock_is_dirty || page_clock_item_focused ||
+        lv_tick_elaps(page_clock_last_input) < 3000) {
+        return;
+    }
+
+    struct rtc_date date;
+    rtc_get_clock(&date);
+
+    // Rebuilding the option lists disturbs the cursor mid-scroll, so only
+    // do the full rebuild when the lists themselves change (the day count
+    // depends on year/month); otherwise just move the selected indices.
+    if (date.year != page_clock_rtc_date.year || date.month != page_clock_rtc_date.month) {
+        page_clock_rtc_date = date;
         page_clock_build_options_from_date(&page_clock_rtc_date);
+    } else {
+        page_clock_rtc_date = date;
+        // First option of each roller, matching page_clock_build_options_from_date()
+        const int starts[ITEM_FORMAT] = {2023, 1, 1, 0, 0, 0};
+        const int values[ITEM_FORMAT] = {date.year, date.month, date.day, date.hour, date.min, date.sec};
         for (int i = 0; i < ITEM_FORMAT; ++i) {
-            if (page_clock_items[i].data.obj) {
-                page_clock_items[i].last_option = lv_dropdown_get_selected(page_clock_items[i].data.obj);
+            lv_obj_t *obj = page_clock_items[i].data.obj;
+            if (obj && (int)lv_dropdown_get_selected(obj) != values[i] - starts[i]) {
+                lv_dropdown_set_selected(obj, values[i] - starts[i]);
             }
+        }
+    }
+
+    for (int i = 0; i < ITEM_FORMAT; ++i) {
+        if (page_clock_items[i].data.obj) {
+            page_clock_items[i].last_option = lv_dropdown_get_selected(page_clock_items[i].data.obj);
         }
     }
 }
@@ -491,6 +515,8 @@ static void page_clock_exit() {
  * Main navigation routine for this page.
  */
 static void page_clock_on_roller(uint8_t key) {
+    page_clock_last_input = lv_tick_get();
+
     // Ignore commands until timer has expired before allowing user to proceed.
     if (page_clock_set_clock_confirm == 2) {
         return;
@@ -552,6 +578,8 @@ static void page_clock_on_roller(uint8_t key) {
  */
 static void page_clock_on_click(uint8_t key, int sel) {
     char buf[128];
+    page_clock_last_input = lv_tick_get();
+
     // Ignore commands until timer has expired before allowing user to proceed.
     if (page_clock_set_clock_confirm == 2) {
         return;

--- a/src/ui/page_clock.c
+++ b/src/ui/page_clock.c
@@ -420,6 +420,10 @@ static lv_obj_t *page_clock_create(lv_obj_t *parent, panel_arr_t *arr) {
  * Main entry routine for this page.
  */
 static void page_clock_enter() {
+    // Reload from the RTC so the rollers show the current time, not the
+    // values cached at boot or last manual set - the clock may have been
+    // updated since via the ELRS backpack or NTP.
+    rtc_get_clock(&page_clock_rtc_date);
     page_clock_build_options_from_date(&page_clock_rtc_date);
     page_clock_refresh_datetime();
     lv_obj_add_style(page_clock_items[ITEM_YEAR].data.obj, &style_dropdown, LV_PART_MAIN);

--- a/src/ui/page_clock.c
+++ b/src/ui/page_clock.c
@@ -74,7 +74,6 @@ static int page_clock_item_focused = 0;
 static date_time_t page_clock_datetime = {0};
 static dropdown_list_t page_clock_options[ITEM_SECOND + 1];
 static lv_timer_t *page_clock_set_clock_pending_timer = NULL;
-static lv_timer_t *page_clock_refresh_ui_timer = NULL;
 static lv_timer_t *page_clock_set_clock_timer = NULL;
 static int page_clock_set_clock_confirm = 0;
 static int page_clock_is_dirty = 0;
@@ -307,9 +306,11 @@ static void page_clock_set_clock_pending_cb(struct _lv_timer_t *timer) {
 }
 
 /**
- * Callback timer for refreshing the date/time/format wihtin the UI.
+ * Refresh the date/time/format and rollers within the UI. Driven from
+ * page_clock_on_update so the page stays live even when it is only
+ * highlighted in the main menu, not entered.
  */
-static void page_clock_refresh_ui_timer_cb(struct _lv_timer_t *timer) {
+static void page_clock_refresh_ui(void) {
     page_clock_refresh_datetime();
 
     // Keep the set-clock rollers tracking the live clock once a second,
@@ -353,6 +354,28 @@ static void page_clock_refresh_ui_timer_cb(struct _lv_timer_t *timer) {
             page_clock_items[i].last_option = lv_dropdown_get_selected(page_clock_items[i].data.obj);
         }
     }
+}
+
+/**
+ * Called continuously from the main menu loop for every page, so the
+ * clock is already showing the live time when the user scrolls onto the
+ * Clock menu item - no need to enter the page first.
+ */
+static void page_clock_on_update(uint32_t delta_ms) {
+    // Pace with the lvgl tick rather than delta_ms, which resets its
+    // reference on every call and alternates between tiny and huge values
+    static uint32_t last_refresh_ms = 0;
+
+    if (!page_clock_datetime.date) {
+        return;
+    }
+
+    if (lv_tick_elaps(last_refresh_ms) < 250) {
+        return;
+    }
+    last_refresh_ms = lv_tick_get();
+
+    page_clock_refresh_ui();
 }
 
 /**
@@ -470,8 +493,6 @@ static void page_clock_enter() {
     page_clock_build_options_from_date(&page_clock_rtc_date);
     page_clock_refresh_datetime();
     lv_obj_add_style(page_clock_items[ITEM_YEAR].data.obj, &style_dropdown, LV_PART_MAIN);
-    page_clock_refresh_ui_timer = lv_timer_create(page_clock_refresh_ui_timer_cb, 250, NULL);
-    lv_timer_set_repeat_count(page_clock_refresh_ui_timer, -1);
 
 #ifdef HDZBOXPRO
     lv_obj_set_style_border_color(page_clock_items[0].data.obj, lv_palette_main(LV_PALETTE_RED), 0);
@@ -482,11 +503,6 @@ static void page_clock_enter() {
  * Main exit routine for this page.
  */
 static void page_clock_exit() {
-    if (page_clock_refresh_ui_timer) {
-        lv_timer_del(page_clock_refresh_ui_timer);
-        page_clock_refresh_ui_timer = NULL;
-    }
-
     page_clock_set_clock_reset();
     page_clock_refresh_styles();
     page_clock_clear_datetime();
@@ -660,7 +676,7 @@ page_pack_t pp_clock = {
     .enter = page_clock_enter,
     .exit = page_clock_exit,
     .on_created = NULL,
-    .on_update = NULL,
+    .on_update = page_clock_on_update,
     .on_roller = page_clock_on_roller,
     .on_click = page_clock_on_click,
     .on_right_button = NULL,

--- a/src/ui/page_clock.c
+++ b/src/ui/page_clock.c
@@ -310,6 +310,25 @@ static void page_clock_set_clock_pending_cb(struct _lv_timer_t *timer) {
  */
 static void page_clock_refresh_ui_timer_cb(struct _lv_timer_t *timer) {
     page_clock_refresh_datetime();
+
+    // Keep the set-clock rollers tracking the live clock once a second,
+    // pausing while the user has a roller open or an unsaved change so
+    // the refresh never fights a manual edit.
+    static uint8_t ticks = 0;
+    if (++ticks < 4) {
+        return;
+    }
+    ticks = 0;
+
+    if (!page_clock_is_dirty && !page_clock_item_focused) {
+        rtc_get_clock(&page_clock_rtc_date);
+        page_clock_build_options_from_date(&page_clock_rtc_date);
+        for (int i = 0; i < ITEM_FORMAT; ++i) {
+            if (page_clock_items[i].data.obj) {
+                page_clock_items[i].last_option = lv_dropdown_get_selected(page_clock_items[i].data.obj);
+            }
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

The set-clock page's rollers are populated from a value cached in memory, not from the RTC. If the clock changes behind the scenes — the goggles already accept `MSP_SET_RTC` from the ELRS backpack today — the page keeps showing the stale time, and a pilot who opens it and hits save writes that stale time back over the correct one.

**Why it helps pilots:** the clock page becomes trustworthy. What it shows is the actual current time, so pilots can confirm at a glance that their clock (and therefore their DVR timestamps) is right, and can't accidentally undo an automatic time sync by saving old roller values.

## Implementation

Changes confined to `src/ui/page_clock.c`:

- **On page entry**, re-read the RTC before building the rollers, so they always start at the actual current time instead of the value cached at boot or the last manual set.
- **The refresh is driven from the page's `on_update` hook** (rather than an lvgl timer scoped to enter/exit), so the page is already showing the live time when the user merely scrolls onto the Clock menu item — no need to enter the page. Paced with the lvgl tick, since the menu loop's `delta_ms` resets its reference on every call.
- **The rollers track the live clock once a second** — but never fighting the user: the refresh pauses while a roller is open or an edit is unsaved, backs off for 3 seconds after any dial/click input, and only rebuilds a roller's option list when its contents actually change (a year/month rollover changes the day count) — otherwise it just moves the selected indices.

No change to how the clock is set or saved.

## Related PRs

Standalone — useful with the existing backpack `MSP_SET_RTC` path alone — but it pairs naturally with the automatic time-sync set, which makes background clock updates much more common:

- ExpressLRS/Backpack#231 — TX backpack distributes the time to the VRX backpack and goggles.
- ExpressLRS/Lua-Scripts#18 and ExpressLRS/ExpressLRS#3701 — one-press time sync from the handset.
