### PR TITLE
Fix build on newer toolchains where ATOMIC_VAR_INIT was removed

### DIFF
--- a/lib/log/src/log.c
+++ b/lib/log/src/log.c
@@ -14,7 +14,7 @@
 static int fd_log_file = -1;
 static char offline_buffer[1 * 1024 * 1024];
 static size_t offline_offset = 0;
-static atomic_bool log_mutex_init = ATOMIC_VAR_INIT(false);
+static atomic_bool log_mutex_init = false; // was ATOMIC_VAR_INIT(false) — macro removed in C23 / modern GCC
 static pthread_mutex_t log_mutex;
 
 static const char *log_level_names[] = {


### PR DESCRIPTION
`ATOMIC_VAR_INIT` was deprecated in C17 and removed in C23, so newer GCC/clang
now error on it and `lib/log` fails to build.

Initialise the atomic directly instead — equivalent behaviour, and portable across
both old and new toolchains.

Small and self-contained; no functional change.
